### PR TITLE
Make add-scrut-cli-tests language-agnostic

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -28,14 +28,14 @@
         "name": "Christopher Boone"
       },
       "category": "code-quality",
-      "description": "Set up scrut snapshot-based CLI integration testing for a Go CLI project.",
+      "description": "Set up scrut snapshot-based CLI integration testing for a CLI project.",
       "homepage": "https://github.com/cboone/cboone-cc-plugins",
-      "keywords": ["cli", "go", "golang", "scrut", "testing"],
+      "keywords": ["cli", "scrut", "testing"],
       "license": "MIT",
       "name": "add-scrut-cli-tests",
       "repository": "https://github.com/cboone/cboone-cc-plugins",
       "source": "./plugins/add-scrut-cli-tests",
-      "version": "1.1.0"
+      "version": "1.2.0"
     },
     {
       "author": {
@@ -366,12 +366,12 @@
       "category": "code-quality",
       "description": "Applies scrut test style conventions when creating or editing scrut CLI test files.",
       "homepage": "https://github.com/cboone/cboone-cc-plugins",
-      "keywords": ["cli", "go", "golang", "scrut", "style", "testing"],
+      "keywords": ["cli", "scrut", "style", "testing"],
       "license": "MIT",
       "name": "write-scrut-tests",
       "repository": "https://github.com/cboone/cboone-cc-plugins",
       "source": "./plugins/write-scrut-tests",
-      "version": "1.0.1"
+      "version": "1.0.2"
     },
     {
       "author": {

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Style guides, linters, and security practices. These skills activate automatical
 
 #### Add Scrut CLI Tests
 
-Set up scrut snapshot-based CLI integration testing for a Go CLI project. Creates starter test files, adds Makefile targets, and configures CI to run scrut tests.
+Set up scrut snapshot-based CLI integration testing for a CLI project. Detects the project language, creates starter test files, adds Makefile targets, and configures CI to run scrut tests.
 
 > **Trigger:** `/add-scrut-cli-tests`
 > **Requires:** [`scrut`](https://github.com/facebookincubator/scrut) (Makefile checks for availability and provides install instructions)

--- a/docs/plans/todo/2026-03-01-make-add-scrut-cli-tests-language-agnostic.md
+++ b/docs/plans/todo/2026-03-01-make-add-scrut-cli-tests-language-agnostic.md
@@ -1,0 +1,132 @@
+# Make add-scrut-cli-tests Language-Agnostic
+
+## Context
+
+The `add-scrut-cli-tests` skill currently assumes it is setting up tests for a Go CLI project. It checks for `go.mod`, derives binary names from Go module paths, hardcodes `actions/setup-go` in the CI template, and references `scaffold-go-cli` in error messages. Scrut itself is completely language-agnostic: it tests CLI binaries by running commands and comparing output. The skill should reflect this and work for any CLI project, including Swift, Rust, Python, Ruby, and shell scripts.
+
+The companion `write-scrut-tests` skill has minor Go-specific wording in its reference guide and keywords that should also be cleaned up.
+
+## Plan
+
+### 1. SKILL.md: Replace Go-specific logic with language detection
+
+**File:** `plugins/add-scrut-cli-tests/skills/add-scrut-cli-tests/SKILL.md`
+
+**Frontmatter:** Change "Go CLI project" to "CLI project" in description. Remove "for a Go project" from trigger phrases.
+
+**Prerequisites:** Replace "A Go CLI project with a `Makefile` and a `build` target that produces a binary" with a general statement: "A CLI project that produces a binary or has an executable entry point." Keep the CI workflow line. Remove the Makefile as a hard prerequisite (it becomes recommended, and the skill can create one).
+
+**Step 1 (Verify the Project):** Replace the `go.mod` check with a language detection step using a manifest-to-language table:
+
+| Marker(s)                        | Language |
+| -------------------------------- | -------- |
+| `go.mod`                         | Go       |
+| `Package.swift`                  | Swift    |
+| `Cargo.toml`                     | Rust     |
+| `pyproject.toml`, `setup.py`     | Python   |
+| `Gemfile`, `*.gemspec`           | Ruby     |
+| Executable scripts (no manifest) | Shell    |
+
+If no manifest is found, ask the user. Keep the existing `tests/scrut/` check.
+
+**Step 2 (Gather Project Information):** Replace Go-specific binary name derivation with per-language detection:
+
+- **Go:** Makefile `-o` flag or last segment of module path in `go.mod`
+- **Swift:** executable target names in `Package.swift` or Makefile
+- **Rust:** `[[bin]]` entries or `[package].name` in `Cargo.toml`
+- **Python:** `[project.scripts]` in `pyproject.toml`
+- **Ruby:** `executables` in gemspec or files in `bin/`/`exe/`
+- **Shell:** the script filename itself
+
+Add a "build required" field: yes for compiled languages (Go, Swift, Rust), no for interpreted languages (Python, Ruby, Shell).
+
+**Step 5 (Add Makefile Targets):** Add handling for projects without a Makefile: offer to create a minimal one. For interpreted languages, remove the `build` dependency from `test-scrut` and `test-scrut-update` targets.
+
+**Step 6 (Update CI Workflow):** Replace "Detect the Go version from the existing workflow's `go-version` field" with "Copy the language setup step(s) from the existing CI workflow." This is better than maintaining per-language CI templates because:
+
+- Projects vary in how they configure language versions, caching, and matrix builds
+- The existing workflow already has the correct setup
+- It is what the current skill conceptually does for Go (copies the `go-version`)
+
+**Error Handling:** Replace `go.mod`-specific abort messages with generic "no recognized project manifest found, ask the user" logic. Replace `scaffold-go-cli` suggestion with language-appropriate suggestion (e.g., suggest `scaffold-go-cli` only if the project is Go).
+
+### 2. ci-job.md: Generic language setup placeholder
+
+**File:** `plugins/add-scrut-cli-tests/skills/add-scrut-cli-tests/references/ci-job.md`
+
+Replace the hardcoded `actions/setup-go@v6` step with a `LANGUAGE_SETUP_STEPS` placeholder. Update the placeholder table to replace `GO_VERSION` with `LANGUAGE_SETUP_STEPS` and add notes listing common setup actions by language:
+
+- **Go:** `actions/setup-go`
+- **Swift:** preinstalled on macOS runners; setup action or install step for Ubuntu
+- **Rust:** `dtolnay/rust-toolchain`
+- **Python:** `actions/setup-python`
+- **Ruby:** `ruby/setup-ruby`
+- **Shell:** no setup step needed
+
+Replace "Match the `go-version`..." note with "Match the `runs-on` value and language setup steps to the project's existing CI configuration."
+
+### 3. makefile-targets.md: Conditional build dependency note
+
+**File:** `plugins/add-scrut-cli-tests/skills/add-scrut-cli-tests/references/makefile-targets.md`
+
+Add a note: "For interpreted languages (shell scripts, Python, Ruby) where no build step is needed, remove the `: build` dependency from `test-scrut` and `test-scrut-update`. The binary path points directly to the executable script."
+
+### 4. Plugin metadata (add-scrut-cli-tests)
+
+**`plugins/add-scrut-cli-tests/.claude-plugin/plugin.json`:**
+
+- Description: "Go CLI project" -> "CLI project"
+- Keywords: remove "go" and "golang", keep `["cli", "scrut", "testing"]`
+- Version: `1.1.0` -> `1.2.0` (minor: new language support capability, not breaking)
+
+**`plugins/add-scrut-cli-tests/README.md`:**
+
+- Line 3: "Go CLI project" -> "CLI project"
+- Line 20: "existing Go CLI project" -> "existing CLI project"
+- See Also: remove "Write Go Code" link. Change "Scaffold Go CLI" parenthetical to "(includes build targets compatible with this skill)".
+
+### 5. Plugin metadata (write-scrut-tests)
+
+**`plugins/write-scrut-tests/.claude-plugin/plugin.json`:**
+
+- Keywords: remove "go" and "golang", keep `["cli", "scrut", "style", "testing"]`
+- Version: `1.0.1` -> `1.0.2` (patch: keyword/wording cleanup)
+
+**`plugins/write-scrut-tests/skills/write-scrut-tests/references/SCRUT.md`:**
+
+- Line 3: "production Go CLI repositories" -> "production CLI repositories"
+- Line 337: "Error messages from Cobra-based CLIs" -> "Error messages from CLI frameworks (e.g., Cobra for Go, Swift Argument Parser, clap for Rust)"
+
+**`plugins/write-scrut-tests/README.md`:**
+
+- Line 38: "Go CLI project" -> "CLI project"
+- Line 39: remove the "Write Go Code" link
+
+### 6. Registry and root README
+
+**`.claude-plugin/marketplace.json`:**
+
+- `add-scrut-cli-tests` entry: description "CLI project", keywords remove "go"/"golang", version `1.2.0`
+- `write-scrut-tests` entry: keywords remove "go"/"golang", version `1.0.2`
+- `metadata.version`: no change (no plugins added or removed)
+
+**`README.md` (root):**
+
+- Line 149: "Go CLI project" -> "CLI project"
+
+## Files unchanged
+
+These files are already language-agnostic and need no modifications:
+
+- `plugins/add-scrut-cli-tests/skills/add-scrut-cli-tests/references/help-test.md`
+- `plugins/add-scrut-cli-tests/skills/add-scrut-cli-tests/references/version-test.md`
+- `plugins/add-scrut-cli-tests/skills/add-scrut-cli-tests/references/test-format.md`
+- `plugins/write-scrut-tests/skills/write-scrut-tests/SKILL.md`
+
+## Verification
+
+1. Read through every modified file and confirm no Go-specific language remains (except where contextually appropriate, e.g., the per-language detection table listing Go as one option)
+1. Invoke `/check-versions` to verify version consistency across `plugin.json` and `marketplace.json`
+1. Run `/lint-and-fix` to check formatting
+1. Invoke `/add-scrut-cli-tests` in a Go project to confirm Go detection still works as before
+1. Invoke `/add-scrut-cli-tests` in a non-Go project (Swift or shell) to confirm the new language detection works

--- a/plugins/add-scrut-cli-tests/.claude-plugin/plugin.json
+++ b/plugins/add-scrut-cli-tests/.claude-plugin/plugin.json
@@ -2,12 +2,12 @@
   "author": {
     "name": "Christopher Boone"
   },
-  "description": "Set up scrut snapshot-based CLI integration testing for a Go CLI project.",
+  "description": "Set up scrut snapshot-based CLI integration testing for a CLI project.",
   "homepage": "https://github.com/cboone/cboone-cc-plugins",
-  "keywords": ["cli", "go", "golang", "scrut", "testing"],
+  "keywords": ["cli", "scrut", "testing"],
   "license": "MIT",
   "name": "add-scrut-cli-tests",
   "repository": "https://github.com/cboone/cboone-cc-plugins",
   "skills": "./skills",
-  "version": "1.1.0"
+  "version": "1.2.0"
 }

--- a/plugins/add-scrut-cli-tests/README.md
+++ b/plugins/add-scrut-cli-tests/README.md
@@ -1,6 +1,6 @@
 # Add Scrut CLI Tests
 
-Set up scrut snapshot-based CLI integration testing for a Go CLI project.
+Set up scrut snapshot-based CLI integration testing for a CLI project.
 
 **Type:** Skill
 **Trigger:** `/add-scrut-cli-tests`
@@ -17,7 +17,7 @@ Then select **Add Scrut CLI Tests** from the available plugins.
 
 ## What It Does
 
-Adds [scrut](https://github.com/facebookincubator/scrut) snapshot-based CLI integration testing to an existing Go CLI project. Creates a `tests/scrut/` directory with starter test files for help and version output, adds Makefile targets for running and updating tests, and configures the CI workflow to install scrut and run CLI tests.
+Adds [scrut](https://github.com/facebookincubator/scrut) snapshot-based CLI integration testing to an existing CLI project. Detects the project language (Go, Swift, Rust, Python, Ruby, shell), creates a `tests/scrut/` directory with starter test files for help and version output, adds Makefile targets for running and updating tests, and configures the CI workflow to install scrut and run CLI tests.
 
 ## Usage
 
@@ -25,7 +25,7 @@ Adds [scrut](https://github.com/facebookincubator/scrut) snapshot-based CLI inte
 /add-scrut-cli-tests
 ```
 
-The skill detects the binary name and build configuration from the existing Makefile and generates test files accordingly.
+The skill detects the project type and binary name from existing project files and generates test files accordingly.
 
 ## Examples
 
@@ -36,8 +36,7 @@ The skill detects the binary name and build configuration from the existing Make
 
 ## See Also
 
-- [Scaffold Go CLI](../scaffold-go-cli/README.md): scaffold a new Go CLI project (includes build targets this skill depends on)
-- [Write Go Code](../write-go-code/README.md): Go style guide for the CLI source code
 - [Write Scrut Tests](../write-scrut-tests/README.md): style conventions for writing scrut test files
 - [Lint and Fix](../lint-and-fix/README.md): run linters and formatters
+- [Scaffold Go CLI](../scaffold-go-cli/README.md): scaffold a new Go CLI project (includes build targets compatible with this skill)
 - [All plugins](../../README.md)

--- a/plugins/add-scrut-cli-tests/skills/add-scrut-cli-tests/SKILL.md
+++ b/plugins/add-scrut-cli-tests/skills/add-scrut-cli-tests/SKILL.md
@@ -1,39 +1,59 @@
 ---
 name: add-scrut-cli-tests
 description: >-
-  Set up scrut snapshot-based CLI integration testing for a Go CLI project.
+  Set up scrut snapshot-based CLI integration testing for a CLI project.
   Use when the user says "add scrut tests", "add CLI tests", "set up scrut",
   "add e2e tests", "add integration tests", "scrut cli tests",
   "add snapshot tests", or asks to set up CLI integration testing with scrut
-  for a Go project.
+  for any CLI project.
 ---
 
 # Add Scrut CLI Tests
 
-Set up [scrut](https://github.com/facebookincubator/scrut) snapshot-based CLI integration testing for a Go CLI project with Makefile targets and CI workflow integration.
+Set up [scrut](https://github.com/facebookincubator/scrut) snapshot-based CLI integration testing for a CLI project with Makefile targets and CI workflow integration.
 
 ## Prerequisites
 
-- A Go CLI project with a `Makefile` and a `build` target that produces a binary
-- A `.github/workflows/ci.yml` workflow (or equivalent CI workflow file)
+- A CLI project that produces a binary or has an executable entry point
+- A `.github/workflows/ci.yml` workflow (or equivalent CI workflow file) is recommended for CI integration
 
 ## Workflow
 
-### 1. Verify the Project
+### 1. Detect the Project Type
 
-Confirm the current directory is a Go CLI project with a build pipeline:
+Identify the project language by checking for manifest files:
 
-- Check that `go.mod` exists (required; abort if missing)
-- Check that a `Makefile` exists with a `build` target (required; abort if missing)
-- Check for an existing `tests/scrut/` directory; if present, warn and ask whether to add to it or abort
+| Marker(s)                        | Language |
+| -------------------------------- | -------- |
+| `go.mod`                         | Go       |
+| `Package.swift`                  | Swift    |
+| `Cargo.toml`                     | Rust     |
+| `pyproject.toml`, `setup.py`     | Python   |
+| `Gemfile`, `*.gemspec`           | Ruby     |
+| Executable scripts (no manifest) | Shell    |
+
+If no manifest is found and executable shell scripts exist in the root, `bin/`, or `scripts/`, treat the project as a shell script CLI.
+
+If the project type cannot be determined, ask the user what language the project uses and where the binary or executable is located.
+
+Check for an existing `tests/scrut/` directory; if present, warn and ask whether to add to it or abort.
 
 ### 2. Gather Project Information
 
 Collect the following, inferring from existing files where possible:
 
-- **Binary name**: check the Makefile `build` target for the output binary name (look for `-o bin/NAME` or `-o NAME`), or derive from the last segment of the module path in `go.mod`
-- **Binary path**: determine the full path used in the Makefile build target (typically `bin/NAME` or `$(CURDIR)/bin/NAME`)
+- **Binary name**: determine by project type:
+  - **Go**: check the Makefile `build` target for the output binary name (look for `-o bin/NAME` or `-o NAME`), or derive from the last segment of the module path in `go.mod`
+  - **Swift**: check `Package.swift` for executable target names, or check the Makefile `build` target
+  - **Rust**: check `Cargo.toml` for `[[bin]]` entries or the `name` field under `[package]`
+  - **Python**: check `pyproject.toml` for `[project.scripts]` entries
+  - **Ruby**: check the gemspec for `executables` or look in `bin/` or `exe/`
+  - **Shell**: use the script filename as the binary name
+- **Binary path**: determine the full path used to run the binary:
+  - **Compiled languages** (Go, Swift, Rust): typically `bin/NAME` or a build output directory (e.g., `$(CURDIR)/bin/NAME`)
+  - **Interpreted languages** (Python, Ruby, Shell): the script path itself (e.g., `bin/NAME`, `./NAME`)
 - **Environment variable name**: derive from the binary name, uppercased with hyphens replaced by underscores, suffixed with `_BIN` (e.g., `bopca` becomes `BOPCA_BIN`, `my-tool` becomes `MY_TOOL_BIN`)
+- **Build required**: whether a build step is needed before running tests (yes for compiled languages, no for interpreted languages)
 
 If the user already provided some or all of these in their initial request, do not re-ask.
 
@@ -63,13 +83,19 @@ If `scrut` is not installed locally, write the test files with placeholder outpu
 
 ### 5. Add Makefile Targets
 
-Check the existing Makefile for any of these targets: `test-scrut`, `test-scrut-update`, `test-all`. If any exist, warn and ask before overwriting.
+If no `Makefile` exists:
+
+- For **compiled languages** (Go, Swift, Rust): ask the user to create one or offer to generate a minimal Makefile with `build` and `test-scrut` targets appropriate to the language
+- For **interpreted languages** (Python, Ruby, Shell): create a minimal Makefile with just the scrut targets (no build dependency needed)
+
+If a `Makefile` exists, check for any of these targets: `test-scrut`, `test-scrut-update`, `test-all`. If any exist, warn and ask before overwriting.
 
 Add the Makefile targets from `./references/makefile-targets.md`:
 
 - Replace `TOOL_BIN` with the environment variable name
-- Replace `BINARY_PATH` with the path to the built binary (e.g., `$(CURDIR)/bin/NAME`)
+- Replace `BINARY_PATH` with the path to the built binary or executable script
 - Replace `TESTS_DIR` with `tests/scrut/`
+- **If the project does not require a build step** (shell scripts, interpreted languages), remove the `build` dependency from `test-scrut` and `test-scrut-update` targets
 
 Append `test-scrut test-scrut-update test-all` to the `.PHONY` declaration (or create one if it does not exist).
 
@@ -85,7 +111,7 @@ ls .github/workflows/ci.yml .github/workflows/ci.yaml
 
 If found, add a `test-scrut` job using the template from `./references/ci-job.md`:
 
-- Detect the Go version from the existing workflow's `go-version` field and use the same value
+- **Copy the language setup step(s)** from the existing CI workflow (e.g., `actions/setup-go`, Swift toolchain setup, `actions/setup-python`, Rust toolchain setup). If the workflow has multiple language setup steps, include only the ones needed to build the project binary. For shell script projects, no language setup step is needed.
 - Detect the runner OS from the existing workflow (e.g., `ubuntu-latest`, `macos-latest`) and use the same value
 - Determine the latest scrut release tag for `SCRUT_VERSION` (run `gh release list --repo facebookincubator/scrut --limit 1 --json tagName --jq '.[0].tagName'`)
 - Place the new job after existing test jobs
@@ -95,7 +121,7 @@ If no CI workflow exists, skip this step and note that the user should add CI wo
 
 ### 7. Build and Run Tests
 
-Build the binary and run the scrut tests to verify the setup:
+Build the binary (if applicable) and run the scrut tests to verify the setup:
 
 ```bash
 make test-scrut
@@ -157,10 +183,11 @@ Print a summary of what was created and modified:
 
 ## Error Handling
 
-- If `go.mod` does not exist, abort with a message that this skill requires an existing Go project
-- If no `Makefile` exists, abort and suggest creating one first (or use the `scaffold-go-cli` skill)
+- If no recognized project manifest is found and no executable scripts exist, ask the user what language the project uses and where the binary or executable is located
+- If no `Makefile` exists and the project is a compiled language, warn that a build step is needed and offer to create a minimal Makefile, or suggest the relevant scaffolding skill (e.g., `scaffold-go-cli` for Go projects)
+- If no `Makefile` exists and the project is an interpreted language, offer to create a minimal Makefile with just the scrut test targets
 - If `tests/scrut/` already exists, ask before adding or overwriting files
 - If `scrut` is not installed locally, write test files with placeholder output and explain how to install scrut and update snapshots
-- If the Makefile does not have a `build` target, ask the user which target builds the binary
+- If the Makefile does not have a `build` target and the project requires one, ask the user which target builds the binary
 - If no CI workflow exists, skip the CI step and inform the user
 - If `make test-scrut` fails, check the output and attempt to fix; if the issue is stale snapshots, run `make test-scrut-update`

--- a/plugins/add-scrut-cli-tests/skills/add-scrut-cli-tests/references/ci-job.md
+++ b/plugins/add-scrut-cli-tests/skills/add-scrut-cli-tests/references/ci-job.md
@@ -12,11 +12,7 @@ test-scrut:
     - name: Checkout code
       uses: actions/checkout@v6
 
-    - name: Set up Go
-      uses: actions/setup-go@v6
-      with:
-        cache: true
-        go-version: "GO_VERSION"
+    LANGUAGE_SETUP_STEPS
 
     - name: Install scrut
       env:
@@ -34,19 +30,27 @@ test-scrut:
 
 ## Placeholders
 
-| Placeholder      | Description                                   | Example                         |
-| ---------------- | --------------------------------------------- | ------------------------------- |
-| `RUNNER_OS`      | GitHub Actions runner OS                      | `macos-latest`, `ubuntu-latest` |
-| `GO_VERSION`     | Go version matching the rest of the workflow  | `1.25`                          |
-| `SCRUT_VERSION`  | Pinned scrut release tag                      | `v0.4.3`                        |
-| `SCRUT_PLATFORM` | Platform identifier from scrut release assets | `macos-aarch64`, `linux-x86_64` |
+| Placeholder            | Description                                                         | Example                         |
+| ---------------------- | ------------------------------------------------------------------- | ------------------------------- |
+| `RUNNER_OS`            | GitHub Actions runner OS                                            | `macos-latest`, `ubuntu-latest` |
+| `LANGUAGE_SETUP_STEPS` | Language setup steps copied from the project's existing CI workflow | (see Notes)                     |
+| `SCRUT_VERSION`        | Pinned scrut release tag                                            | `v0.4.3`                        |
+| `SCRUT_PLATFORM`       | Platform identifier from scrut release assets                       | `macos-aarch64`, `linux-x86_64` |
 
 ## Notes
 
+- `LANGUAGE_SETUP_STEPS` should be copied from the project's existing CI workflow. Common examples:
+  - **Go**: `actions/setup-go@v6` with `go-version` and caching settings matching the existing workflow
+  - **Swift**: Swift is preinstalled on macOS runners; for Ubuntu runners, use a Swift setup action or install step
+  - **Rust**: `dtolnay/rust-toolchain` with the appropriate toolchain version
+  - **Python**: `actions/setup-python@v5` with `python-version` matching the existing workflow
+  - **Ruby**: `ruby/setup-ruby@v1` with `ruby-version` matching the existing workflow
+  - **Shell**: no language setup step needed; remove the placeholder entirely
+- Copy the language setup verbatim from the existing CI workflow to ensure version consistency and caching configuration are preserved.
 - Scrut is installed via `gh release download` from `facebookincubator/scrut`. The upstream install script is not used because its `get_latest_version()` function hardcodes `ukautz/scrut`, and it installs to a directory not in `PATH` on GitHub Actions runners.
 - The `SCRUT_VERSION` tag pins the download to a specific release for reproducible builds. Check [scrut releases](https://github.com/facebookincubator/scrut/releases) for available versions.
 - Scrut does not currently publish checksums or signatures with its releases, so integrity verification is not yet possible. If checksums become available in the future, add a verification step after the download.
 - The `SCRUT_PLATFORM` value must match the runner OS: use `macos-aarch64` for `macos-latest` and `linux-x86_64` for `ubuntu-latest`.
-- The job relies on `make test-scrut`, which handles building the binary and running tests.
-- Match the `go-version` and `runs-on` values to the project's existing CI configuration.
+- The job relies on `make test-scrut`, which handles building the binary (if applicable) and running tests.
+- Match the `runs-on` value and language setup steps to the project's existing CI configuration.
 - Place this job alongside other test jobs in the workflow. If the workflow uses job dependencies, this job typically depends on the lint job (if any).

--- a/plugins/add-scrut-cli-tests/skills/add-scrut-cli-tests/references/makefile-targets.md
+++ b/plugins/add-scrut-cli-tests/skills/add-scrut-cli-tests/references/makefile-targets.md
@@ -32,7 +32,7 @@ test-all: test test-scrut
 
 ## Notes
 
-- `test-scrut` depends on `build` so the binary is compiled before tests run.
+- `test-scrut` depends on `build` so the binary is compiled before tests run. For interpreted languages (shell scripts, Python, Ruby) where no build step is needed, remove the `: build` dependency from `test-scrut` and `test-scrut-update`. The binary path points directly to the executable script.
 - The presence check (`command -v scrut`) gives a clear error message if scrut is not installed.
 - `test-scrut-update` uses `--replace` to overwrite the original files and `--assume-yes` to skip confirmation prompts.
 - `test-all` chains both unit tests (`test`) and scrut tests (`test-scrut`).

--- a/plugins/write-scrut-tests/.claude-plugin/plugin.json
+++ b/plugins/write-scrut-tests/.claude-plugin/plugin.json
@@ -4,10 +4,10 @@
   },
   "description": "Applies scrut test style conventions when creating or editing scrut CLI test files.",
   "homepage": "https://github.com/cboone/cboone-cc-plugins",
-  "keywords": ["cli", "go", "golang", "scrut", "style", "testing"],
+  "keywords": ["cli", "scrut", "style", "testing"],
   "license": "MIT",
   "name": "write-scrut-tests",
   "repository": "https://github.com/cboone/cboone-cc-plugins",
   "skills": "./skills",
-  "version": "1.0.1"
+  "version": "1.0.2"
 }

--- a/plugins/write-scrut-tests/README.md
+++ b/plugins/write-scrut-tests/README.md
@@ -35,6 +35,5 @@ The skill also activates automatically when creating or editing `.md` files in `
 
 ## See Also
 
-- [Add Scrut CLI Tests](../add-scrut-cli-tests/README.md): set up scrut testing infrastructure in a Go CLI project
-- [Write Go Code](../write-go-code/README.md): Go style guide for the CLI source code
+- [Add Scrut CLI Tests](../add-scrut-cli-tests/README.md): set up scrut testing infrastructure in a CLI project
 - [All plugins](../../README.md)

--- a/plugins/write-scrut-tests/skills/write-scrut-tests/references/SCRUT.md
+++ b/plugins/write-scrut-tests/skills/write-scrut-tests/references/SCRUT.md
@@ -1,6 +1,6 @@
 # Scrut Test Style Guide
 
-Conventions for writing and maintaining [scrut](https://github.com/facebookincubator/scrut) CLI test files. These conventions are derived from established patterns in production Go CLI repositories and scrut's official documentation.
+Conventions for writing and maintaining [scrut](https://github.com/facebookincubator/scrut) CLI test files. These conventions are derived from established patterns in production CLI repositories and scrut's official documentation.
 
 ## File Organization
 
@@ -334,7 +334,7 @@ The `2>&1` redirect approach is simpler for one-off cases. Use `{output_stream: 
 
 ### Test Only the Relevant Error Output
 
-Error messages from Cobra-based CLIs often include usage text after the error line. Pipe through `head -1` or `head -n N` to test only the meaningful part:
+Error messages from CLI frameworks (e.g., Cobra for Go, Swift Argument Parser, clap for Rust) often include usage text after the error line. Pipe through `head -1` or `head -n N` to test only the meaningful part:
 
 ```scrut
 $ "${TOOL_BIN}" nonexistent 2>&1 | head -1


### PR DESCRIPTION
## Summary

- Replace Go-specific project detection with a language detection table supporting Go, Swift, Rust, Python, Ruby, and shell scripts
- Generalize CI job template to use a `LANGUAGE_SETUP_STEPS` placeholder instead of hardcoded `actions/setup-go`
- Handle compiled vs. interpreted language differences in Makefile targets (optional `build` dependency)
- Clean up Go-specific wording and keywords from the companion `write-scrut-tests` skill

## Test plan

- [ ] Invoke `/add-scrut-cli-tests` in a Go project to confirm existing behavior is preserved
- [ ] Invoke `/add-scrut-cli-tests` in a Swift or shell script project to confirm language detection works
- [ ] Run `/check-versions` to verify version consistency
- [ ] Run linters to verify formatting