### PR TITLE
chore: fix plugin config structure per latest spec

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,12 +1,12 @@
 {
-  "description": "Claude Code skills and hooks from Christopher Boone (cboone.github.io)",
   "metadata": {
     "description": "Claude Code skills and hooks from Christopher Boone (cboone.github.io)",
-    "version": "1.0.2"
+    "version": "1.0.3"
   },
   "name": "cboone-cc-plugins",
   "owner": {
-    "name": "Christopher Boone"
+    "name": "Christopher Boone",
+    "url": "https://cboone.github.io"
   },
   "plugins": [
     {
@@ -17,14 +17,12 @@
       "category": "productivity",
       "description": "Notifies you when Claude finishes a task or needs your attention.",
       "homepage": "https://github.com/cboone/cboone-cc-plugins",
-      "hooks": "./hooks/hooks.json",
       "keywords": ["notifications", "alerts", "macos"],
       "license": "MIT",
       "name": "notify",
       "repository": "https://github.com/cboone/cboone-cc-plugins",
       "source": "./plugins/notify",
-      "tags": ["notifications", "alerts", "macos"],
-      "version": "1.0.2"
+      "version": "1.0.3"
     },
     {
       "author": {
@@ -38,10 +36,8 @@
       "license": "MIT",
       "name": "writing-shell-scripts",
       "repository": "https://github.com/cboone/cboone-cc-plugins",
-      "skills": "./",
       "source": "./plugins/writing-shell-scripts",
-      "tags": ["bash", "shell", "scripts", "format", "style"],
-      "version": "1.0.2"
+      "version": "1.0.3"
     }
   ]
 }

--- a/plugins/notify/.claude-plugin/plugin.json
+++ b/plugins/notify/.claude-plugin/plugin.json
@@ -5,9 +5,10 @@
   },
   "description": "Notifies you when Claude finishes a task or needs your attention.",
   "homepage": "https://github.com/cboone/cboone-cc-plugins",
+  "hooks": "./hooks/hooks.json",
   "keywords": ["notifications", "alerts", "macos"],
   "license": "MIT",
   "name": "notify",
   "repository": "https://github.com/cboone/cboone-cc-plugins",
-  "version": "1.0.2"
+  "version": "1.0.3"
 }

--- a/plugins/writing-shell-scripts/.claude-plugin/plugin.json
+++ b/plugins/writing-shell-scripts/.claude-plugin/plugin.json
@@ -9,5 +9,6 @@
   "license": "MIT",
   "name": "writing-shell-scripts",
   "repository": "https://github.com/cboone/cboone-cc-plugins",
-  "version": "1.0.2"
+  "skills": "./",
+  "version": "1.0.3"
 }


### PR DESCRIPTION
- Move component configs (hooks/skills) from marketplace.json to plugin.json
- Remove redundant tags field (keep keywords only)
- Remove redundant root-level description (keep in metadata)
- Add owner URL to marketplace.json
- Bump version to 1.0.3