### PR TITLE
Fix permission prompts for reply commands in resolve-copilot-pr-feedback

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -245,7 +245,7 @@
       "name": "resolve-copilot-pr-feedback",
       "repository": "https://github.com/cboone/cboone-cc-plugins",
       "source": "./plugins/resolve-copilot-pr-feedback",
-      "version": "1.1.6"
+      "version": "1.1.7"
     },
     {
       "author": {

--- a/plugins/resolve-copilot-pr-feedback/.claude-plugin/plugin.json
+++ b/plugins/resolve-copilot-pr-feedback/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "name": "resolve-copilot-pr-feedback",
   "repository": "https://github.com/cboone/cboone-cc-plugins",
   "skills": "./skills",
-  "version": "1.1.6"
+  "version": "1.1.7"
 }

--- a/plugins/resolve-copilot-pr-feedback/skills/resolve-copilot-pr-feedback/SKILL.md
+++ b/plugins/resolve-copilot-pr-feedback/skills/resolve-copilot-pr-feedback/SKILL.md
@@ -185,18 +185,18 @@ bash resolve-copilot-threads resolve THREAD_ID
 
 **CRITICAL: Reply directly to the Copilot review thread, NOT to the PR.**
 
-Use the script to reply to the specific Copilot thread:
+**CRITICAL: Always use `--body-file` to pass reply bodies.** Write the response to a temp file first using the Write tool, then reference it with `--body-file`. This keeps the Bash command short and avoids permission prompts from long inline strings.
 
 ```bash
-# Reply from a file (recommended for multiline bodies):
-bash resolve-copilot-threads reply THREAD_ID --body-file response.md
-
-# Reply from stdin:
-echo "Your explanation here" | bash resolve-copilot-threads reply THREAD_ID
+# Step 1: Write the response body using the Write tool (NOT shown here as bash)
+# Step 2: Pass it to the script:
+bash resolve-copilot-threads reply THREAD_ID --body-file /tmp/copilot-reply.md
 
 # Reply and resolve in one step:
-bash resolve-copilot-threads reply-and-resolve THREAD_ID --body-file response.md
+bash resolve-copilot-threads reply-and-resolve THREAD_ID --body-file /tmp/copilot-reply.md
 ```
+
+**NEVER pass the reply body inline** (e.g., via `echo "..." |` or heredocs). Always use the Write tool + `--body-file` pattern.
 
 **FORBIDDEN COMMANDS - NEVER USE:**
 
@@ -248,6 +248,8 @@ bash resolve-copilot-threads reply-and-resolve THREAD_ID --body-file response.md
 1. Report summary of actions taken
 
 ## Reply Templates
+
+Write these to `/tmp/copilot-reply.md` using the Write tool, then pass via `--body-file`.
 
 **For outdated comments:**
 


### PR DESCRIPTION
## Summary

- Update SKILL.md to require the Write tool + `--body-file` pattern for all reply bodies, instead of inline `echo "..." |` piping
- Remove stdin-based reply examples that produce long Bash commands triggering permission prompts
- Add explicit prohibition against inline body passing
- Bump plugin version to 1.1.7

## Test plan

- [ ] Use the resolve-copilot-pr-feedback skill on a PR with Copilot comments and verify replies use `--body-file` without triggering special permission prompts