### PR TITLE
Simplify setup-secret-scanning workflow triggers

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -455,7 +455,7 @@
       "name": "setup-secret-scanning",
       "repository": "https://github.com/cboone/cboone-cc-plugins",
       "source": "./plugins/setup-secret-scanning",
-      "version": "2.4.0"
+      "version": "2.5.0"
     },
     {
       "author": {

--- a/plugins/setup-secret-scanning/.claude-plugin/plugin.json
+++ b/plugins/setup-secret-scanning/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "name": "setup-secret-scanning",
   "repository": "https://github.com/cboone/cboone-cc-plugins",
   "skills": "./skills",
-  "version": "2.4.0"
+  "version": "2.5.0"
 }

--- a/plugins/setup-secret-scanning/README.md
+++ b/plugins/setup-secret-scanning/README.md
@@ -17,7 +17,7 @@ Then select **Setup Secret Scanning** from the available plugins.
 
 ## What It Does
 
-Sets up complementary secret scanning with two tools: gitleaks for fast pattern matching on every push and PR (with daily scheduled scans), and TruffleHog for deeper verification-based scanning on pushes to main (with weekly scheduled scans). Lets you choose both tools (recommended), gitleaks only, or TruffleHog only. For gitleaks, detects organization vs. personal repositories and optionally creates a starter `.gitleaks.toml`.
+Sets up complementary secret scanning with two tools: gitleaks for fast pattern matching, and TruffleHog for deeper verification-based scanning that confirms whether detected credentials are still live. Both run on pushes to `main`, on every pull request, and on manual `workflow_dispatch`. Lets you choose both tools (recommended), gitleaks only, or TruffleHog only. For gitleaks, optionally creates a starter `.gitleaks.toml`.
 
 ## Usage
 

--- a/plugins/setup-secret-scanning/skills/setup-secret-scanning/SKILL.md
+++ b/plugins/setup-secret-scanning/skills/setup-secret-scanning/SKILL.md
@@ -5,8 +5,8 @@ description: >-
   and optional gitleaks configuration. Use when the user says "add secret
   scanning", "set up secret scanning", "set up gitleaks", "set up trufflehog",
   "scan for secrets in CI", or wants to detect leaked credentials in a
-  repository. Both tools run on pushes to main, on pull requests, and on
-  manual dispatch; gitleaks does fast pattern matching, TruffleHog adds
+  repository. Both tools run on pushes to `main`, on pull requests, and on
+  `workflow_dispatch`; gitleaks does fast pattern matching, TruffleHog adds
   verification-based scanning. Pairs with handle-secrets for
   application-level secret hygiene.
 ---

--- a/plugins/setup-secret-scanning/skills/setup-secret-scanning/SKILL.md
+++ b/plugins/setup-secret-scanning/skills/setup-secret-scanning/SKILL.md
@@ -5,9 +5,9 @@ description: >-
   and optional gitleaks configuration. Use when the user says "add secret
   scanning", "set up secret scanning", "set up gitleaks", "set up trufflehog",
   "scan for secrets in CI", or wants to detect leaked credentials in a
-  repository. Gitleaks performs fast pattern matching on every push and PR
-  plus a daily scheduled scan; TruffleHog adds verification-based scanning on
-  pushes to main with a weekly schedule. Pairs with handle-secrets for
+  repository. Both tools run on pushes to main, on pull requests, and on
+  manual dispatch; gitleaks does fast pattern matching, TruffleHog adds
+  verification-based scanning. Pairs with handle-secrets for
   application-level secret hygiene.
 ---
 
@@ -17,8 +17,10 @@ Set up secret scanning in a repository with [gitleaks](https://github.com/gitlea
 
 The two tools are complementary:
 
-- **Gitleaks** performs fast pattern matching on every push and PR, plus a daily scheduled scan.
-- **TruffleHog** performs deeper verification-based scanning on pushes to main, with a weekly scheduled scan.
+- **Gitleaks** performs fast pattern matching.
+- **TruffleHog** performs deeper verification-based scanning that confirms whether detected credentials are still live.
+
+Both run on pushes to `main`, on every pull request, and on manual `workflow_dispatch`.
 
 ## Workflow
 
@@ -81,8 +83,7 @@ If no, skip this step.
 Print a summary of what was created:
 
 - List every file generated
-- For gitleaks: note that it runs on pushes, pull requests, and daily at 4 AM UTC
-- For TruffleHog: note that it runs on pushes to main and weekly on Saturdays at 4 AM UTC
+- Note that both workflows run on pushes to `main`, pull requests, and `workflow_dispatch`
 - Mention that gitleaks will automatically comment on PRs when secrets are detected
 
 ## Error Handling

--- a/plugins/setup-secret-scanning/skills/setup-secret-scanning/references/gitleaks-workflow.md
+++ b/plugins/setup-secret-scanning/skills/setup-secret-scanning/references/gitleaks-workflow.md
@@ -9,10 +9,9 @@ name: gitleaks
 
 on:
   push:
+    branches: [main]
   pull_request:
   workflow_dispatch:
-  schedule:
-    - cron: "0 4 * * *"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -31,7 +30,7 @@ jobs:
 ## Notes
 
 - The reusable workflow uses the gitleaks CLI directly, not `gitleaks/gitleaks-action`. The CLI works without a license for both personal and organization repositories.
-- The `schedule` trigger runs a daily scan at 4 AM UTC to catch secrets introduced outside of PR workflows (e.g., direct pushes).
-- `workflow_dispatch` allows manual triggering from the GitHub Actions UI.
+- Runs on pushes to `main` (post-merge) and on every pull request, so all merged code is scanned and proposed changes are scanned before merge.
+- `workflow_dispatch` allows manual triggering from the GitHub Actions UI, useful for re-scanning history after a gitleaks rule update.
 - The reusable workflow handles checkout with `fetch-depth: 0` and tool installation internally.
 - `permissions: contents: read` grants the minimum access needed for scanning. Reusable workflows cannot elevate permissions beyond what the caller grants.

--- a/plugins/setup-secret-scanning/skills/setup-secret-scanning/references/trufflehog-workflow.md
+++ b/plugins/setup-secret-scanning/skills/setup-secret-scanning/references/trufflehog-workflow.md
@@ -10,9 +10,8 @@ name: trufflehog
 on:
   push:
     branches: [main]
+  pull_request:
   workflow_dispatch:
-  schedule:
-    - cron: "0 4 * * 6"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -31,6 +30,5 @@ jobs:
 ## Notes
 
 - The reusable workflow handles TruffleHog version pinning, checkout with `fetch-depth: 0`, and configuration internally.
-- The `schedule` trigger runs a weekly scan on Saturdays at 4 AM UTC, complementing gitleaks' daily scans.
-- `workflow_dispatch` allows manual triggering from the GitHub Actions UI.
-- Runs on pushes to `main` only (post-merge), since gitleaks already covers per-push and per-PR pattern matching.
+- Runs on pushes to `main` (post-merge) and on every pull request, so verification-based scanning covers both merged code and proposed changes.
+- `workflow_dispatch` allows manual triggering from the GitHub Actions UI, useful for re-running verification against live providers on demand.


### PR DESCRIPTION
## Summary

- Drop the daily gitleaks cron and the weekly TruffleHog cron from the generated workflows; both tools now run on pushes to `main`, every pull request, and `workflow_dispatch`.
- Restrict the gitleaks `push` trigger to `main` only (it previously ran on push to any branch) so post-merge scanning is symmetric with TruffleHog.
- Add `pull_request` to the TruffleHog workflow so verification-based scanning runs against proposed changes, not just merged code.
- Update SKILL.md, README.md, and the workflow reference docs to reflect the new trigger set; bump `setup-secret-scanning` from 2.4.0 to 2.5.0 in `plugin.json` and `marketplace.json`.

## Test plan

- [ ] `yarn lint` passes
- [ ] `bin/validate-json` passes
- [ ] `bin/validate-plugins` passes
- [ ] `actionlint` passes on the repo's own workflows
- [ ] `bin/build-opencode-mirror` produces no diff in `dist/`
- [ ] Spot-check the rendered YAML in `gitleaks-workflow.md` and `trufflehog-workflow.md` to confirm the trigger blocks match the new contract
