### PR TITLE
chore: migrate to gh-actions composite actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,11 +30,12 @@ jobs:
       - name: ShellCheck
         run: shellcheck -S warning bin/* plugins/*/scripts/*
       - name: Set up shfmt
-        uses: mfinelli/setup-shfmt@v4
+        uses: cboone/gh-actions/actions/setup-shfmt@main
       - name: shfmt
         run: shfmt -d bin/* plugins/*/scripts/*
+      - uses: cboone/gh-actions/actions/setup-actionlint@main
       - name: Actionlint
-        uses: raven-actions/actionlint@v2
+        run: actionlint
       - name: Validate JSON syntax
         run: bin/validate-json
       - name: Validate plugin structure


### PR DESCRIPTION
## Summary

- Replace `mfinelli/setup-shfmt@v4` with `setup-shfmt` composite action from `cboone/gh-actions`
- Replace `raven-actions/actionlint@v2` with `setup-actionlint` composite action from `cboone/gh-actions`
- Keep yarn-based linting, shellcheck, and custom validation scripts unchanged

## Test plan

- [ ] Verify shfmt runs successfully
- [ ] Verify actionlint runs successfully
- [ ] Verify all other linting steps still pass