### PR TITLE
Add table column alignment rule to markdown style guide

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -231,7 +231,7 @@
       "name": "write-markdown",
       "repository": "https://github.com/cboone/cboone-cc-plugins",
       "source": "./plugins/write-markdown",
-      "version": "1.0.0"
+      "version": "1.1.0"
     },
     {
       "author": {

--- a/plugins/write-markdown/.claude-plugin/plugin.json
+++ b/plugins/write-markdown/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "name": "write-markdown",
   "repository": "https://github.com/cboone/cboone-cc-plugins",
   "skills": "./skills",
-  "version": "1.0.0"
+  "version": "1.1.0"
 }

--- a/plugins/write-markdown/skills/write-markdown/SKILL.md
+++ b/plugins/write-markdown/skills/write-markdown/SKILL.md
@@ -39,6 +39,12 @@ Read `./references/MARKDOWN.md` for the complete guide. Summary:
 - Indent nested lists consistently
 - Blank line before and after a list block (MD032)
 
+### Tables
+
+- Pad cells so pipe characters align vertically across all rows (MD060)
+- Leading and trailing pipes on every row (MD055)
+- Consistent column count across all rows (MD056)
+
 ### Code
 
 - Fenced code blocks with language identifier: ` ```js ` (MD040)

--- a/plugins/write-markdown/skills/write-markdown/references/MARKDOWN.md
+++ b/plugins/write-markdown/skills/write-markdown/references/MARKDOWN.md
@@ -522,7 +522,29 @@ Use pipes and hyphens for tables. Surround tables with blank lines. Ensure consi
 | retries | number | 3       |
 ```
 
-Aligning columns in the source improves readability but is not required when the table is maintained programmatically.
+---
+
+### Table column alignment (MD060)
+
+Pad cell content so that pipe characters align vertically across all rows. Fill the delimiter row with hyphens to match the column width. This is the `aligned` style in markdownlint's MD060 rule and matches Prettier's default table formatting.
+
+```markdown
+<!-- Use: aligned columns -->
+
+| Name    | Type   | Default |
+| ------- | ------ | ------- |
+| timeout | number | 30      |
+| retries | number | 3       |
+```
+
+```markdown
+<!-- Avoid: ragged columns -->
+
+| Name | Type | Default |
+| --- | --- | --- |
+| timeout | number | 30 |
+| retries | number | 3 |
+```
 
 ---
 
@@ -670,4 +692,5 @@ Use headings to create a navigable outline. Do not use headings solely for visua
 Compiled by [Christopher Boone](https://cboone.github.io). Based on:
 
 - [markdownlint rules](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md) via [markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2)
+- [Prettier Markdown support](https://prettier.io/blog/2017/11/07/1.8.0.html) (table alignment, prose wrapping)
 - [GitHub Flavored Markdown Spec](https://github.github.com/gfm/)


### PR DESCRIPTION
## Summary

- Add MD060 (`table-column-style`) rule requiring aligned table columns in the markdown style guide reference
- Add Tables subsection to SKILL.md key conventions summary covering MD060, MD055, and MD056
- Add Prettier as a source in the style guide (its default table formatting matches MD060 aligned style)
- Remove previous hedge that column alignment was "not required"
- Bump write-markdown plugin version from 1.0.0 to 1.1.0

## Test plan

- [ ] Verify the write-markdown skill triggers correctly and includes the new table rules in its guidance
- [ ] Confirm the aligned table examples render correctly on GitHub