### PR TITLE
Improve READMEs with group headers, installation sections, and em dash removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ A collection of plugins for [Claude Code](https://docs.anthropic.com/en/docs/cla
 [Address Review](#address-review)
 ∙ [Resolve Copilot PR Feedback](#resolve-copilot-pr-feedback)
 <br>Code Quality:
-[Lint and Fix](#lint-and-fix)
+[Handle Secrets](#handle-secrets)
+∙ [Lint and Fix](#lint-and-fix)
 ∙ [Write Go Code](#write-go-code)
 ∙ [Write Markdown](#write-markdown)
 ∙ [Write Shell Scripts](#write-shell-scripts)
@@ -46,14 +47,18 @@ Or, from within `claude`, run:
 
 ## Skills
 
-### Commit
+### Git
+
+Skills for the commit-to-PR pipeline. Stage, commit, merge, review, and open pull requests without leaving the conversation.
+
+#### Commit
 
 Smart, context-aware git commits with conventional commit messages and plan awareness. Analyzes your diff to generate well-structured commit messages, handles staged-only vs. all changes, and supports commit-and-push workflows.
 
 > **Trigger:** `/commit`
 > **Details:** [README](./plugins/commit/README.md)
 
-### Merge Main
+#### Merge Main
 
 Fetch and merge the repository's base branch into the current feature branch. Automatically detects the default branch, handles uncommitted changes, resolves merge conflicts, and pushes after a successful merge.
 
@@ -61,7 +66,7 @@ Fetch and merge the repository's base branch into the current feature branch. Au
 > **Requires:** [`gh`](https://cli.github.com/) (falls back to `git remote show origin` if unavailable)
 > **Details:** [README](./plugins/merge-main/README.md)
 
-### PR
+#### PR
 
 Commit all changes, push to remote, and create a GitHub pull request in one automated step with no prompts. Detects connected issues and adds closing references automatically.
 
@@ -69,14 +74,18 @@ Commit all changes, push to remote, and create a GitHub pull request in one auto
 > **Requires:** [`gh`](https://cli.github.com/)
 > **Details:** [README](./plugins/pr/README.md)
 
-### Review Branch
+#### Review Branch
 
 Summarize all work done on the current branch compared to the base branch. Groups changes by area, highlights notable modifications, and optionally compares progress against a plan document.
 
 > **Trigger:** `/review-branch`
 > **Details:** [README](./plugins/review-branch/README.md)
 
-### Create Worktree
+### Issues and Worktrees
+
+Parallel development with git worktrees. Pick an issue, spin up an isolated worktree with its own agent session, and let each agent work independently.
+
+#### Create Worktree
 
 Create a new git worktree, branch, and tmux window with a task prompt injected into the new agent session. Derives the branch name from the task description or accepts an explicit branch name.
 
@@ -84,7 +93,7 @@ Create a new git worktree, branch, and tmux window with a task prompt injected i
 > **Requires:** [`workmux`](https://github.com/paiml/workmux)
 > **Details:** [README](./plugins/create-worktree/README.md)
 
-### Create Worktree from Issue
+#### Create Worktree from Issue
 
 Find a GitHub issue and create a dedicated worktree, branch, and tmux window for working on it. Derives the branch name from the issue title and labels, and injects the issue context into the new session.
 
@@ -92,7 +101,7 @@ Find a GitHub issue and create a dedicated worktree, branch, and tmux window for
 > **Requires:** [`gh`](https://cli.github.com/), [`workmux`](https://github.com/paiml/workmux)
 > **Details:** [README](./plugins/create-worktree-from-issue/README.md)
 
-### Suggest Next Issue
+#### Suggest Next Issue
 
 Review all open GitHub issues, analyze them in context, and recommend what to work on next with prioritized reasoning.
 
@@ -100,77 +109,100 @@ Review all open GitHub issues, analyze them in context, and recommend what to wo
 > **Requires:** [`gh`](https://cli.github.com/)
 > **Details:** [README](./plugins/suggest-next-issue/README.md)
 
-### Address Review
+### Code Review
+
+Process feedback from human reviewers and automated tools. Parse review documents, triage Copilot suggestions, and resolve comments systematically.
+
+#### Address Review
 
 Parse a review document for actionable feedback items, work through them systematically, and track resolution progress. Commits fixes in logical groups by default.
 
 > **Trigger:** `/address-review <path>`
 > **Details:** [README](./plugins/address-review/README.md)
 
-### Resolve Copilot PR Feedback
+#### Resolve Copilot PR Feedback
 
 Process and resolve GitHub Copilot automated PR review comments. Categorizes threads, resolves them, and updates Copilot instruction files when feedback is incorrect.
 
 > **Trigger:** `/resolve-copilot-pr-feedback`
 > **Details:** [README](./plugins/resolve-copilot-pr-feedback/README.md)
 
-### Lint and Fix
+### Code Quality
+
+Style guides, linters, and security practices. These skills activate automatically when working with their target languages and file types.
+
+#### Handle Secrets
+
+Best practices for handling user-provided secrets in CLI tools. Covers secure input methods, credential storage, secret masking, and language-specific libraries.
+
+> **Trigger:** `/handle-secrets`
+> **Details:** [README](./plugins/handle-secrets/README.md)
+
+#### Lint and Fix
 
 Detect available linters and formatters in the project, run them with auto-fix, and resolve remaining issues. Supports ESLint, Prettier, markdownlint, ShellCheck, shfmt, Knip, and project-specific lint scripts.
 
 > **Trigger:** `/lint-and-fix`
 > **Details:** [README](./plugins/lint-and-fix/README.md)
 
-### Write Go Code
+#### Write Go Code
 
 Go code style guide based on Google Go Style Guide, Effective Go, and Code Review Comments. Organized into an essential checklist and comprehensive references by topic.
 
 > **Trigger:** `/write-go-code` (also activates automatically)
 > **Details:** [README](./plugins/write-go-code/README.md)
 
-### Write Markdown
+#### Write Markdown
 
 Markdown style conventions targeting GitHub Flavored Markdown (GFM), aligned with markdownlint-cli2 rules. Activates automatically when creating or editing Markdown files.
 
 > **Trigger:** `/write-markdown` (also activates automatically)
 > **Details:** [README](./plugins/write-markdown/README.md)
 
-### Write Shell Scripts
+#### Write Shell Scripts
 
 Bash style conventions for creating and editing shell scripts. Activates automatically when creating or editing shell scripts.
 
 > **Trigger:** `/write-shell-scripts` (also activates automatically)
 > **Details:** [README](./plugins/write-shell-scripts/README.md)
 
-### Scaffold Go CLI
+### Scaffolding
+
+Bootstrap new projects with consistent structure. Generate boilerplate, CI/CD pipelines, and security scanning from templates.
+
+#### Scaffold Go CLI
 
 Scaffold a complete Go CLI project with Cobra, GoReleaser, GitHub Actions CI/CD, and Homebrew tap support. Generates all project files and supports optional Viper and Charmbracelet dependencies.
 
 > **Trigger:** `/scaffold-go-cli`
 > **Details:** [README](./plugins/scaffold-go-cli/README.md)
 
-### Scaffold New Repo
+#### Scaffold New Repo
 
 Scaffold the universal boilerplate for any new repository: LICENSE, README, .gitignore, agent config files, and a plans directory. Supports multiple project types.
 
 > **Trigger:** `/scaffold-new-repo`
 > **Details:** [README](./plugins/scaffold-new-repo/README.md)
 
-### Setup Gitleaks
+#### Setup Gitleaks
 
 Set up gitleaks secret scanning with a GitHub Actions workflow and optional configuration. Detects organization vs. personal repositories and generates the appropriate workflow.
 
 > **Trigger:** `/setup-gitleaks`
 > **Details:** [README](./plugins/setup-gitleaks/README.md)
 
-### Clean Up Agent Config
+### Agents
+
+Meta-tools for the agent ecosystem. Audit agent configuration files and create new plugins.
+
+#### Clean Up Agent Config
 
 Review and reorganize AI coding agent configuration files across Claude Code, OpenAI Codex, GitHub Copilot, and OpenCode. Identifies duplications, proposes a consolidated structure, and includes comprehensive reference documentation.
 
 > **Trigger:** `/clean-up-agent-config`
 > **Details:** [README](./plugins/clean-up-agent-config/README.md)
 
-### Create Plugin
+#### Create Plugin
 
 Guide for creating new plugins in this repository with consistent structure and conventions. Walks through the full process from choosing a plugin type to registering in the marketplace.
 
@@ -179,18 +211,26 @@ Guide for creating new plugins in this repository with consistent structure and 
 
 ## Hooks
 
-### Block rm -rf
+### Security
+
+Prevent destructive operations before they happen.
+
+#### Block rm -rf
 
 Blocks recursive `rm` commands before they execute and suggests using `trash` instead, which moves files to the system Trash.
 
-> **Requires:** [`trash`](https://hasseg.org/trash/) — install via [Homebrew](https://brew.sh): `brew install trash`
+> **Requires:** [`trash`](https://hasseg.org/trash/). Install via [Homebrew](https://brew.sh): `brew install trash`
 > **Details:** [README](./plugins/block-rm-rf/README.md)
 
-### Notify (macOS)
+### Workflow
+
+Stay informed about agent activity.
+
+#### Notify (macOS)
 
 Sends macOS notifications when Claude finishes a task or needs your attention.
 
-> **Requires:** [`terminal-notifier`](https://github.com/julienXX/terminal-notifier) — install via [Homebrew](https://brew.sh): `brew install terminal-notifier`
+> **Requires:** [`terminal-notifier`](https://github.com/julienXX/terminal-notifier). Install via [Homebrew](https://brew.sh): `brew install terminal-notifier`
 > **Details:** [README](./plugins/notify/README.md)
 
 ## License

--- a/docs/plans/todo/declarative-noodling-pudding.md
+++ b/docs/plans/todo/declarative-noodling-pudding.md
@@ -1,0 +1,142 @@
+# 2026-02-18 Improve READMEs
+
+## Context
+
+The root README and per-plugin READMEs need three improvements:
+
+1. **Group blurbs in root README**: The skills section lists 18 plugins as flat H3 entries with no group-level context. The ToC already organizes plugins into subcategories (Git, Issues and Worktrees, Code Review, Code Quality, Scaffolding, Agents), but the content section does not mirror this grouping. Adding H3 group headers with workflow blurbs, and demoting plugin entries to H4, gives readers orientation before diving into individual plugins.
+
+2. **Em dash removal**: 142 em dashes across README files (root + 20 per-plugin). The user preference forbids em dashes. Replace with colons, commas, periods, or rephrasing.
+
+3. **Plugin installation instructions**: No per-plugin README explains how to install the plugin. Each needs a short Installation section pointing to the marketplace.
+
+4. **Missing content**: The `handle-secrets` plugin has no README at all. It is also missing from the root README's ToC and skills listing.
+
+## Changes
+
+### 1. Root README (`README.md`)
+
+**Structure change**: Add H3 group headers with blurbs, demote plugin entries to H4.
+
+```
+## Skills                        (stays H2)
+### Git                          (new H3 with blurb)
+#### Commit                      (was H3, now H4)
+#### Merge Main                  (was H3, now H4)
+#### PR                          (was H3, now H4)
+#### Review Branch               (was H3, now H4)
+### Issues and Worktrees         (new H3 with blurb)
+#### Create Worktree             (was H3, now H4)
+...
+## Hooks                         (stays H2)
+### Security                     (new H3 with blurb)
+#### Block rm -rf                (was H3, now H4)
+### Workflow                     (new H3 with blurb)
+#### Notify (macOS)              (was H3, now H4)
+```
+
+GFM anchors are derived from heading text regardless of level, so all existing ToC links (e.g., `#commit`) remain valid.
+
+**Group blurbs** (draft content, will refine during implementation):
+
+- **Git**: Skills for the commit-to-PR pipeline. Stage, commit, merge, review, and open pull requests without leaving the conversation.
+- **Issues and Worktrees**: Parallel development with git worktrees. Pick an issue, spin up an isolated worktree with its own agent session, and let each agent work independently.
+- **Code Review**: Process feedback from human reviewers and automated tools. Parse review documents, triage Copilot suggestions, and resolve comments systematically.
+- **Code Quality**: Style guides, linters, and security practices. These skills activate automatically when working with their target languages and file types.
+- **Scaffolding**: Bootstrap new projects with consistent structure. Generate boilerplate, CI/CD pipelines, and security scanning from templates.
+- **Agents**: Meta-tools for the agent ecosystem. Audit agent configuration files and create new plugins.
+- **Security** (Hooks): Prevent destructive operations before they happen.
+- **Workflow** (Hooks): Stay informed about agent activity.
+
+**Add Handle Secrets**: Insert into the Code Quality group (ToC + content).
+
+**Em dashes**: 2 instances on lines 186 and 193 (Requires lines for hooks). Replace `— install via` with `. Install via`.
+
+### 2. Per-Plugin READMEs (21 files)
+
+For all 20 existing READMEs, plus creating `handle-secrets/README.md`:
+
+**Add Installation section** after the Type/Trigger/Requires metadata block, before "What It Does":
+
+```markdown
+## Installation
+
+Add the [`cboone/cboone-cc-plugins`](https://github.com/cboone/cboone-cc-plugins) marketplace in Claude Code:
+
+```text
+/plugin marketplace add cboone/cboone-cc-plugins
+```
+
+Then select **Plugin Name** from the available plugins.
+```
+
+**Remove em dashes** with these substitutions:
+
+| Pattern | Replacement |
+| --- | --- |
+| `"command" — description` (Examples) | `"command": description` |
+| `[Link](url) — description` (See Also) | `[Link](url): description` |
+| `— install via` (Requires) | `. Install via` |
+| Prose em dashes | Rewrite with colons, commas, or separate sentences |
+
+**Create `plugins/handle-secrets/README.md`** following the existing per-plugin template:
+
+- Title: Handle Secrets
+- Type: Skill
+- Trigger: `/handle-secrets`
+- What It Does: Best practices for handling user-provided secrets in CLI tools (env vars, stdin, keychains, config files)
+- Installation section
+- Usage, Examples, See Also
+
+### 3. Update Template Reference (`plugins/create-plugin/skills/create-plugin/references/readme-updates.md`)
+
+Remove em dashes from the templates that generate future READMEs:
+
+- Line 107: `— install via` in hook Requires template
+- Line 134: `— install via` in Requirements section template
+- Line 146: `— brief reason` in See Also template
+- Line 158: `— install via` in hook Requires template
+
+Add the Installation section to both the skill and hook README templates.
+
+## Files to Modify
+
+- `README.md` (root)
+- `plugins/address-review/README.md`
+- `plugins/block-rm-rf/README.md`
+- `plugins/clean-up-agent-config/README.md`
+- `plugins/commit/README.md`
+- `plugins/create-plugin/README.md`
+- `plugins/create-worktree/README.md`
+- `plugins/create-worktree-from-issue/README.md`
+- `plugins/handle-secrets/README.md` (create new)
+- `plugins/lint-and-fix/README.md`
+- `plugins/merge-main/README.md`
+- `plugins/notify/README.md`
+- `plugins/pr/README.md`
+- `plugins/resolve-copilot-pr-feedback/README.md`
+- `plugins/review-branch/README.md`
+- `plugins/scaffold-go-cli/README.md`
+- `plugins/scaffold-new-repo/README.md`
+- `plugins/setup-gitleaks/README.md`
+- `plugins/suggest-next-issue/README.md`
+- `plugins/write-go-code/README.md`
+- `plugins/write-markdown/README.md`
+- `plugins/write-shell-scripts/README.md`
+- `plugins/create-plugin/skills/create-plugin/references/readme-updates.md`
+
+Total: 23 files (22 edits + 1 new)
+
+## Not in Scope
+
+- SKILL.md files and other non-README markdown (em dashes exist but are agent-facing, not user-facing)
+- Plan files in `docs/plans/` (historical documents)
+- Reference files outside the README template (`BASH.md`, `security-hierarchy.md`, etc.)
+
+## Verification
+
+1. Grep for em dashes across all README files: `rg '—' --glob '*/README.md'` should return zero matches
+2. Verify no broken links: each See Also link should resolve
+3. Verify ToC anchors still work: each `#anchor` in the ToC should match an H3 or H4 heading
+4. Run `markdownlint-cli2` on all modified files
+5. Verify handle-secrets appears in root README ToC and content

--- a/plugins/address-review/README.md
+++ b/plugins/address-review/README.md
@@ -5,6 +5,16 @@ Parse a review document for actionable feedback items, work through them systema
 **Type:** Skill
 **Trigger:** `/address-review <path>`
 
+## Installation
+
+Add the [`cboone/cboone-cc-plugins`](https://github.com/cboone/cboone-cc-plugins) marketplace in Claude Code:
+
+```text
+/plugin marketplace add cboone/cboone-cc-plugins
+```
+
+Then select **Address Review** from the available plugins.
+
 ## What It Does
 
 Extracts items from checkboxes, bullets, numbered lists, and headings in a review document. Categorizes each item by type (code change, documentation, question, style), presents a summary for confirmation, then resolves items one by one. Commits fixes in logical groups by default, or per-item on request.
@@ -18,18 +28,18 @@ Extracts items from checkboxes, bullets, numbered lists, and headings in a revie
 /address-review docs/reviews/my-review.md --skip 2,5,8
 ```
 
-| Option | Description |
-| --------------------- | ----------------------------------------------------------- |
-| `--dry-run` | Parse and list items without making changes |
+| Option              | Description                                              |
+| ------------------- | -------------------------------------------------------- |
+| `--dry-run`         | Parse and list items without making changes              |
 | `--commit-per-item` | Commit after each item instead of grouping related fixes |
-| `--skip <numbers>` | Skip specific item numbers (comma-separated) |
+| `--skip <numbers>`  | Skip specific item numbers (comma-separated)             |
 
 ## Examples
 
-- "address review @docs/reviews/pr-feedback.md" — works through all items
-- "address the review --dry-run" — previews items without making changes
+- "address review @docs/reviews/pr-feedback.md": works through all items
+- "address the review --dry-run": previews items without making changes
 
 ## See Also
 
-- [Resolve Copilot PR Feedback](../resolve-copilot-pr-feedback/README.md) — resolve automated Copilot review comments
+- [Resolve Copilot PR Feedback](../resolve-copilot-pr-feedback/README.md): resolve automated Copilot review comments
 - [All plugins](../../README.md)

--- a/plugins/block-rm-rf/README.md
+++ b/plugins/block-rm-rf/README.md
@@ -3,7 +3,17 @@
 Blocks recursive `rm` commands before they execute.
 
 **Type:** Hook
-**Requires:** [`trash`](https://hasseg.org/trash/) — install via [Homebrew](https://brew.sh): `brew install trash`
+**Requires:** [`trash`](https://hasseg.org/trash/). Install via [Homebrew](https://brew.sh): `brew install trash`
+
+## Installation
+
+Add the [`cboone/cboone-cc-plugins`](https://github.com/cboone/cboone-cc-plugins) marketplace in Claude Code:
+
+```text
+/plugin marketplace add cboone/cboone-cc-plugins
+```
+
+Then select **Block rm -rf** from the available plugins.
 
 ## What It Does
 

--- a/plugins/clean-up-agent-config/README.md
+++ b/plugins/clean-up-agent-config/README.md
@@ -5,6 +5,16 @@ Review and reorganize AI coding agent configuration and instruction files.
 **Type:** Skill
 **Trigger:** `/clean-up-agent-config`
 
+## Installation
+
+Add the [`cboone/cboone-cc-plugins`](https://github.com/cboone/cboone-cc-plugins) marketplace in Claude Code:
+
+```text
+/plugin marketplace add cboone/cboone-cc-plugins
+```
+
+Then select **Clean Up Agent Config** from the available plugins.
+
 ## What It Does
 
 Audits agent configuration files across Claude Code, OpenAI Codex, GitHub Copilot (CLI and code review), and OpenCode. Identifies duplications and misplaced settings, proposes a consolidated structure, handles the `settings.json` vs `settings.local.json` split, sets up `AGENTS.md` as the single source of truth with `CLAUDE.md` as a symlink, and takes advantage of tool-specific features like Copilot's path-scoped `.instructions.md` files.
@@ -19,11 +29,11 @@ Includes comprehensive reference documentation on all agent instruction and conf
 
 ## Examples
 
-- "clean up agent config" — audits and reorganizes all agent config files
-- "organize agent files" — same behavior
-- "consolidate agent files" — same behavior
+- "clean up agent config": audits and reorganizes all agent config files
+- "organize agent files": same behavior
+- "consolidate agent files": same behavior
 
 ## See Also
 
-- [Create Plugin](../create-plugin/README.md) — create new plugins for the agent ecosystem
+- [Create Plugin](../create-plugin/README.md): create new plugins for the agent ecosystem
 - [All plugins](../../README.md)

--- a/plugins/commit/README.md
+++ b/plugins/commit/README.md
@@ -5,6 +5,16 @@ Smart, context-aware git commits with conventional commit messages and plan awar
 **Type:** Skill
 **Trigger:** `/commit`
 
+## Installation
+
+Add the [`cboone/cboone-cc-plugins`](https://github.com/cboone/cboone-cc-plugins) marketplace in Claude Code:
+
+```text
+/plugin marketplace add cboone/cboone-cc-plugins
+```
+
+Then select **Commit** from the available plugins.
+
 ## What It Does
 
 Analyzes your diff to generate well-structured conventional commit messages that match your repository's existing style. Handles staged-only vs. all changes, supports commit-and-push workflows, and can detect plan files for separate commits.
@@ -19,21 +29,21 @@ Analyzes your diff to generate well-structured conventional commit messages that
 /commit --all
 ```
 
-| Option | Description |
-| --------- | ------------------------------------------------------- |
-| `--push` | Push to remote after committing |
-| `--staged` | Commit only staged changes, ignoring unstaged changes |
-| `--plan` | Commit only the plan file(s) |
-| `--all` | Stage and commit all changes including untracked files |
+| Option     | Description                                            |
+| ---------- | ------------------------------------------------------ |
+| `--push`   | Push to remote after committing                        |
+| `--staged` | Commit only staged changes, ignoring unstaged changes  |
+| `--plan`   | Commit only the plan file(s)                           |
+| `--all`    | Stage and commit all changes including untracked files |
 
 ## Examples
 
-- "commit" — stages and commits with an auto-generated message
-- "commit and push" — commits then pushes to remote
-- "commit the plan, then the changes" — creates two sequential commits
-- "give the plan a meaningful name and commit" — renames and commits the plan file
+- "commit": stages and commits with an auto-generated message
+- "commit and push": commits then pushes to remote
+- "commit the plan, then the changes": creates two sequential commits
+- "give the plan a meaningful name and commit": renames and commits the plan file
 
 ## See Also
 
-- [PR](../pr/README.md) — commit, push, and open a pull request in one step
+- [PR](../pr/README.md): commit, push, and open a pull request in one step
 - [All plugins](../../README.md)

--- a/plugins/create-plugin/README.md
+++ b/plugins/create-plugin/README.md
@@ -5,6 +5,16 @@ Guide for creating new plugins in this repository with consistent structure and 
 **Type:** Skill
 **Trigger:** `/create-plugin`
 
+## Installation
+
+Add the [`cboone/cboone-cc-plugins`](https://github.com/cboone/cboone-cc-plugins) marketplace in Claude Code:
+
+```text
+/plugin marketplace add cboone/cboone-cc-plugins
+```
+
+Then select **Create Plugin** from the available plugins.
+
 ## What It Does
 
 Walks through the full process of creating a new Claude Code plugin: choosing a plugin type (skill, hook, or both), scaffolding the directory structure, writing all required files (`plugin.json`, `SKILL.md`, `hooks.json`, scripts), and registering the plugin in the marketplace. Includes reference documentation for every file format.
@@ -17,11 +27,11 @@ Walks through the full process of creating a new Claude Code plugin: choosing a 
 
 ## Examples
 
-- "create a plugin" — starts the guided plugin creation workflow
-- "add a new skill" — same behavior
-- "new plugin" — same behavior
+- "create a plugin": starts the guided plugin creation workflow
+- "add a new skill": same behavior
+- "new plugin": same behavior
 
 ## See Also
 
-- [Clean Up Agent Config](../clean-up-agent-config/README.md) — organize existing agent config files
+- [Clean Up Agent Config](../clean-up-agent-config/README.md): organize existing agent config files
 - [All plugins](../../README.md)

--- a/plugins/create-plugin/skills/create-plugin/references/readme-updates.md
+++ b/plugins/create-plugin/skills/create-plugin/references/readme-updates.md
@@ -67,7 +67,7 @@ Use this guide to determine which subcategory a new plugin belongs to:
 
 ## Installation Section
 
-The installation section directs users to add the marketplace and browse plugins from there. It does not list individual install commands — users select plugins interactively after adding the marketplace.
+The installation section directs users to add the marketplace and browse plugins from there. It does not list individual install commands; users select plugins interactively after adding the marketplace.
 
 ## Plugin Description Sections
 
@@ -104,7 +104,7 @@ Each hook gets an H3 subsection under `## Hooks`. The description is 1-2 sentenc
 
 Description of what the hook does and when it fires.
 
-> **Requires:** [`dependency`](URL) — install via [Homebrew](https://brew.sh): `install command`
+> **Requires:** [`dependency`](URL). Install via [Homebrew](https://brew.sh): `install command`
 > **Details:** [README](./plugins/hook-name/README.md)
 ```
 
@@ -122,6 +122,16 @@ One-sentence description.
 **Type:** Skill
 **Trigger:** `/plugin-name` [(also activates automatically)]
 
+## Installation
+
+Add the [`cboone/cboone-cc-plugins`](https://github.com/cboone/cboone-cc-plugins) marketplace in Claude Code:
+
+` ```text `
+/plugin marketplace add cboone/cboone-cc-plugins
+` ``` `
+
+Then select **Plugin Name** from the available plugins.
+
 ## What It Does
 
 2-4 sentences describing the outcome for the user. Focus on what the user
@@ -131,7 +141,7 @@ gets, not internal agent workflow.
 
 (Only if external dependencies exist.)
 
-- [`dependency`](URL) — install via Homebrew: `brew install dependency`
+- [`dependency`](URL). Install via Homebrew: `brew install dependency`
 
 ## Usage
 
@@ -143,7 +153,7 @@ Trigger phrases or usage scenarios.
 
 ## See Also
 
-- [Related Plugin](../related-plugin/README.md) — brief reason
+- [Related Plugin](../related-plugin/README.md): brief reason
 - [All plugins](../../README.md)
 ```
 
@@ -155,7 +165,17 @@ Trigger phrases or usage scenarios.
 One-sentence description.
 
 **Type:** Hook
-**Requires:** [`dependency`](URL) — install via [Homebrew](https://brew.sh): `brew install dependency`
+**Requires:** [`dependency`](URL). Install via [Homebrew](https://brew.sh): `brew install dependency`
+
+## Installation
+
+Add the [`cboone/cboone-cc-plugins`](https://github.com/cboone/cboone-cc-plugins) marketplace in Claude Code:
+
+` ```text `
+/plugin marketplace add cboone/cboone-cc-plugins
+` ``` `
+
+Then select **Hook Name** from the available plugins.
 
 ## What It Does
 

--- a/plugins/create-worktree-from-issue/README.md
+++ b/plugins/create-worktree-from-issue/README.md
@@ -6,6 +6,16 @@ Find a GitHub issue and create a dedicated worktree, branch, and tmux window for
 **Trigger:** `/create-worktree-from-issue`
 **Requires:** [`gh`](https://cli.github.com/), [`workmux`](https://github.com/paiml/workmux)
 
+## Installation
+
+Add the [`cboone/cboone-cc-plugins`](https://github.com/cboone/cboone-cc-plugins) marketplace in Claude Code:
+
+```text
+/plugin marketplace add cboone/cboone-cc-plugins
+```
+
+Then select **Create Worktree from Issue** from the available plugins.
+
 ## What It Does
 
 Finds a GitHub issue by number or fuzzy text search, derives a branch name from the issue title and labels, self-assigns the issue, labels it "in progress", and creates a worktree via `workmux add` with the full issue context injected as a task prompt.
@@ -21,12 +31,12 @@ Provide either an issue number or descriptive text to search for.
 
 ## Examples
 
-- "start issue #42" — looks up issue 42 and creates a worktree for it
-- "work on the dark mode issue" — searches for a matching issue by title
-- "create worktree for issue 15" — same as providing the number directly
+- "start issue #42": looks up issue 42 and creates a worktree for it
+- "work on the dark mode issue": searches for a matching issue by title
+- "create worktree for issue 15": same as providing the number directly
 
 ## See Also
 
-- [Create Worktree](../create-worktree/README.md) — create a worktree from a task description (not a GitHub issue)
-- [Suggest Next Issue](../suggest-next-issue/README.md) — get a recommendation for which issue to work on
+- [Create Worktree](../create-worktree/README.md): create a worktree from a task description (not a GitHub issue)
+- [Suggest Next Issue](../suggest-next-issue/README.md): get a recommendation for which issue to work on
 - [All plugins](../../README.md)

--- a/plugins/create-worktree/README.md
+++ b/plugins/create-worktree/README.md
@@ -6,6 +6,16 @@ Create a new git worktree, branch, and tmux window with a task prompt injected i
 **Trigger:** `/create-worktree`
 **Requires:** [`workmux`](https://github.com/paiml/workmux)
 
+## Installation
+
+Add the [`cboone/cboone-cc-plugins`](https://github.com/cboone/cboone-cc-plugins) marketplace in Claude Code:
+
+```text
+/plugin marketplace add cboone/cboone-cc-plugins
+```
+
+Then select **Create Worktree** from the available plugins.
+
 ## What It Does
 
 Derives a branch name from your task description (e.g., `feature/add-dark-mode-support` or `fix/auth-timeout`), or accepts an explicit branch name. Creates the worktree via `workmux add` and injects a task prompt so the new agent session knows what to work on.
@@ -21,11 +31,11 @@ Provide either a task description (branch name is derived automatically) or an e
 
 ## Examples
 
-- "create worktree for adding dark mode" — creates `feature/adding-dark-mode`
-- "spin up a worktree to fix the auth timeout" — creates `fix/auth-timeout`
-- "new worktree feature/refactor-config" — uses the branch name as-is
+- "create worktree for adding dark mode": creates `feature/adding-dark-mode`
+- "spin up a worktree to fix the auth timeout": creates `fix/auth-timeout`
+- "new worktree feature/refactor-config": uses the branch name as-is
 
 ## See Also
 
-- [Create Worktree from Issue](../create-worktree-from-issue/README.md) — create a worktree tied to a GitHub issue
+- [Create Worktree from Issue](../create-worktree-from-issue/README.md): create a worktree tied to a GitHub issue
 - [All plugins](../../README.md)

--- a/plugins/handle-secrets/README.md
+++ b/plugins/handle-secrets/README.md
@@ -1,0 +1,42 @@
+# Handle Secrets
+
+Best practices for handling user-provided secrets in CLI tools.
+
+**Type:** Skill
+**Trigger:** `/handle-secrets`
+
+## Installation
+
+Add the [`cboone/cboone-cc-plugins`](https://github.com/cboone/cboone-cc-plugins) marketplace in Claude Code:
+
+```text
+/plugin marketplace add cboone/cboone-cc-plugins
+```
+
+Then select **Handle Secrets** from the available plugins.
+
+## What It Does
+
+Provides security best practices for accepting secrets (API keys, tokens, passwords) from users in CLI tools. Covers the security hierarchy of input methods, credential storage patterns with OS keychains and config files, secret masking in output, and language-specific libraries for Rust, Go, Python, Node.js, and Ruby.
+
+Organized into a quick-review checklist and deep-dive references by topic.
+
+## Usage
+
+```text
+/handle-secrets
+```
+
+The skill also activates automatically when Claude Code detects work involving user-provided secrets in CLI tools.
+
+## Examples
+
+- Building a CLI that accepts an API key: the skill provides the secure input hierarchy
+- "review this code for secret handling": checks against the security checklist
+- "/handle-secrets": loads the full best practices guide explicitly
+
+## See Also
+
+- [Write Go Code](../write-go-code/README.md): Go-specific libraries for credential handling
+- [Setup Gitleaks](../setup-gitleaks/README.md): prevent secrets from being committed to repositories
+- [All plugins](../../README.md)

--- a/plugins/lint-and-fix/README.md
+++ b/plugins/lint-and-fix/README.md
@@ -5,6 +5,16 @@ Detect available linters and formatters in the project, run them with auto-fix, 
 **Type:** Skill
 **Trigger:** `/lint-and-fix`
 
+## Installation
+
+Add the [`cboone/cboone-cc-plugins`](https://github.com/cboone/cboone-cc-plugins) marketplace in Claude Code:
+
+```text
+/plugin marketplace add cboone/cboone-cc-plugins
+```
+
+Then select **Lint and Fix** from the available plugins.
+
 ## What It Does
 
 Checks for configuration files to detect ESLint, Prettier, markdownlint, ShellCheck, shfmt, Knip, and project-specific lint scripts. Runs each detected tool with auto-fix flags, reports what was fixed and what remains, then attempts to manually resolve remaining issues.
@@ -19,21 +29,21 @@ Checks for configuration files to detect ESLint, Prettier, markdownlint, ShellCh
 /lint-and-fix --no-commit
 ```
 
-| Option | Description |
-| ------------------- | --------------------------------------------------------- |
-| `--check` | Report issues without fixing (dry run) |
-| `--tool <name>` | Run only a specific tool |
-| `--commit` | Commit fixes automatically |
-| `--no-commit` | Do not commit fixes |
+| Option          | Description                            |
+| --------------- | -------------------------------------- |
+| `--check`       | Report issues without fixing (dry run) |
+| `--tool <name>` | Run only a specific tool               |
+| `--commit`      | Commit fixes automatically             |
+| `--no-commit`   | Do not commit fixes                    |
 
 ## Examples
 
-- "lint and fix" — detects and runs all available linters with auto-fix
-- "run the linter --check" — reports issues without modifying files
-- "fix lint errors --tool prettier" — runs only Prettier
+- "lint and fix": detects and runs all available linters with auto-fix
+- "run the linter --check": reports issues without modifying files
+- "fix lint errors --tool prettier": runs only Prettier
 
 ## See Also
 
-- [Write Go Code](../write-go-code/README.md) — Go-specific style enforcement
-- [Write Markdown](../write-markdown/README.md) — Markdown-specific style enforcement
+- [Write Go Code](../write-go-code/README.md): Go-specific style enforcement
+- [Write Markdown](../write-markdown/README.md): Markdown-specific style enforcement
 - [All plugins](../../README.md)

--- a/plugins/merge-main/README.md
+++ b/plugins/merge-main/README.md
@@ -6,6 +6,16 @@ Fetch and merge the repository's base branch into the current feature branch.
 **Trigger:** `/merge-main`
 **Requires:** [`gh`](https://cli.github.com/) (falls back to `git remote show origin` if unavailable)
 
+## Installation
+
+Add the [`cboone/cboone-cc-plugins`](https://github.com/cboone/cboone-cc-plugins) marketplace in Claude Code:
+
+```text
+/plugin marketplace add cboone/cboone-cc-plugins
+```
+
+Then select **Merge Main** from the available plugins.
+
 ## What It Does
 
 Automatically detects the default branch, handles uncommitted changes (stash, commit, or abort), resolves merge conflicts, and pushes after a successful merge. Suggests running install commands when lockfiles change.
@@ -17,17 +27,17 @@ Automatically detects the default branch, handles uncommitted changes (stash, co
 /merge-main --base develop
 ```
 
-| Option | Description |
-| ------------------- | ----------------------------------------------- |
+| Option            | Description                            |
+| ----------------- | -------------------------------------- |
 | `--base <branch>` | Override the auto-detected base branch |
 
 ## Examples
 
-- "merge main" — fetches and merges the default branch
-- "merge main --base develop" — merges the `develop` branch instead
-- "sync with main" — same as "merge main"
+- "merge main": fetches and merges the default branch
+- "merge main --base develop": merges the `develop` branch instead
+- "sync with main": same as "merge main"
 
 ## See Also
 
-- [Review Branch](../review-branch/README.md) — summarize what changed on the current branch
+- [Review Branch](../review-branch/README.md): summarize what changed on the current branch
 - [All plugins](../../README.md)

--- a/plugins/notify/README.md
+++ b/plugins/notify/README.md
@@ -3,7 +3,17 @@
 Sends macOS notifications when Claude finishes a task or needs your attention.
 
 **Type:** Hook
-**Requires:** [`terminal-notifier`](https://github.com/julienXX/terminal-notifier) — install via [Homebrew](https://brew.sh): `brew install terminal-notifier`
+**Requires:** [`terminal-notifier`](https://github.com/julienXX/terminal-notifier). Install via [Homebrew](https://brew.sh): `brew install terminal-notifier`
+
+## Installation
+
+Add the [`cboone/cboone-cc-plugins`](https://github.com/cboone/cboone-cc-plugins) marketplace in Claude Code:
+
+```text
+/plugin marketplace add cboone/cboone-cc-plugins
+```
+
+Then select **Notify** from the available plugins.
 
 ## What It Does
 

--- a/plugins/pr/README.md
+++ b/plugins/pr/README.md
@@ -6,6 +6,16 @@ Commit all changes, push to remote, and create a GitHub pull request in one auto
 **Trigger:** `/pr`
 **Requires:** [`gh`](https://cli.github.com/)
 
+## Installation
+
+Add the [`cboone/cboone-cc-plugins`](https://github.com/cboone/cboone-cc-plugins) marketplace in Claude Code:
+
+```text
+/plugin marketplace add cboone/cboone-cc-plugins
+```
+
+Then select **PR** from the available plugins.
+
 ## What It Does
 
 Stages everything, generates a conventional commit message from the diff, pushes the branch, and opens a PR with an auto-generated title and summary. Detects connected GitHub issues from branch names and commit messages, and adds closing references automatically. Handles branches with no upstream, skips the commit step when the working tree is clean, and detects when a PR already exists.
@@ -16,16 +26,16 @@ Stages everything, generates a conventional commit message from the diff, pushes
 /pr
 ```
 
-No options — the skill makes opinionated decisions at every step with no prompts.
+No options. The skill makes opinionated decisions at every step with no prompts.
 
 ## Examples
 
-- "pr" — commits, pushes, and creates a pull request
-- "create a pr" — same behavior
-- "push and create pr" — same behavior
+- "pr": commits, pushes, and creates a pull request
+- "create a pr": same behavior
+- "push and create pr": same behavior
 
 ## See Also
 
-- [Commit](../commit/README.md) — commit without creating a PR
-- [Review Branch](../review-branch/README.md) — summarize branch work before opening a PR
+- [Commit](../commit/README.md): commit without creating a PR
+- [Review Branch](../review-branch/README.md): summarize branch work before opening a PR
 - [All plugins](../../README.md)

--- a/plugins/resolve-copilot-pr-feedback/README.md
+++ b/plugins/resolve-copilot-pr-feedback/README.md
@@ -5,6 +5,16 @@ Process and resolve GitHub Copilot automated PR review comments.
 **Type:** Skill
 **Trigger:** `/resolve-copilot-pr-feedback`
 
+## Installation
+
+Add the [`cboone/cboone-cc-plugins`](https://github.com/cboone/cboone-cc-plugins) marketplace in Claude Code:
+
+```text
+/plugin marketplace add cboone/cboone-cc-plugins
+```
+
+Then select **Resolve Copilot PR Feedback** from the available plugins.
+
 ## What It Does
 
 Fetches unresolved Copilot review threads via GraphQL, categorizes them (nitpick, outdated, incorrect, valid, deferred), resolves threads, and updates Copilot instruction files under `.github/` when Copilot feedback is incorrect. Helps you quickly triage automated suggestions after opening a PR.
@@ -17,12 +27,12 @@ Fetches unresolved Copilot review threads via GraphQL, categorizes them (nitpick
 
 ## Examples
 
-- "resolve copilot feedback" — fetches and processes Copilot review comments
-- "check copilot review" — same behavior
-- "handle copilot comments" — same behavior
+- "resolve copilot feedback": fetches and processes Copilot review comments
+- "check copilot review": same behavior
+- "handle copilot comments": same behavior
 
 ## See Also
 
-- [Address Review](../address-review/README.md) — work through a human-written review document
-- [PR](../pr/README.md) — create the PR that Copilot will review
+- [Address Review](../address-review/README.md): work through a human-written review document
+- [PR](../pr/README.md): create the PR that Copilot will review
 - [All plugins](../../README.md)

--- a/plugins/review-branch/README.md
+++ b/plugins/review-branch/README.md
@@ -5,6 +5,16 @@ Summarize all work done on the current branch compared to the base branch.
 **Type:** Skill
 **Trigger:** `/review-branch`
 
+## Installation
+
+Add the [`cboone/cboone-cc-plugins`](https://github.com/cboone/cboone-cc-plugins) marketplace in Claude Code:
+
+```text
+/plugin marketplace add cboone/cboone-cc-plugins
+```
+
+Then select **Review Branch** from the available plugins.
+
 ## What It Does
 
 Groups changes by area/concern, lists new/modified/deleted files, and highlights notable changes (new dependencies, config changes, schema changes, API changes). Optionally compares progress against a plan document, reporting completed, in-progress, and remaining items with a completion percentage.
@@ -18,19 +28,19 @@ Groups changes by area/concern, lists new/modified/deleted files, and highlights
 /review-branch --brief
 ```
 
-| Option | Description |
-| ------------------- | --------------------------------------------------------- |
-| `--plan <path>` | Compare progress against a plan document |
+| Option          | Description                                       |
+| --------------- | ------------------------------------------------- |
+| `--plan <path>` | Compare progress against a plan document          |
 | `--since <ref>` | Use a specific tag, branch, or commit as the base |
-| `--brief` | Output only a high-level summary |
+| `--brief`       | Output only a high-level summary                  |
 
 ## Examples
 
-- "review branch" — full summary of all changes
-- "where are we on this branch" — same as above
-- "compare branch to plan" — auto-detects a matching plan file
+- "review branch": full summary of all changes
+- "where are we on this branch": same as above
+- "compare branch to plan": auto-detects a matching plan file
 
 ## See Also
 
-- [PR](../pr/README.md) — create a pull request after reviewing
+- [PR](../pr/README.md): create a pull request after reviewing
 - [All plugins](../../README.md)

--- a/plugins/scaffold-go-cli/README.md
+++ b/plugins/scaffold-go-cli/README.md
@@ -5,6 +5,16 @@ Scaffold a complete Go CLI project with Cobra, GoReleaser, GitHub Actions CI/CD,
 **Type:** Skill
 **Trigger:** `/scaffold-go-cli`
 
+## Installation
+
+Add the [`cboone/cboone-cc-plugins`](https://github.com/cboone/cboone-cc-plugins) marketplace in Claude Code:
+
+```text
+/plugin marketplace add cboone/cboone-cc-plugins
+```
+
+Then select **Scaffold Go CLI** from the available plugins.
+
 ## What It Does
 
 Generates the full boilerplate for a new Go CLI project: `main.go`, `cmd/root.go`, `go.mod`, `Makefile`, `.gitignore`, `.goreleaser.yml`, CI and release workflows, `LICENSE`, `README`, and directory stubs. Supports optional Viper config management and Charmbracelet TUI dependencies.
@@ -19,12 +29,12 @@ The skill prompts for project name, module path, description, and optional featu
 
 ## Examples
 
-- "scaffold go cli" — starts the interactive scaffolding process
-- "new go cli" — same behavior
-- "start a go cli project" — same behavior
+- "scaffold go cli": starts the interactive scaffolding process
+- "new go cli": same behavior
+- "start a go cli project": same behavior
 
 ## See Also
 
-- [Scaffold New Repo](../scaffold-new-repo/README.md) — language-agnostic repo boilerplate (included automatically)
-- [Write Go Code](../write-go-code/README.md) — Go style guide for writing code in the new project
+- [Scaffold New Repo](../scaffold-new-repo/README.md): language-agnostic repo boilerplate (included automatically)
+- [Write Go Code](../write-go-code/README.md): Go style guide for writing code in the new project
 - [All plugins](../../README.md)

--- a/plugins/scaffold-new-repo/README.md
+++ b/plugins/scaffold-new-repo/README.md
@@ -5,6 +5,16 @@ Scaffold the universal boilerplate for any new repository, regardless of languag
 **Type:** Skill
 **Trigger:** `/scaffold-new-repo`
 
+## Installation
+
+Add the [`cboone/cboone-cc-plugins`](https://github.com/cboone/cboone-cc-plugins) marketplace in Claude Code:
+
+```text
+/plugin marketplace add cboone/cboone-cc-plugins
+```
+
+Then select **Scaffold New Repo** from the available plugins.
+
 ## What It Does
 
 Generates LICENSE (MIT), README.md, a project-type-specific `.gitignore`, agent config files (`AGENTS.md`, `CLAUDE.md` symlink, `.claude/settings.json`, `.github/copilot-instructions.md`), and a `docs/plans/` directory. Infers the project type from an existing `.gitignore` when possible. Supports Go CLI, Go library, Shell, JavaScript, Ruby, and generic project types.
@@ -19,12 +29,12 @@ The skill prompts for project name, description, and type during setup.
 
 ## Examples
 
-- "scaffold a new repo" — starts the interactive scaffolding process
-- "new repo" — same behavior
-- "start a new project" — same behavior
+- "scaffold a new repo": starts the interactive scaffolding process
+- "new repo": same behavior
+- "start a new project": same behavior
 
 ## See Also
 
-- [Scaffold Go CLI](../scaffold-go-cli/README.md) — Go CLI-specific scaffolding (includes this boilerplate)
-- [Setup Gitleaks](../setup-gitleaks/README.md) — add secret scanning after scaffolding
+- [Scaffold Go CLI](../scaffold-go-cli/README.md): Go CLI-specific scaffolding (includes this boilerplate)
+- [Setup Gitleaks](../setup-gitleaks/README.md): add secret scanning after scaffolding
 - [All plugins](../../README.md)

--- a/plugins/setup-gitleaks/README.md
+++ b/plugins/setup-gitleaks/README.md
@@ -5,6 +5,16 @@ Set up gitleaks secret scanning in a repository with a GitHub Actions workflow a
 **Type:** Skill
 **Trigger:** `/setup-gitleaks`
 
+## Installation
+
+Add the [`cboone/cboone-cc-plugins`](https://github.com/cboone/cboone-cc-plugins) marketplace in Claude Code:
+
+```text
+/plugin marketplace add cboone/cboone-cc-plugins
+```
+
+Then select **Setup Gitleaks** from the available plugins.
+
 ## What It Does
 
 Detects whether the repository is organization-owned (requires a gitleaks license secret) or personal, and generates the appropriate GitHub Actions workflow. Optionally creates a starter `.gitleaks.toml` with sensible defaults and example allowlist entries.
@@ -17,11 +27,11 @@ Detects whether the repository is organization-owned (requires a gitleaks licens
 
 ## Examples
 
-- "set up gitleaks" — generates the workflow and optional config
-- "add secret scanning" — same behavior
-- "setup gitleaks" — same behavior
+- "set up gitleaks": generates the workflow and optional config
+- "add secret scanning": same behavior
+- "setup gitleaks": same behavior
 
 ## See Also
 
-- [Scaffold New Repo](../scaffold-new-repo/README.md) — scaffold a full repo (then add gitleaks)
+- [Scaffold New Repo](../scaffold-new-repo/README.md): scaffold a full repo (then add gitleaks)
 - [All plugins](../../README.md)

--- a/plugins/suggest-next-issue/README.md
+++ b/plugins/suggest-next-issue/README.md
@@ -6,9 +6,19 @@ Review all open GitHub issues and recommend what to work on next with prioritize
 **Trigger:** `/suggest-next-issue`
 **Requires:** [`gh`](https://cli.github.com/)
 
+## Installation
+
+Add the [`cboone/cboone-cc-plugins`](https://github.com/cboone/cboone-cc-plugins) marketplace in Claude Code:
+
+```text
+/plugin marketplace add cboone/cboone-cc-plugins
+```
+
+Then select **Suggest Next Issue** from the available plugins.
+
 ## What It Does
 
-Analyzes open issues in context — current branches, recent work, project goals, and dependencies — then categorizes them as quick wins, high impact, unblocks others, or overdue. Provides specific reasoning for each recommendation so you can make an informed decision.
+Analyzes open issues in context (current branches, recent work, project goals, and dependencies), then categorizes them as quick wins, high impact, unblocks others, or overdue. Provides specific reasoning for each recommendation so you can make an informed decision.
 
 ## Usage
 
@@ -18,11 +28,11 @@ Analyzes open issues in context — current branches, recent work, project goals
 
 ## Examples
 
-- "suggest next issue" — analyzes all open issues and recommends priorities
-- "what should I work on next" — same behavior
-- "triage issues" — same behavior
+- "suggest next issue": analyzes all open issues and recommends priorities
+- "what should I work on next": same behavior
+- "triage issues": same behavior
 
 ## See Also
 
-- [Create Worktree from Issue](../create-worktree-from-issue/README.md) — start working on the suggested issue
+- [Create Worktree from Issue](../create-worktree-from-issue/README.md): start working on the suggested issue
 - [All plugins](../../README.md)

--- a/plugins/write-go-code/README.md
+++ b/plugins/write-go-code/README.md
@@ -5,6 +5,16 @@ Go code style guide based on Google Go Style Guide, Effective Go, and Code Revie
 **Type:** Skill
 **Trigger:** `/write-go-code` (also activates automatically)
 
+## Installation
+
+Add the [`cboone/cboone-cc-plugins`](https://github.com/cboone/cboone-cc-plugins) marketplace in Claude Code:
+
+```text
+/plugin marketplace add cboone/cboone-cc-plugins
+```
+
+Then select **Write Go Code** from the available plugins.
+
 ## What It Does
 
 Provides Go style conventions covering naming, error handling, concurrency, testing, data types, functions, interfaces, and code organization. Activates automatically when writing, reviewing, or refactoring Go code, so you get consistent style guidance without needing to invoke it manually.
@@ -21,12 +31,12 @@ The skill also activates automatically when Claude Code detects Go code work.
 
 ## Examples
 
-- Writing a new Go function — the style guide activates automatically
-- "review this Go code for style" — activates automatically
-- "/write-go-code" — loads the full style guide explicitly
+- Writing a new Go function: the style guide activates automatically
+- "review this Go code for style": activates automatically
+- "/write-go-code": loads the full style guide explicitly
 
 ## See Also
 
-- [Lint and Fix](../lint-and-fix/README.md) — run linters and formatters across the project
-- [Scaffold Go CLI](../scaffold-go-cli/README.md) — scaffold a full Go CLI project
+- [Lint and Fix](../lint-and-fix/README.md): run linters and formatters across the project
+- [Scaffold Go CLI](../scaffold-go-cli/README.md): scaffold a full Go CLI project
 - [All plugins](../../README.md)

--- a/plugins/write-markdown/README.md
+++ b/plugins/write-markdown/README.md
@@ -5,6 +5,16 @@ Markdown style conventions targeting GitHub Flavored Markdown (GFM), aligned wit
 **Type:** Skill
 **Trigger:** `/write-markdown` (also activates automatically)
 
+## Installation
+
+Add the [`cboone/cboone-cc-plugins`](https://github.com/cboone/cboone-cc-plugins) marketplace in Claude Code:
+
+```text
+/plugin marketplace add cboone/cboone-cc-plugins
+```
+
+Then select **Write Markdown** from the available plugins.
+
 ## What It Does
 
 Provides Markdown formatting conventions for document structure, headings, links, lists, tables, code blocks, and HTML usage. Activates automatically when creating, editing, or reviewing Markdown files, ensuring consistent formatting across the project.
@@ -21,11 +31,11 @@ The skill also activates automatically when Claude Code detects Markdown file wo
 
 ## Examples
 
-- Creating a new `.md` file — the style guide activates automatically
-- "review this Markdown for formatting" — activates automatically
-- "/write-markdown" — loads the full style guide explicitly
+- Creating a new `.md` file: the style guide activates automatically
+- "review this Markdown for formatting": activates automatically
+- "/write-markdown": loads the full style guide explicitly
 
 ## See Also
 
-- [Lint and Fix](../lint-and-fix/README.md) — run markdownlint and other formatters
+- [Lint and Fix](../lint-and-fix/README.md): run markdownlint and other formatters
 - [All plugins](../../README.md)

--- a/plugins/write-shell-scripts/README.md
+++ b/plugins/write-shell-scripts/README.md
@@ -5,6 +5,16 @@ Bash style conventions for creating and editing shell scripts.
 **Type:** Skill
 **Trigger:** `/write-shell-scripts` (also activates automatically)
 
+## Installation
+
+Add the [`cboone/cboone-cc-plugins`](https://github.com/cboone/cboone-cc-plugins) marketplace in Claude Code:
+
+```text
+/plugin marketplace add cboone/cboone-cc-plugins
+```
+
+Then select **Write Shell Scripts** from the available plugins.
+
 ## What It Does
 
 Provides Bash coding conventions covering script structure, strict mode, quoting, error handling, and portability. Activates automatically when creating, editing, or reviewing shell scripts, ensuring consistent style across all Bash files.
@@ -21,11 +31,11 @@ The skill also activates automatically when Claude Code detects shell script wor
 
 ## Examples
 
-- Creating a new shell script — the style guide activates automatically
-- Editing a script in `bin/` — activates automatically
-- "/write-shell-scripts" — loads the full style guide explicitly
+- Creating a new shell script: the style guide activates automatically
+- Editing a script in `bin/`: activates automatically
+- "/write-shell-scripts": loads the full style guide explicitly
 
 ## See Also
 
-- [Lint and Fix](../lint-and-fix/README.md) — run ShellCheck and shfmt across the project
+- [Lint and Fix](../lint-and-fix/README.md): run ShellCheck and shfmt across the project
 - [All plugins](../../README.md)


### PR DESCRIPTION
## Summary

- Add H3 group headers with workflow blurbs to root README (Git, Issues and Worktrees, Code Review, Code Quality, Scaffolding, Agents, Security, Workflow), demoting plugin entries from H3 to H4
- Add installation sections to all 21 per-plugin READMEs pointing to the marketplace
- Create missing `handle-secrets/README.md` and add it to the root README ToC and content
- Replace all em dashes across README files with colons, periods, or rephrased sentences
- Update the `create-plugin` readme-updates template to match new conventions (no em dashes, includes installation section)

## Test plan

- [ ] Verify em dash grep returns zero matches: `rg '—' --glob '*/README.md'`
- [ ] Verify markdownlint passes: `npx markdownlint-cli2 README.md "plugins/*/README.md"`
- [ ] Verify all ToC anchor links in root README resolve to matching headings
- [ ] Verify handle-secrets appears in root README ToC and content section
- [ ] Spot-check installation sections render correctly on GitHub