### PR TITLE
chore: pin gh-actions to v2.1.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,10 @@ jobs:
       - name: ShellCheck
         run: shellcheck -S warning bin/* plugins/*/scripts/*
       - name: Set up shfmt
-        uses: cboone/gh-actions/actions/setup-shfmt@v1
+        uses: cboone/gh-actions/actions/setup-shfmt@v2.1.2
       - name: shfmt
         run: shfmt -d bin/* plugins/*/scripts/*
-      - uses: cboone/gh-actions/actions/setup-actionlint@v1
+      - uses: cboone/gh-actions/actions/setup-actionlint@v2.1.2
       - name: Actionlint
         run: actionlint
       - name: Validate JSON syntax


### PR DESCRIPTION
Pin all `cboone/gh-actions` workflow and action references from floating
tags (`@v1`, `@v2`) to the exact version `@v2.1.2`.

Part of the migration to exact-version-only tagging (cboone/gh-actions#25).
After all consuming repos are updated, the floating `v1` and `v2` tags
will be deleted from the gh-actions remote.