### PR TITLE
Skip GitHub Release creation when a release workflow exists

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -301,7 +301,7 @@
       "name": "release",
       "repository": "https://github.com/cboone/cboone-cc-plugins",
       "source": "./plugins/release",
-      "version": "1.2.0"
+      "version": "1.3.0"
     },
     {
       "author": {

--- a/docs/plans/done/2026-03-27-skip-gh-release-when-workflow-exists.md
+++ b/docs/plans/done/2026-03-27-skip-gh-release-when-workflow-exists.md
@@ -1,0 +1,59 @@
+# Skip GitHub Release Creation When a Release Workflow Exists
+
+## Context
+
+The release skill (step 11) always tries to create a GitHub Release manually via `gh release create` after pushing a tag. However, many projects already have a GitHub Actions release workflow (e.g., `.github/workflows/release.yml`) that automatically creates a GitHub Release when a version tag is pushed. In those cases, the manual `gh release create` duplicates or conflicts with the automated workflow.
+
+All scaffolded release workflows in this repository (Go CLI, Go library, Rust CLI, GoReleaser+Homebrew) share the same trigger pattern: `on: push: tags: - "v*"`. They create GitHub Releases automatically via GoReleaser or `softprops/action-gh-release`.
+
+The fix: detect tag-triggered release workflows during pre-flight checks and conditionally skip the manual `gh release create` step.
+
+## Detection Approach
+
+Add a Grep command to the step 1 pre-flight parallel block:
+
+```bash
+grep -rl '"v\*"' .github/workflows/*.yml .github/workflows/*.yaml 2>/dev/null
+```
+
+If this returns any files, a release workflow exists. The `"v*"` string inside `.github/workflows/` is a highly specific signal: tag-triggered workflows matching `v*` are almost always release workflows. This avoids requiring `yq` and keeps detection simple.
+
+## Files to Modify
+
+### 1. `plugins/release/skills/release/SKILL.md`
+
+Four areas need changes:
+
+**Step 1 (Pre-Flight Checks):** Add the grep command to the parallel block. Note the result as a flag (e.g., "release workflow detected" or "no release workflow detected").
+
+**Step 11 prompt:** Change the prompt wording based on detection:
+- No workflow: "Push and create a GitHub Release for vVERSION?" (current behavior)
+- Workflow detected: "Push commit and tag for vVERSION? (release workflow detected; it will create the GitHub Release automatically)"
+
+**Step 11 "If the user declines":** Conditional manual commands:
+- No workflow: show all three commands (push HEAD, push tag, `gh release create`) as today
+- Workflow detected: show only the two push commands, note the workflow will handle the release
+
+**Step 11 "If the user accepts" (11c-11e):** Add a branch after 11b:
+- If a release workflow was detected: report that the workflow will create the GitHub Release when it runs, skip 11c/11d entirely, and go straight to 11e with adjusted output (no GitHub Release URL, note workflow will handle it)
+- If no workflow detected: proceed with existing 11c/11d/11e unchanged
+
+**Error Handling section:** Add a new entry: "Release workflow detected: skip manual GitHub Release creation; the workflow will create it when the tag is pushed."
+
+### 2. `plugins/release/README.md`
+
+Add `Bash(grep *)` to the recommended permissions array (line 47) so the workflow detection grep does not trigger a permission prompt.
+
+### 3. `plugins/release/.claude-plugin/plugin.json`
+
+Bump version from `1.2.0` to `1.3.0` (new capability: workflow-aware release).
+
+### 4. `.claude-plugin/marketplace.json`
+
+Mirror the version bump from `1.2.0` to `1.3.0` on line 304.
+
+## Verification
+
+1. Read the modified SKILL.md end-to-end to confirm the flow is coherent
+2. Use `check-versions` skill to verify plugin.json and marketplace.json versions match
+3. Review the conditional logic to ensure both paths (workflow exists / no workflow) are complete and consistent

--- a/docs/plans/done/2026-03-27-skip-gh-release-when-workflow-exists.md
+++ b/docs/plans/done/2026-03-27-skip-gh-release-when-workflow-exists.md
@@ -27,14 +27,17 @@ Four areas need changes:
 **Step 1 (Pre-Flight Checks):** Add the grep command to the parallel block. Note the result as a flag (e.g., "release workflow detected" or "no release workflow detected").
 
 **Step 11 prompt:** Change the prompt wording based on detection:
+
 - No workflow: "Push and create a GitHub Release for vVERSION?" (current behavior)
 - Workflow detected: "Push commit and tag for vVERSION? (release workflow detected; it will create the GitHub Release automatically)"
 
 **Step 11 "If the user declines":** Conditional manual commands:
+
 - No workflow: show all three commands (push HEAD, push tag, `gh release create`) as today
 - Workflow detected: show only the two push commands, note the workflow will handle the release
 
 **Step 11 "If the user accepts" (11c-11e):** Add a branch after 11b:
+
 - If a release workflow was detected: report that the workflow will create the GitHub Release when it runs, skip 11c/11d entirely, and go straight to 11e with adjusted output (no GitHub Release URL, note workflow will handle it)
 - If no workflow detected: proceed with existing 11c/11d/11e unchanged
 

--- a/plugins/release/.claude-plugin/plugin.json
+++ b/plugins/release/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "name": "release",
   "repository": "https://github.com/cboone/cboone-cc-plugins",
   "skills": "./skills",
-  "version": "1.2.0"
+  "version": "1.3.0"
 }

--- a/plugins/release/README.md
+++ b/plugins/release/README.md
@@ -44,7 +44,7 @@ This skill runs git commands that trigger permission prompts. To allow them auto
 ```json
 {
   "permissions": {
-    "allow": ["Bash(git status --porcelain)", "Bash(git branch --show-current)", "Bash(git tag *)", "Bash(git log *)", "Bash(git add *)", "Bash(git commit *)", "Bash(git remote get-url *)", "Bash(git push *)", "Bash(command -v gh)", "Bash(mktemp /tmp/gh-release-notes-*)", "Bash(rm -f /tmp/gh-release-notes-*)", "Bash(gh release create *)", "Bash(date *)"]
+    "allow": ["Bash(git status --porcelain)", "Bash(git branch --show-current)", "Bash(git tag *)", "Bash(git log *)", "Bash(git add *)", "Bash(git commit *)", "Bash(git remote get-url *)", "Bash(git push *)", "Bash(grep -rl *)", "Bash(command -v gh)", "Bash(mktemp /tmp/gh-release-notes-*)", "Bash(rm -f /tmp/gh-release-notes-*)", "Bash(gh release create *)", "Bash(date *)"]
   }
 }
 ```

--- a/plugins/release/skills/release/SKILL.md
+++ b/plugins/release/skills/release/SKILL.md
@@ -42,10 +42,12 @@ git tag --list 'v*' --sort=-version:refname
 date +%Y-%m-%d
 
 # Check for a release workflow triggered by version tags
-grep -rl '"v\*"' .github/workflows/*.yml .github/workflows/*.yaml 2>/dev/null
+if [ -d .github/workflows ]; then
+  grep -rl '"v\*"' .github/workflows/*.yml .github/workflows/*.yaml 2>/dev/null || true
+fi
 ```
 
-If the `grep` returns any files, note that a **release workflow exists** that will automatically create a GitHub Release when a version tag is pushed. This flag affects step 11.
+If the `grep` returns any files, note that a **release workflow likely exists** that will automatically create a GitHub Release when a version tag is pushed. This detection is best-effort: it may miss workflows that use different quoting (e.g., single quotes around `v*`) or match unrelated workflows. If the detection seems wrong, ask the user to confirm. This flag affects step 11.
 
 **Abort conditions:**
 
@@ -300,10 +302,10 @@ If the push is rejected, report the error and stop. Never force push. Show the r
 If a **release workflow was detected** in step 1, skip steps 11d and 11e. Report:
 
 ```text
-Release vVERSION published.
+Tagged vVERSION and pushed to origin.
 
   Tag: vVERSION
-  GitHub Release: the release workflow will create it automatically.
+  GitHub Release: the release workflow is expected to create it automatically.
 ```
 
 Then stop.

--- a/plugins/release/skills/release/SKILL.md
+++ b/plugins/release/skills/release/SKILL.md
@@ -40,7 +40,12 @@ git tag --list 'v*' --sort=-version:refname
 
 # Get today's date
 date +%Y-%m-%d
+
+# Check for a release workflow triggered by version tags
+grep -rl '"v\*"' .github/workflows/*.yml .github/workflows/*.yaml 2>/dev/null
 ```
+
+If the `grep` returns any files, note that a **release workflow exists** that will automatically create a GitHub Release when a version tag is pushed. This flag affects step 11.
 
 **Abort conditions:**
 
@@ -229,15 +234,26 @@ Release vVERSION tagged locally.
 
 ### 11. Publish
 
-Ask the user if they want to push the commit and tag and create a GitHub Release:
+Ask the user if they want to push the commit and tag.
+
+If **no release workflow** was detected in step 1:
 
 ```text
 Push and create a GitHub Release for vVERSION?
 ```
 
+If a **release workflow was detected** in step 1:
+
+```text
+Push commit and tag for vVERSION?
+(Release workflow detected; it will create the GitHub Release automatically.)
+```
+
 #### If the user declines
 
-Show the manual commands and stop:
+Show the manual commands and stop. The commands depend on whether a release workflow was detected.
+
+If **no release workflow** was detected:
 
 ```text
 Release vVERSION is ready locally.
@@ -246,6 +262,18 @@ To publish manually:
   git push origin HEAD
   git push origin vVERSION
   gh release create vVERSION --title "vVERSION" --notes-file <changelog-notes-file> --verify-tag
+```
+
+If a **release workflow was detected**:
+
+```text
+Release vVERSION is ready locally.
+
+To publish manually:
+  git push origin HEAD
+  git push origin vVERSION
+
+The release workflow will create the GitHub Release automatically when the tag is pushed.
 ```
 
 #### If the user accepts
@@ -265,15 +293,30 @@ git push origin HEAD
 git push origin vVERSION
 ```
 
-If the push is rejected, report the error and stop. Never force push. Show the remaining manual commands (retry the failed `git push` command(s), then run the `gh release create` command) so the user can complete the process after resolving the push issue.
+If the push is rejected, report the error and stop. Never force push. Show the remaining manual commands so the user can complete the process after resolving the push issue: retry the failed `git push` command(s), and if no release workflow was detected, also show the `gh release create` command.
 
-##### 11c. Extract changelog section
+##### 11c. Check for release workflow
+
+If a **release workflow was detected** in step 1, skip steps 11d and 11e. Report:
+
+```text
+Release vVERSION published.
+
+  Tag: vVERSION
+  GitHub Release: the release workflow will create it automatically.
+```
+
+Then stop.
+
+If **no release workflow** was detected, continue to step 11d.
+
+##### 11d. Extract changelog section
 
 Read `CHANGELOG.md` and extract the content for the new version. The section starts after the `## [VERSION] - YYYY-MM-DD` heading and ends before the next `## [` heading or before the comparison link block at the bottom of the file. Include the category headings (`### Added`, `### Fixed`, etc.) and their entries. Do not include the version heading itself or comparison links.
 
 If `CHANGELOG.md` does not exist or the version section cannot be found, use the fallback: `Release vVERSION`.
 
-##### 11d. Create GitHub Release
+##### 11e. Create GitHub Release
 
 First, check that `gh` is available:
 
@@ -303,7 +346,7 @@ Always remove the tmpfile after the command completes, regardless of success or 
 rm -f TMPFILE
 ```
 
-##### 11e. Report results
+##### 11f. Report results
 
 ```text
 Release vVERSION published.
@@ -332,5 +375,6 @@ Release vVERSION published.
 - **No remote configured:** Skip comparison links in CHANGELOG, skip push and GitHub Release in step 11, warn the user.
 - **First release:** Use `v0.0.0` as the base for bump calculation, create the CHANGELOG from scratch, skip doc version updates (no old version to replace).
 - **Push rejected:** Report the error and show remaining manual commands. Never force push.
+- **Release workflow detected:** Skip manual GitHub Release creation; the workflow will create it when the tag is pushed. Push the commit and tag only.
 - **`gh` not available:** Push the commit and tag, skip GitHub Release creation, note that `gh` is required for GitHub Releases and show the manual `gh release create` command.
 - **GitHub Release creation fails:** The push already succeeded, so the tag is on the remote. Report the `gh` error and show the manual `gh release create` command for the user to retry.


### PR DESCRIPTION
## Summary

- Add release workflow detection to pre-flight checks (step 1) by grepping for `"v*"` tag triggers in `.github/workflows/`
- Conditionally skip manual `gh release create` in step 11 when a release workflow is detected, since the workflow will create the GitHub Release automatically when the tag is pushed
- Update step 11 prompt, decline path, accept path, and error handling to account for both workflow-detected and no-workflow scenarios
- Bump release plugin version from 1.2.0 to 1.3.0

## Test plan

- [ ] Run `/release --dry-run` on a project **with** a release workflow and verify the detection appears in step 1 output
- [ ] Run `/release` on a project **with** a release workflow, accept at step 11, and verify no `gh release create` is attempted
- [ ] Run `/release` on a project **without** a release workflow and verify existing behavior is unchanged
