### PR TITLE
Fix lint-and-fix skipping commit after auto-fix

### DIFF
--- a/plugins/lint-and-fix/skills/lint-and-fix/SKILL.md
+++ b/plugins/lint-and-fix/skills/lint-and-fix/SKILL.md
@@ -159,9 +159,9 @@ Re-run all detected tools one final time in check mode to confirm a clean state:
 
 Otherwise, check for file changes and commit:
 
-1. Run `git status` to check whether any files were modified by the fix commands.
-1. **If no files were modified**: Report "No changes needed, all files were already clean." and stop.
-1. **If files were modified**: Stage all files modified by the lint and format fixes.
+1. Run `git status --porcelain` and check whether its output is empty.
+1. **If no files were modified** (i.e., `git status --porcelain` produced no output): Report "No changes needed, all files were already clean." and stop.
+1. **If files were modified** (i.e., `git status --porcelain` produced any output): Stage all files modified by the lint and format fixes.
 1. Generate a conventional commit message:
    - Use `style:` for pure formatting and linting fixes.
    - Use `fix:` if linting changes corrected actual bugs (e.g., unused variables removed, error handling added).


### PR DESCRIPTION
## Summary

- Fixed the lint-and-fix skill incorrectly concluding there was nothing to commit after auto-fix tools resolved all issues
- Added explicit `git status` check in step 7 to detect file changes before deciding whether to commit
- Clarified the step 4 skip-to-step-6 transition to note that auto-fix commands may have modified files on disk

## Test plan

- [ ] Run `lint-and-fix` on a project where prettier or eslint auto-fixes files, verify it commits the changes
- [ ] Run `lint-and-fix` on an already-clean project, verify it reports "No changes needed"
- [ ] Run `lint-and-fix --no-commit` and verify it still skips committing
- [ ] Run `lint-and-fix --check` and verify it skips committing