### PR TITLE
chore: reduce unnecessary user prompting in skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -21,7 +21,7 @@
       "name": "clean-up-agent-config",
       "repository": "https://github.com/cboone/cboone-cc-plugins",
       "source": "./plugins/clean-up-agent-config",
-      "version": "1.0.0"
+      "version": "1.0.1"
     },
     {
       "author": {
@@ -35,7 +35,7 @@
       "name": "commit",
       "repository": "https://github.com/cboone/cboone-cc-plugins",
       "source": "./plugins/commit",
-      "version": "1.0.0"
+      "version": "1.0.1"
     },
     {
       "author": {
@@ -49,7 +49,7 @@
       "name": "create-plugin",
       "repository": "https://github.com/cboone/cboone-cc-plugins",
       "source": "./plugins/create-plugin",
-      "version": "1.1.0"
+      "version": "1.1.1"
     },
     {
       "author": {

--- a/plugins/clean-up-agent-config/.claude-plugin/plugin.json
+++ b/plugins/clean-up-agent-config/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "name": "clean-up-agent-config",
   "repository": "https://github.com/cboone/cboone-cc-plugins",
   "skills": "./skills",
-  "version": "1.0.0"
+  "version": "1.0.1"
 }

--- a/plugins/clean-up-agent-config/skills/clean-up-agent-config/SKILL.md
+++ b/plugins/clean-up-agent-config/skills/clean-up-agent-config/SKILL.md
@@ -172,7 +172,7 @@ Recommend keeping CLAUDE.md as the real file (no symlink) when:
 - The team exclusively uses Claude Code and the user prefers the CLAUDE.md name
 - CLAUDE.md has extensive Claude-specific `@import` references that other tools wouldn't understand
 
-In either case, ask the user for their preference.
+Follow whichever recommendation applies. The Phase 3 plan approval gives the user a chance to override the choice.
 
 ### Phase 4: Implement
 
@@ -403,6 +403,6 @@ Add glob patterns for subdirectory AGENTS.md files in monorepos:
 - **settings.local.json has team settings:** Propose moving them to settings.json with a clear before/after diff.
 - **settings.json has personal settings:** Propose moving them to settings.local.json.
 - **Symlinks point to wrong targets:** Fix them after confirming with the user.
-- **.github/ does not exist:** Only create it if the repo is hosted on GitHub. Check for `.git/config` remote URLs or ask the user.
+- **.github/ does not exist:** Create it. Assume the repository is hosted on GitHub.
 - **Monorepo detected:** Suggest subdirectory AGENTS.md files and Copilot path-scoped instructions for each major package/module.
 - **Large existing CLAUDE.md (over 200 lines):** Propose splitting into AGENTS.md (shared core) + .claude/rules/ (Claude-specific) + tool-specific files.

--- a/plugins/commit/.claude-plugin/plugin.json
+++ b/plugins/commit/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "name": "commit",
   "repository": "https://github.com/cboone/cboone-cc-plugins",
   "skills": "./skills",
-  "version": "1.0.0"
+  "version": "1.0.1"
 }

--- a/plugins/commit/skills/commit/SKILL.md
+++ b/plugins/commit/skills/commit/SKILL.md
@@ -154,4 +154,3 @@ When the user gives compound instructions like "commit, then push" or "commit an
 - **Nothing to commit**: Report cleanly, do not create an empty commit.
 - **Pre-commit hook failure**: Read the hook output, fix the issue if possible, re-stage, and create a new commit (never amend).
 - **Push failure**: Report the error. If it's a rejected push due to remote changes, suggest `git pull --rebase` first. Never force push unless the user explicitly requests it.
-- **Merge conflicts in staged files**: Report the conflicted files and ask the user to resolve them before committing.

--- a/plugins/create-plugin/.claude-plugin/plugin.json
+++ b/plugins/create-plugin/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "name": "create-plugin",
   "repository": "https://github.com/cboone/cboone-cc-plugins",
   "skills": "./skills",
-  "version": "1.1.0"
+  "version": "1.1.1"
 }

--- a/plugins/create-plugin/skills/create-plugin/SKILL.md
+++ b/plugins/create-plugin/skills/create-plugin/SKILL.md
@@ -15,11 +15,13 @@ Create a new plugin for this repository following established conventions.
 
 ### 1. Determine Plugin Type
 
-Ask the user what their plugin will provide:
+Infer the plugin type from the user's request:
 
 - **Skills plugin**: Provides instructions and workflows that Claude Code follows (e.g., style guides, multi-step procedures). Most plugins are this type.
 - **Hooks plugin**: Provides event-driven shell commands that run automatically in response to Claude Code lifecycle events (e.g., notifications on task completion).
 - **Both**: A plugin can provide both skills and hooks.
+
+If the request doesn't imply a type (e.g., just "create a plugin"), ask. If ambiguous, default to a skills plugin.
 
 ### 2. Choose a Name
 
@@ -30,7 +32,7 @@ The plugin name must be:
 - **Descriptive** of what the plugin does
 - **Unique** within the `plugins/` directory
 
-Confirm the name with the user before proceeding.
+If the user provided a name, use it. Otherwise, generate a descriptive name from the plugin's purpose and proceed.
 
 ### 3. Create Directory Structure
 


### PR DESCRIPTION
## Summary

- **commit**: Remove the "merge conflicts in staged files" error case — `git commit` doesn't produce merge conflicts, so this was a nonsensical prompt
- **create-plugin**: Infer plugin type from trigger phrases (e.g., "add a new skill" → skills plugin) instead of always asking; generate a descriptive name and proceed instead of confirming
- **clean-up-agent-config**: Follow the symlink recommendation based on existing heuristics instead of asking (plan approval is the checkpoint); assume GitHub when `.github/` is missing instead of asking

## Test plan

- [ ] Invoke `/commit` and verify error handling section no longer mentions merge conflicts
- [ ] Invoke "add a new skill called foo" via create-plugin and verify it proceeds without asking plugin type or confirming the name
- [ ] Invoke "create a plugin" (no type hint) via create-plugin and verify it asks for the type
- [ ] Invoke clean-up-agent-config and verify it follows the symlink recommendation without a separate prompt, and creates `.github/` without asking