### PR TITLE
fix: remove explicit hooks path to prevent duplicate loading

### DIFF
--- a/plugins/notify/.claude-plugin/plugin.json
+++ b/plugins/notify/.claude-plugin/plugin.json
@@ -4,7 +4,6 @@
   },
   "description": "Notifies you when Claude finishes a task or needs your attention.",
   "homepage": "https://github.com/cboone/cboone-cc-plugins",
-  "hooks": "./hooks/hooks.json",
   "keywords": ["alerts", "macos", "notifications"],
   "license": "MIT",
   "name": "notify",


### PR DESCRIPTION
hooks/hooks.json is auto-discovered by Claude Code, so declaring it
in the manifest caused it to be loaded twice.
