### PR TITLE
Use default markdownlint formatter for line-specific output

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -12,8 +12,7 @@
 
   // "fix": true,
 
-  "outputFormatters": [
-    // https://github.com/DavidAnson/markdownlint-cli2/blob/main/formatter-summarize/README.md
-    ["markdownlint-cli2-formatter-summarize", { "byFileByRule": true }],
-  ],
+  // The default formatter outputs `file:line rule description`, which is
+  // easier for automated tools (like Claude Code) to parse and fix.
+  // https://github.com/DavidAnson/markdownlint-cli2/blob/main/formatter-default/README.md
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   "devDependencies": {
     "@github/markdownlint-github": "^0.8.0",
     "markdownlint-cli2": "^0.20.0",
-    "markdownlint-cli2-formatter-summarize": "^0.0.8",
     "markdownlint-rule-force-align-table-columns": "^0.1.1",
     "markdownlint-rule-relative-links": "^4.2.0",
     "prettier": "^3.8.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -365,15 +365,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"markdownlint-cli2-formatter-summarize@npm:^0.0.8":
-  version: 0.0.8
-  resolution: "markdownlint-cli2-formatter-summarize@npm:0.0.8"
-  peerDependencies:
-    markdownlint-cli2: ">=0.0.4"
-  checksum: 10c0/084abe448de3095952c4b3f73fde347fb459ace8418c44f844c9818586c3037ff475ff2db715032c122bc689e09c19fcfe3fb468cbda776df38201163c760b4a
-  languageName: node
-  linkType: hard
-
 "markdownlint-cli2@npm:^0.20.0":
   version: 0.20.0
   resolution: "markdownlint-cli2@npm:0.20.0"
@@ -817,7 +808,6 @@ __metadata:
   dependencies:
     "@github/markdownlint-github": "npm:^0.8.0"
     markdownlint-cli2: "npm:^0.20.0"
-    markdownlint-cli2-formatter-summarize: "npm:^0.0.8"
     markdownlint-rule-force-align-table-columns: "npm:^0.1.1"
     markdownlint-rule-relative-links: "npm:^4.2.0"
     prettier: "npm:^3.8.1"


### PR DESCRIPTION
## Summary

- Replace `markdownlint-cli2-formatter-summarize` with the built-in default formatter
- The summarize formatter groups errors by file and rule in a summary table, which makes it hard for automated tools (like Claude Code) to locate and fix specific issues
- The default formatter outputs `file:line rule description`, which is straightforward to parse and act on
- Remove the `markdownlint-cli2-formatter-summarize` dev dependency

## Test plan

- [ ] Run `yarn lint:md` on a file with markdown issues and verify the output shows `file:line rule description` format