### PR TITLE
Add issue status management to worktree and suggestion skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -91,7 +91,7 @@
       "name": "create-worktree-from-issue",
       "repository": "https://github.com/cboone/cboone-cc-plugins",
       "source": "./plugins/create-worktree-from-issue",
-      "version": "1.1.4"
+      "version": "1.2.0"
     },
     {
       "author": {
@@ -175,7 +175,7 @@
       "name": "suggest-next-issue",
       "repository": "https://github.com/cboone/cboone-cc-plugins",
       "source": "./plugins/suggest-next-issue",
-      "version": "1.0.1"
+      "version": "1.1.0"
     },
     {
       "author": {

--- a/docs/plans/todo/quizzical-imagining-cerf.md
+++ b/docs/plans/todo/quizzical-imagining-cerf.md
@@ -1,0 +1,86 @@
+# 2026-02-17 Add Issue Status Management
+
+## Context
+
+Several skills in this repository interact with GitHub issues but none manage issue status transitions. When `create-worktree-from-issue` starts work on an issue, the issue remains untouched — no assignment, no label, no signal that someone is working on it. Similarly, `suggest-next-issue` detects in-progress work only by checking for matching branches/worktrees, missing issues that were claimed via labels or assignment outside this toolchain.
+
+This plan adds lightweight, universally-compatible status management using self-assignment and an "in progress" label — no GitHub Projects setup required.
+
+## Skills Reviewed
+
+| Skill | Interacts with issues? | Needs changes? |
+|-------|----------------------|----------------|
+| create-worktree-from-issue | Yes — finds and starts work on issues | **Yes** — add status transitions |
+| suggest-next-issue | Yes — lists and recommends issues | **Yes** — enhance in-progress detection |
+| pr | Yes — references issues in PR body | No — GitHub handles close-on-merge via "Closes #N" |
+| commit | Yes — references issues from branch name | No — no status management needed |
+| resolve-copilot-pr-feedback | No — operates at PR level | No |
+| create-worktree | No — general task worktrees | No |
+
+## Changes
+
+### 1. create-worktree-from-issue SKILL.md — Add "Mark Issue In Progress" step
+
+**File:** `plugins/create-worktree-from-issue/skills/create-worktree-from-issue/SKILL.md`
+
+Insert a new **step 2** between the current "1. Find the Issue" and "2. Build the Branch Name". Renumber all subsequent steps (current 2→3, 3→4, 4→5, 5→6).
+
+**New step 2 content:**
+
+- Skip if the issue is closed (the skill already warns about closed issues)
+- Self-assign: `gh issue edit NUMBER --add-assignee @me`
+- Add label: `gh issue edit NUMBER --add-label "in progress"`
+- Both commands are idempotent — safe to re-run
+- Failures warn but never block worktree creation (best-effort)
+
+**Update to step 6 (Report Success):** Add a bullet noting the issue was marked in progress.
+
+**Update to Error Handling section:** Add a bullet about status-marking failures being non-blocking.
+
+### 2. suggest-next-issue SKILL.md — Enhance in-progress detection
+
+**File:** `plugins/suggest-next-issue/skills/suggest-next-issue/SKILL.md`
+
+**Enhance step 2 (Identify In-Progress Work):** Expand the definition of "in progress" from just branch/worktree matching to include:
+
+1. Has a corresponding branch or worktree (existing behavior)
+2. Has an "in progress" label (new)
+3. Is assigned to the current user (new — use `gh api user --jq '.login'` to get username)
+
+Note: The `gh issue list` command in step 1 already fetches `labels` and `assignees` fields, so no extra API call is needed for those. Only one new call: `gh api user --jq '.login'`.
+
+**Update step 5 (Summarize In-Progress Work):** Note how each issue was detected (branch, label, or assignment).
+
+**Update example output (line 146):** Add examples showing label- and assignment-detected in-progress issues.
+
+### 3. Version bumps
+
+These are additive enhancements (new behavior layered onto existing workflows), warranting **patch** bumps:
+
+| File | Field | Old | New |
+|------|-------|-----|-----|
+| `plugins/create-worktree-from-issue/.claude-plugin/plugin.json` | version | 1.1.4 | 1.1.5 |
+| `plugins/suggest-next-issue/.claude-plugin/plugin.json` | version | 1.0.1 | 1.0.2 |
+| `.claude-plugin/marketplace.json` line 94 | version (create-worktree-from-issue) | 1.1.4 | 1.1.5 |
+| `.claude-plugin/marketplace.json` line 178 | version (suggest-next-issue) | 1.0.1 | 1.0.2 |
+
+Marketplace `metadata.version` stays at `1.6.0` (no plugins added or removed).
+
+## Files Modified (6 total)
+
+1. `plugins/create-worktree-from-issue/skills/create-worktree-from-issue/SKILL.md`
+2. `plugins/suggest-next-issue/skills/suggest-next-issue/SKILL.md`
+3. `plugins/create-worktree-from-issue/.claude-plugin/plugin.json`
+4. `plugins/suggest-next-issue/.claude-plugin/plugin.json`
+5. `.claude-plugin/marketplace.json`
+
+## Verification
+
+- [ ] Step numbers in create-worktree-from-issue are sequential 1–6 after insertion
+- [ ] `gh issue edit` commands use correct flags (`--add-assignee @me`, `--add-label "in progress"`)
+- [ ] suggest-next-issue step 2 references data already fetched in step 1 (no redundant API calls)
+- [ ] `gh api user --jq '.login'` is correct syntax for getting authenticated username
+- [ ] Versions match between each plugin.json and its marketplace.json entry
+- [ ] Marketplace metadata.version unchanged at 1.6.0
+- [ ] Status marking documented as best-effort / non-blocking
+- [ ] Closed issues excluded from "mark in progress" step

--- a/plugins/create-worktree-from-issue/.claude-plugin/plugin.json
+++ b/plugins/create-worktree-from-issue/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "name": "create-worktree-from-issue",
   "repository": "https://github.com/cboone/cboone-cc-plugins",
   "skills": "./skills",
-  "version": "1.1.4"
+  "version": "1.2.0"
 }

--- a/plugins/create-worktree-from-issue/skills/create-worktree-from-issue/SKILL.md
+++ b/plugins/create-worktree-from-issue/skills/create-worktree-from-issue/SKILL.md
@@ -37,7 +37,27 @@ If the search returns multiple results, present them to the user and ask which o
 
 If no results, try broadening the search or ask the user to refine their query.
 
-### 2. Build the Branch Name
+### 2. Mark Issue In Progress
+
+If the issue is open, signal that work is starting. Skip this step for closed issues.
+
+**Self-assign:**
+
+```bash
+gh issue edit NUMBER --add-assignee @me
+```
+
+**Add label:**
+
+```bash
+gh issue edit NUMBER --add-label "in progress"
+```
+
+Both commands are idempotent — safe to re-run if the assignee or label already exists. If the "in progress" label does not exist in the repository, `gh` creates it automatically.
+
+If either command fails, warn the user but continue with worktree creation. Status marking is best-effort and must never block the primary workflow.
+
+### 3. Build the Branch Name
 
 Construct a branch name in the format `TYPE/SLUG` where:
 
@@ -50,7 +70,7 @@ Examples:
 - Issue "Login fails with special chars" with label "bug" -> `fix/login-fails-with-special-chars`
 - Issue "Update README" with no labels -> `feature/update-readme`
 
-### 3. Compose the Issue Prompt
+### 4. Compose the Issue Prompt
 
 Build a prompt from the issue data retrieved in step 1. Format:
 
@@ -66,9 +86,9 @@ BODY_CONTENT
 - If the issue body is empty, omit it.
 - If there are no labels, omit the labels line.
 
-### 4. Create the Worktree
+### 5. Create the Worktree
 
-Use the Write tool to create a temporary prompt file at `/tmp/workmux-prompt-BRANCH_NAME.md` with the composed prompt from step 3. Using the Write tool avoids shell escaping issues with arbitrary issue body content.
+Use the Write tool to create a temporary prompt file at `/tmp/workmux-prompt-BRANCH_NAME.md` with the composed prompt from step 4. Using the Write tool avoids shell escaping issues with arbitrary issue body content.
 
 **Important:** The `workmux add` command must be fully detached from the Claude Code process. `workmux` creates tmux windows and spawns new Claude sessions, which cannot initialize while the parent Claude Code process is alive. Background the command with `& disown` so it survives shell exit.
 
@@ -94,7 +114,7 @@ rm -f /tmp/workmux-prompt-BRANCH_NAME.md /tmp/workmux-BRANCH_NAME.log
 
 If the log shows an error (e.g., "Failed to read prompt file"), the prompt file may have been deleted too early or another issue occurred. Use the Read tool to check the log for details.
 
-### 5. Report Success
+### 6. Report Success
 
 After confirming the worktree exists in `git worktree list`, report:
 
@@ -102,9 +122,11 @@ After confirming the worktree exists in `git worktree list`, report:
 - The branch name created
 - The tmux window name (to help the user switch to it)
 - A note that the issue context was injected into the new session
+- Whether the issue was marked in progress (assigned and labeled), or if status marking was skipped/failed
 
 ## Error Handling
 
 - If `gh` is not authenticated, instruct the user to run `gh auth login`
 - If `workmux` is not installed, inform the user
 - If the issue is closed, warn the user and ask if they want to proceed anyway
+- If status marking fails (assignment or labeling), warn the user but continue with worktree creation — status marking is best-effort

--- a/plugins/suggest-next-issue/.claude-plugin/plugin.json
+++ b/plugins/suggest-next-issue/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "name": "suggest-next-issue",
   "repository": "https://github.com/cboone/cboone-cc-plugins",
   "skills": "./skills",
-  "version": "1.0.1"
+  "version": "1.1.0"
 }

--- a/plugins/suggest-next-issue/skills/suggest-next-issue/SKILL.md
+++ b/plugins/suggest-next-issue/skills/suggest-next-issue/SKILL.md
@@ -40,6 +40,9 @@ gh issue list --state closed --json number,title,labels,closedAt --limit 10 --so
 git worktree list
 git branch --list --format='%(refname:short)'
 
+# Current authenticated user (for assignment detection)
+gh api user --jq '.login'
+
 # Project context
 gh repo view --json description,defaultBranchRef
 ```
@@ -56,7 +59,13 @@ Also read the repo's README and any roadmap or project documentation to understa
 
 ### 2. Identify In-Progress Work
 
-Cross-reference open issues against existing branches and worktrees. Exclude issues that already have a corresponding branch (matching issue number in branch name) from recommendations, but note them in the output as "already in progress."
+An issue is considered in progress if **any** of the following are true:
+
+1. **Branch or worktree match**: A branch or worktree name contains the issue number (existing behavior)
+2. **"in progress" label**: The issue has a label named "in progress" (case-insensitive match on the `labels` data already fetched in step 1)
+3. **Assigned to current user**: The issue's `assignees` list (already fetched in step 1) includes the authenticated username from `gh api user`
+
+Exclude in-progress issues from recommendations, but note them in the output as "already in progress" along with how each was detected (branch, label, assignment, or a combination).
 
 ### 3. Analyze Each Issue
 
@@ -97,7 +106,7 @@ For each recommendation, include:
 
 ### 5. Summarize In-Progress Work
 
-After recommendations, briefly list issues that appear to already have worktrees or branches, so the user has a complete picture.
+After recommendations, briefly list issues detected as in progress. For each, note how it was detected: branch/worktree, "in progress" label, assignment to current user, or a combination. This gives the user a complete picture of active work.
 
 ### 6. Offer to Start Work
 
@@ -143,7 +152,11 @@ Ready to start on one of these? Just say "start issue #N" or pick a number from 
 
 ---
 
-**Already in progress:** #14 (feature/improve-notifications), #16 (fix/search-pagination)
+**Already in progress:**
+- #14 — feature/improve-notifications (branch)
+- #16 — fix/search-pagination (branch, assigned)
+- #21 — Add export feature (label: "in progress")
+- #25 — Fix auth timeout (assigned)
 
 Ready to start on one of these? Just say "start issue #N".
 ```


### PR DESCRIPTION
## Summary

- **create-worktree-from-issue**: New step 2 self-assigns the issue and adds an "in progress" label when starting work. Both operations are idempotent and best-effort (failures warn but never block worktree creation).
- **suggest-next-issue**: Enhanced in-progress detection now recognizes issues via "in progress" label and assignment to the current user, in addition to the existing branch/worktree matching. The summary notes how each issue was detected.
- Minor version bumps for both plugins (create-worktree-from-issue 1.1.4 → 1.2.0, suggest-next-issue 1.0.1 → 1.1.0).

## Test plan

- [ ] Run `create-worktree-from-issue` on an open issue and verify the issue gets self-assigned and labeled "in progress"
- [ ] Run `create-worktree-from-issue` on a closed issue and verify the status-marking step is skipped
- [ ] Run `suggest-next-issue` on a repo with labeled/assigned issues and verify they appear in the "Already in progress" section with correct detection methods
- [ ] Verify version numbers match between plugin.json and marketplace.json for both plugins