### PR TITLE
Fix prompt-file path substitution in create-worktree-from-issue skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -203,7 +203,7 @@
       "name": "create-worktree-from-issue",
       "repository": "https://github.com/cboone/cboone-cc-plugins",
       "source": "./plugins/create-worktree-from-issue",
-      "version": "1.2.5"
+      "version": "1.2.6"
     },
     {
       "author": {

--- a/plugins/create-worktree-from-issue/.claude-plugin/plugin.json
+++ b/plugins/create-worktree-from-issue/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "name": "create-worktree-from-issue",
   "repository": "https://github.com/cboone/cboone-cc-plugins",
   "skills": "./skills",
-  "version": "1.2.5"
+  "version": "1.2.6"
 }

--- a/plugins/create-worktree-from-issue/skills/create-worktree-from-issue/SKILL.md
+++ b/plugins/create-worktree-from-issue/skills/create-worktree-from-issue/SKILL.md
@@ -91,7 +91,9 @@ BODY_CONTENT
 
 ### 5. Create the Worktree
 
-Use the Write tool to create a temporary prompt file at `/tmp/workmux-prompt-BRANCH_NAME.md` with the composed prompt from step 4. Using the Write tool avoids shell escaping issues with arbitrary issue body content.
+Derive a filesystem-safe name from the branch by replacing `/` with `-`. For example, `feature/add-dark-mode` becomes `feature-add-dark-mode`. This `SAFE_NAME` is used only for the temporary prompt file path; pass the original `BRANCH_NAME` (with the slash) to `launch-workmux`.
+
+Use the Write tool to create a temporary prompt file at `/tmp/workmux-prompt-SAFE_NAME.md` with the composed prompt from step 4. Using the Write tool avoids shell escaping issues with arbitrary issue body content. Substituting the unsanitized `BRANCH_NAME` would cause the `Write` tool to treat the slash as a directory separator, creating a stray subdirectory under `/tmp/`.
 
 **Important:** The `workmux add` command must be fully detached from the Claude Code process. `workmux` creates tmux windows and spawns new Claude sessions, which cannot initialize while the parent Claude Code process is alive. The `launch-workmux` script handles backgrounding, detaching, waiting, and outputting the log.
 
@@ -104,7 +106,7 @@ In the example below, `SCRIPTS_DIR/launch-workmux` is a placeholder for the scri
 Do not specify a `--base` branch. Let `workmux` use its default.
 
 ```bash
-bash "SCRIPTS_DIR/launch-workmux" "BRANCH_NAME" "/tmp/workmux-prompt-BRANCH_NAME.md"
+bash "SCRIPTS_DIR/launch-workmux" "BRANCH_NAME" "/tmp/workmux-prompt-SAFE_NAME.md"
 ```
 
 The script outputs the workmux log directly and cleans up its own log file. Verify success:
@@ -116,7 +118,7 @@ git worktree list
 If the log shows success and the worktree appears in the list, clean up the prompt file:
 
 ```bash
-rm -f /tmp/workmux-prompt-BRANCH_NAME.md
+rm -f /tmp/workmux-prompt-SAFE_NAME.md
 ```
 
 If the log shows an error (e.g., "Failed to read prompt file"), the prompt file may have been deleted too early or another issue occurred. Check the log output for details.


### PR DESCRIPTION
## Summary

- Sanitize `BRANCH_NAME` to a `SAFE_NAME` (slashes replaced with hyphens) when constructing the temporary prompt file path in step 5 of `create-worktree-from-issue`, preventing the `Write` tool from creating a stray subdirectory under `/tmp/` for branch names like `feature/foo`.
- Update the `launch-workmux` invocation example and the `rm -f` cleanup example to use `SAFE_NAME` consistently. The original `BRANCH_NAME` (with the slash) is still passed as the first argument to `launch-workmux`.
- Patch-bump `create-worktree-from-issue` from 1.2.5 to 1.2.6 in `plugin.json` and `marketplace.json`.

## Test plan

- [ ] Run `/create-worktree-from-issue` against an issue whose generated branch name uses a slash (e.g., `feature/some-slug`) and confirm the prompt file is written to `/tmp/workmux-prompt-feature-some-slug.md` with no `/tmp/workmux-prompt-feature/` directory created.
- [ ] Confirm `workmux` still creates the worktree on the slash-bearing branch and the post-success `rm -f` removes the prompt file cleanly, leaving nothing behind under `/tmp/`.

## Closes

Fixes #252
