### PR TITLE
Fix bootstrap-project to correctly invoke commands vs skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -77,7 +77,7 @@
       "name": "bootstrap-project",
       "repository": "https://github.com/cboone/cboone-cc-plugins",
       "source": "./plugins/bootstrap-project",
-      "version": "1.0.0"
+      "version": "1.0.1"
     },
     {
       "author": {

--- a/plugins/bootstrap-project/.claude-plugin/plugin.json
+++ b/plugins/bootstrap-project/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "name": "bootstrap-project",
   "repository": "https://github.com/cboone/cboone-cc-plugins",
   "skills": "./skills",
-  "version": "1.0.0"
+  "version": "1.0.1"
 }

--- a/plugins/bootstrap-project/skills/bootstrap-project/SKILL.md
+++ b/plugins/bootstrap-project/skills/bootstrap-project/SKILL.md
@@ -114,10 +114,26 @@ Wait for explicit approval before proceeding.
 
 ### 5. Execute
 
-Invoke each confirmed tool in order using the Skill tool. Each tool is registered as a slash command (e.g., `/scaffold-new-repo`, `/setup-ci`).
+The tools referenced in this plan are a mix of **skills** and **commands**. They require different invocation methods:
 
-Between each invocation:
+- **Skills** (have a `skills/` directory): Invoke using the Skill tool.
+  - `setup-linters`
+- **Commands** (have a `commands/` directory): Read the command's Markdown file from its plugin directory using the Read tool, then follow the workflow instructions in that file directly.
+  - `scaffold-new-repo` (read `plugins/scaffold-new-repo/commands/scaffold-new-repo.md`)
+  - `scaffold-go-cli` (read `plugins/scaffold-go-cli/commands/scaffold-go-cli.md`)
+  - `scaffold-go-library` (read `plugins/scaffold-go-library/commands/scaffold-go-library.md`)
+  - `setup-ci` (read `plugins/setup-ci/commands/setup-ci.md`)
+  - `setup-gitleaks` (read `plugins/setup-gitleaks/commands/setup-gitleaks.md`)
+  - `add-goreleaser-homebrew` (read `plugins/add-goreleaser-homebrew/commands/add-goreleaser-homebrew.md`)
+  - `setup-installers` (read `plugins/setup-installers/commands/setup-installers.md`)
+  - `add-scrut-cli-tests` (read `plugins/add-scrut-cli-tests/commands/add-scrut-cli-tests.md`)
 
+The command file paths above are relative to the `cboone-cc-plugins` plugin repository root. To resolve the absolute path, use Glob to search for the command file (e.g., `**/commands/scaffold-new-repo.md`).
+
+For each confirmed tool, in execution order:
+
+1. If it is a **skill**, invoke it via the Skill tool.
+1. If it is a **command**, read its `.md` file and follow the workflow instructions directly.
 1. Verify the tool completed successfully.
 1. If a tool fails, report the error to the user and ask whether to continue with the remaining tools or stop.
 


### PR DESCRIPTION
## Summary

- Fix bootstrap-project execute step to distinguish between **skills** (invoked via Skill tool) and **commands** (read via Read tool and followed directly)
- Only `setup-linters` is a skill; the other 8 tools (`scaffold-new-repo`, `scaffold-go-cli`, `scaffold-go-library`, `setup-ci`, `setup-gitleaks`, `add-goreleaser-homebrew`, `setup-installers`, `add-scrut-cli-tests`) are commands
- Bump bootstrap-project version from 1.0.0 to 1.0.1

## Test plan

- [ ] Run `/bootstrap-project` on a test repository and verify it reads command `.md` files directly instead of failing with Skill tool invocation errors
- [ ] Verify `setup-linters` is still invoked via the Skill tool
