### PR TITLE
chore: pin gh-actions to v1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,10 @@ jobs:
       - name: ShellCheck
         run: shellcheck -S warning bin/* plugins/*/scripts/*
       - name: Set up shfmt
-        uses: cboone/gh-actions/actions/setup-shfmt@main
+        uses: cboone/gh-actions/actions/setup-shfmt@v1
       - name: shfmt
         run: shfmt -d bin/* plugins/*/scripts/*
-      - uses: cboone/gh-actions/actions/setup-actionlint@main
+      - uses: cboone/gh-actions/actions/setup-actionlint@v1
       - name: Actionlint
         run: actionlint
       - name: Validate JSON syntax


### PR DESCRIPTION
## Summary

- Pin `cboone/gh-actions` references from `@main` to `@v1`

The gh-actions repo has been tagged with v1.0.0. Using the floating `@v1` tag ensures we automatically pick up non-breaking updates while maintaining stability.