### PR TITLE
Refactor productivity marketplace category into granular subcategories

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "author": {
         "name": "Christopher Boone"
       },
-      "category": "productivity",
+      "category": "scaffolding",
       "description": "Add standard community files to a project: CONTRIBUTING.md, CODE_OF_CONDUCT.md, SECURITY.md, and PR template",
       "homepage": "https://github.com/cboone/cboone-cc-plugins",
       "keywords": ["code-of-conduct", "community", "contributing", "open-source", "security"],
@@ -27,7 +27,7 @@
       "author": {
         "name": "Christopher Boone"
       },
-      "category": "productivity",
+      "category": "ci-and-release",
       "description": "Add GoReleaser and Homebrew tap publishing to an existing Go CLI project with conditional support for completions, man pages, and macOS-only builds.",
       "homepage": "https://github.com/cboone/cboone-cc-plugins",
       "keywords": ["github-actions", "go", "golang", "goreleaser", "homebrew"],
@@ -55,7 +55,7 @@
       "author": {
         "name": "Christopher Boone"
       },
-      "category": "productivity",
+      "category": "issues-and-worktrees",
       "description": "Fetch a GitHub issue, plan the work, execute changes, and commit with issue references.",
       "homepage": "https://github.com/cboone/cboone-cc-plugins",
       "keywords": ["gh", "github", "issues", "workflow"],
@@ -69,7 +69,7 @@
       "author": {
         "name": "Christopher Boone"
       },
-      "category": "productivity",
+      "category": "code-review",
       "description": "Parse a review document for actionable feedback, work through items systematically, and track resolution progress.",
       "homepage": "https://github.com/cboone/cboone-cc-plugins",
       "keywords": ["code-review", "feedback", "markdown", "review", "workflow"],
@@ -83,7 +83,7 @@
       "author": {
         "name": "Christopher Boone"
       },
-      "category": "code-quality",
+      "category": "security",
       "description": "Blocks recursive rm commands and suggests using trash instead.",
       "homepage": "https://github.com/cboone/cboone-cc-plugins",
       "keywords": ["guard", "safety", "trash"],
@@ -97,7 +97,7 @@
       "author": {
         "name": "Christopher Boone"
       },
-      "category": "productivity",
+      "category": "scaffolding",
       "description": "Assess a repository, determine what scaffolding and setup tools are needed, present a plan, and execute them in the correct order.",
       "homepage": "https://github.com/cboone/cboone-cc-plugins",
       "keywords": ["bootstrap", "ci", "go", "linters", "rust", "scaffolding", "setup", "zig", "zsh"],
@@ -125,7 +125,7 @@
       "author": {
         "name": "Christopher Boone"
       },
-      "category": "productivity",
+      "category": "agents",
       "description": "Review and reorganize AI coding agent configuration and instruction files across Claude Code, Codex, Copilot, and OpenCode.",
       "homepage": "https://github.com/cboone/cboone-cc-plugins",
       "keywords": ["agents", "codex", "config", "copilot", "opencode", "settings"],
@@ -139,7 +139,7 @@
       "author": {
         "name": "Christopher Boone"
       },
-      "category": "productivity",
+      "category": "git",
       "description": "Smart, context-aware git commits with conventional commit messages and plan awareness.",
       "homepage": "https://github.com/cboone/cboone-cc-plugins",
       "keywords": ["commit", "conventional-commits", "git", "plans"],
@@ -153,7 +153,7 @@
       "author": {
         "name": "Christopher Boone"
       },
-      "category": "productivity",
+      "category": "issues-and-worktrees",
       "description": "Create GitHub issues using tmpfiles to avoid permission prompts from large multiline Bash arguments.",
       "homepage": "https://github.com/cboone/cboone-cc-plugins",
       "keywords": ["gh", "github", "issues", "workflow"],
@@ -167,7 +167,7 @@
       "author": {
         "name": "Christopher Boone"
       },
-      "category": "productivity",
+      "category": "agents",
       "description": "Guide for creating new plugins in this repository with consistent structure and conventions.",
       "homepage": "https://github.com/cboone/cboone-cc-plugins",
       "keywords": ["claude-code", "hooks", "plugins", "scaffolding", "skills"],
@@ -175,13 +175,13 @@
       "name": "create-plugin",
       "repository": "https://github.com/cboone/cboone-cc-plugins",
       "source": "./plugins/create-plugin",
-      "version": "1.2.1"
+      "version": "1.2.2"
     },
     {
       "author": {
         "name": "Christopher Boone"
       },
-      "category": "productivity",
+      "category": "issues-and-worktrees",
       "description": "Create a git worktree, branch, and tmux window with a task prompt using workmux.",
       "homepage": "https://github.com/cboone/cboone-cc-plugins",
       "keywords": ["git", "tmux", "workmux", "worktree"],
@@ -195,7 +195,7 @@
       "author": {
         "name": "Christopher Boone"
       },
-      "category": "productivity",
+      "category": "issues-and-worktrees",
       "description": "Find a GitHub issue and create a worktree, branch, and tmux window for working on it, with issue context injected as a task prompt.",
       "homepage": "https://github.com/cboone/cboone-cc-plugins",
       "keywords": ["git", "github", "issues", "tmux", "workmux", "worktree"],
@@ -237,7 +237,7 @@
       "author": {
         "name": "Christopher Boone"
       },
-      "category": "productivity",
+      "category": "scaffolding",
       "description": "Bootstrap, audit, and maintain REUSE-style mixed-license coverage in a repository: LICENSES/, NOTICE, REUSE.toml, SPDX headers, and reuse lint cleanliness.",
       "homepage": "https://github.com/cboone/cboone-cc-plugins",
       "keywords": ["licensing", "notice", "reuse", "spdx"],
@@ -251,7 +251,7 @@
       "author": {
         "name": "Christopher Boone"
       },
-      "category": "productivity",
+      "category": "git",
       "description": "Fetch and merge the base branch into the current feature branch with automatic conflict resolution.",
       "homepage": "https://github.com/cboone/cboone-cc-plugins",
       "keywords": ["branch", "conflicts", "git", "merge"],
@@ -265,7 +265,7 @@
       "author": {
         "name": "Christopher Boone"
       },
-      "category": "productivity",
+      "category": "workflow",
       "description": "Notifies you when Claude finishes a task or needs your attention.",
       "homepage": "https://github.com/cboone/cboone-cc-plugins",
       "keywords": ["alerts", "macos", "notifications"],
@@ -279,7 +279,7 @@
       "author": {
         "name": "Christopher Boone"
       },
-      "category": "productivity",
+      "category": "ci-and-release",
       "description": "Add paths-ignore, concurrency groups, and timeout-minutes to existing GitHub Actions workflows.",
       "homepage": "https://github.com/cboone/cboone-cc-plugins",
       "keywords": ["ci", "concurrency", "github-actions", "optimization", "timeout", "workflow"],
@@ -293,7 +293,7 @@
       "author": {
         "name": "Christopher Boone"
       },
-      "category": "productivity",
+      "category": "git",
       "description": "Lint, commit, push, and create a pull request in one step with no prompts.",
       "homepage": "https://github.com/cboone/cboone-cc-plugins",
       "keywords": ["git", "github", "plans", "pull-requests", "workflow"],
@@ -307,7 +307,7 @@
       "author": {
         "name": "Christopher Boone"
       },
-      "category": "productivity",
+      "category": "git",
       "description": "Prepare a versioned release: analyze commits, update versions and changelog, create a release commit, tag locally, and optionally publish a GitHub Release.",
       "homepage": "https://github.com/cboone/cboone-cc-plugins",
       "keywords": ["changelog", "conventional-commits", "gh", "git", "github-release", "release", "semver", "tags", "versioning"],
@@ -321,7 +321,7 @@
       "author": {
         "name": "Christopher Boone"
       },
-      "category": "code-quality",
+      "category": "code-review",
       "description": "Process and resolve GitHub Copilot automated PR review comments.",
       "homepage": "https://github.com/cboone/cboone-cc-plugins",
       "keywords": ["code-review", "copilot", "github", "pull-requests"],
@@ -335,7 +335,7 @@
       "author": {
         "name": "Christopher Boone"
       },
-      "category": "productivity",
+      "category": "git",
       "description": "Review and evaluate all work done on the current branch: summarize changes, assess plan compliance, and evaluate code quality.",
       "homepage": "https://github.com/cboone/cboone-cc-plugins",
       "keywords": ["branch", "code-review", "diff", "git", "plans", "review", "summary"],
@@ -349,7 +349,7 @@
       "author": {
         "name": "Christopher Boone"
       },
-      "category": "productivity",
+      "category": "scaffolding",
       "description": "Scaffold a complete Go CLI project with Cobra, GoReleaser, GitHub Actions, and Homebrew tap support.",
       "homepage": "https://github.com/cboone/cboone-cc-plugins",
       "keywords": ["cli", "go", "golang", "goreleaser", "scaffolding"],
@@ -363,7 +363,7 @@
       "author": {
         "name": "Christopher Boone"
       },
-      "category": "productivity",
+      "category": "scaffolding",
       "description": "Scaffold a Go library project with GoReleaser changelog releases, golangci-lint, GitHub Actions CI/CD, and Makefile.",
       "homepage": "https://github.com/cboone/cboone-cc-plugins",
       "keywords": ["go", "golang", "goreleaser", "library", "scaffolding"],
@@ -377,7 +377,7 @@
       "author": {
         "name": "Christopher Boone"
       },
-      "category": "productivity",
+      "category": "scaffolding",
       "description": "Scaffold the universal boilerplate for a new repository: LICENSE, README, CHANGELOG, .gitignore, agent config files, and a plans directory.",
       "homepage": "https://github.com/cboone/cboone-cc-plugins",
       "keywords": ["boilerplate", "git", "project", "repo", "scaffolding"],
@@ -391,7 +391,7 @@
       "author": {
         "name": "Christopher Boone"
       },
-      "category": "productivity",
+      "category": "scaffolding",
       "description": "Scaffold a complete Rust CLI project with Cargo, cargo-deny, cargo-nextest, git-cliff, GitHub Actions CI/CD, and Makefile.",
       "homepage": "https://github.com/cboone/cboone-cc-plugins",
       "keywords": ["cargo", "cli", "rust", "scaffolding"],
@@ -405,7 +405,7 @@
       "author": {
         "name": "Christopher Boone"
       },
-      "category": "productivity",
+      "category": "ci-and-release",
       "description": "Set up GitHub Actions CI with test, lint, format, and vulnerability check jobs, plus matching Makefile targets.",
       "homepage": "https://github.com/cboone/cboone-cc-plugins",
       "keywords": ["ci", "github-actions", "makefile", "testing", "workflow", "zig", "zsh"],
@@ -419,7 +419,7 @@
       "author": {
         "name": "Christopher Boone"
       },
-      "category": "productivity",
+      "category": "ci-and-release",
       "description": "Set up installer and distribution methods for Go, Swift, Rust, and Zig projects: Homebrew tap, go/cargo install, and release workflow.",
       "homepage": "https://github.com/cboone/cboone-cc-plugins",
       "keywords": ["cargo", "distribution", "github-actions", "go", "golang", "homebrew", "install", "release", "rust", "swift", "zig"],
@@ -447,7 +447,7 @@
       "author": {
         "name": "Christopher Boone"
       },
-      "category": "code-quality",
+      "category": "ci-and-release",
       "description": "Set up secret scanning with gitleaks and TruffleHog GitHub Actions workflows and optional gitleaks configuration.",
       "homepage": "https://github.com/cboone/cboone-cc-plugins",
       "keywords": ["gitleaks", "github-actions", "scanning", "secrets", "security", "trufflehog"],
@@ -461,7 +461,7 @@
       "author": {
         "name": "Christopher Boone"
       },
-      "category": "productivity",
+      "category": "issues-and-worktrees",
       "description": "Review open GitHub issues and recommend what to work on next with prioritized reasoning.",
       "homepage": "https://github.com/cboone/cboone-cc-plugins",
       "keywords": ["github", "issues", "planning", "prioritization", "triage"],
@@ -475,7 +475,7 @@
       "author": {
         "name": "Christopher Boone"
       },
-      "category": "productivity",
+      "category": "workflow",
       "description": "Reminds you to update documentation when a commit includes significant code changes.",
       "homepage": "https://github.com/cboone/cboone-cc-plugins",
       "keywords": ["documentation", "git", "hooks", "reminders"],
@@ -489,7 +489,7 @@
       "author": {
         "name": "Christopher Boone"
       },
-      "category": "productivity",
+      "category": "ci-and-release",
       "description": "Audit a repository against the latest plugin templates and update anything out of date.",
       "homepage": "https://github.com/cboone/cboone-cc-plugins",
       "keywords": ["audit", "ci", "linters", "scaffolding", "templates", "update"],
@@ -503,7 +503,7 @@
       "author": {
         "name": "Christopher Boone"
       },
-      "category": "productivity",
+      "category": "code-review",
       "description": "Find the latest branch review, assess commits made since, and update the review document with a synthesized reassessment.",
       "homepage": "https://github.com/cboone/cboone-cc-plugins",
       "keywords": ["branch", "code-review", "diff", "git", "review", "update"],
@@ -517,7 +517,7 @@
       "author": {
         "name": "Christopher Boone"
       },
-      "category": "code-quality",
+      "category": "git",
       "description": "Git and GitHub CLI conventions for Claude Code: tmpfile patterns, HEREDOC commits, GPG signing, safe push practices, and permission-prompt avoidance.",
       "homepage": "https://github.com/cboone/cboone-cc-plugins",
       "keywords": ["cli", "conventions", "gh", "git", "github", "permissions"],

--- a/plugins/create-plugin/.claude-plugin/plugin.json
+++ b/plugins/create-plugin/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "name": "create-plugin",
   "repository": "https://github.com/cboone/cboone-cc-plugins",
   "skills": "./skills",
-  "version": "1.2.1"
+  "version": "1.2.2"
 }

--- a/plugins/create-plugin/skills/create-plugin/references/marketplace-json.md
+++ b/plugins/create-plugin/skills/create-plugin/references/marketplace-json.md
@@ -51,11 +51,18 @@ Each entry in the `plugins` array has these fields, alphabetized:
 
 ## Valid Categories
 
-Categories currently used in this repository:
+Categories currently used in this repository. Each marketplace category corresponds to a subcategory in the root `README.md` table of contents:
 
-- `"code-quality"` -- style guides for code, code review tools, linting
-- `"productivity"` -- workflow automation, scaffolding, issue management
-- `"writing"` -- style and structure guides for prose, documentation, and document artifacts (Markdown, Pandoc, mathematical exposition, document templates)
+- `"agents"` -- meta-tools for the agent ecosystem (e.g., `clean-up-agent-config`, `create-plugin`)
+- `"ci-and-release"` -- CI workflows, installers, release automation, repo audits (e.g., `setup-ci`, `add-goreleaser-homebrew`, `setup-secret-scanning`, `update-everything`)
+- `"code-quality"` -- style guides for code, linting, formatting, language-specific testing (e.g., `lint-and-fix`, `write-go-code`)
+- `"code-review"` -- responding to external review feedback (e.g., `address-review`, `resolve-copilot-pr-feedback`)
+- `"git"` -- the commit-to-PR pipeline (e.g., `commit`, `pr`, `merge-main`, `release`, `review-branch`, `use-git`)
+- `"issues-and-worktrees"` -- issue management and multi-agent worktree workflows (e.g., `create-issue`, `create-worktree`, `suggest-next-issue`)
+- `"scaffolding"` -- project and repository scaffolding (e.g., `scaffold-go-cli`, `scaffold-new-repo`, `bootstrap-project`)
+- `"security"` -- security-focused hooks (e.g., `block-rm-rf`)
+- `"workflow"` -- general workflow utility hooks (e.g., `notify`, `update-docs-reminder`)
+- `"writing"` -- style and structure guides for prose and document artifacts (e.g., `write-markdown`, `write-pandoc-markdown`, `write-math`, `write-formalization-roadmap`)
 
 ## Plugin Entry Template
 

--- a/plugins/create-plugin/skills/create-plugin/references/readme-updates.md
+++ b/plugins/create-plugin/skills/create-plugin/references/readme-updates.md
@@ -40,25 +40,35 @@ Format rules:
 - Skills and hooks are listed alphabetically within their respective groups/subcategories.
 - Anchor links use the kebab-case H3 heading (e.g., `#create-worktree-from-issue`).
 
-### Subcategory Guide
+### Subcategory Guide for Skills
 
-Use this guide to determine which subcategory a new plugin belongs to:
+Use this guide to determine which subcategory a new skill belongs to. Each subcategory maps directly to a marketplace `category` value (kebab-case version of the label). Keep the README ToC subcategory and the marketplace `category` aligned so filtering in either place yields the same grouping.
 
-| Subcategory              | Covers                                                       | Examples                                    |
-| ------------------------ | ------------------------------------------------------------ | ------------------------------------------- |
-| **Git**                  | Commit-to-PR pipeline                                        | commit, merge-main, pr, review-branch       |
-| **Issues and Worktrees** | Multi-agent and issue-driven work                            | create-worktree, suggest-next-issue         |
-| **Code Review**          | Responding to external feedback                              | address-review, resolve-copilot-pr-feedback |
-| **Code Quality**         | Style guides for code, linting, formatting                   | lint-and-fix, write-go-code                 |
-| **Writing**              | Style and structure guides for prose and document artifacts  | write-markdown, write-pandoc-markdown       |
-| **Scaffolding**          | Project and repo setup                                       | scaffold-go-cli, setup-secret-scanning      |
-| **Agents**               | Meta-tools for the agent ecosystem                           | clean-up-agent-config, create-plugin        |
+| Subcategory              | Marketplace category    | Covers                                                       | Examples                                    |
+| ------------------------ | ----------------------- | ------------------------------------------------------------ | ------------------------------------------- |
+| **Git**                  | `git`                   | Commit-to-PR pipeline                                        | commit, merge-main, pr, review-branch, use-git |
+| **Issues and Worktrees** | `issues-and-worktrees`  | Multi-agent and issue-driven work                            | create-worktree, suggest-next-issue         |
+| **Code Review**          | `code-review`           | Responding to external feedback                              | address-review, resolve-copilot-pr-feedback |
+| **Code Quality**         | `code-quality`          | Style guides for code, linting, formatting                   | lint-and-fix, write-go-code                 |
+| **Writing**              | `writing`               | Style and structure guides for prose and document artifacts  | write-markdown, write-pandoc-markdown       |
+| **Scaffolding**          | `scaffolding`           | Project and repo scaffolding                                 | scaffold-go-cli, bootstrap-project          |
+| **CI and Release**       | `ci-and-release`        | CI workflows, installers, release automation, repo audits    | setup-ci, add-goreleaser-homebrew, setup-secret-scanning |
+| **Agents**               | `agents`                | Meta-tools for the agent ecosystem                           | clean-up-agent-config, create-plugin        |
 
 ### Adding a New Skill
 
 1. Insert a new line with `∙ [Skill Name](#skill-name)` in alphabetical order within the appropriate subcategory. If the new entry is the first in its subcategory, omit the leading `∙`.
 1. Add an H3 description section (see below).
 1. Create a per-plugin README (see below).
+
+### Subcategory Guide for Hooks
+
+Use this guide to determine which subcategory a new hook belongs to. Each subcategory maps directly to a marketplace `category` value.
+
+| Subcategory  | Marketplace category | Covers                                | Examples                       |
+| ------------ | -------------------- | ------------------------------------- | ------------------------------ |
+| **Security** | `security`           | Hooks that block dangerous operations | block-rm-rf                    |
+| **Workflow** | `workflow`           | General workflow utility hooks        | notify, update-docs-reminder   |
 
 ### Adding a New Hook
 

--- a/plugins/create-plugin/skills/create-plugin/references/readme-updates.md
+++ b/plugins/create-plugin/skills/create-plugin/references/readme-updates.md
@@ -44,16 +44,16 @@ Format rules:
 
 Use this guide to determine which subcategory a new skill belongs to. Each subcategory maps directly to a marketplace `category` value (kebab-case version of the label). Keep the README ToC subcategory and the marketplace `category` aligned so filtering in either place yields the same grouping.
 
-| Subcategory              | Marketplace category    | Covers                                                       | Examples                                    |
-| ------------------------ | ----------------------- | ------------------------------------------------------------ | ------------------------------------------- |
-| **Git**                  | `git`                   | Commit-to-PR pipeline                                        | commit, merge-main, pr, review-branch, use-git |
-| **Issues and Worktrees** | `issues-and-worktrees`  | Multi-agent and issue-driven work                            | create-worktree, suggest-next-issue         |
-| **Code Review**          | `code-review`           | Responding to external feedback                              | address-review, resolve-copilot-pr-feedback |
-| **Code Quality**         | `code-quality`          | Style guides for code, linting, formatting                   | lint-and-fix, write-go-code                 |
-| **Writing**              | `writing`               | Style and structure guides for prose and document artifacts  | write-markdown, write-pandoc-markdown       |
-| **Scaffolding**          | `scaffolding`           | Project and repo scaffolding                                 | scaffold-go-cli, bootstrap-project          |
-| **CI and Release**       | `ci-and-release`        | CI workflows, installers, release automation, repo audits    | setup-ci, add-goreleaser-homebrew, setup-secret-scanning |
-| **Agents**               | `agents`                | Meta-tools for the agent ecosystem                           | clean-up-agent-config, create-plugin        |
+| Subcategory              | Marketplace category   | Covers                                                      | Examples                                                 |
+| ------------------------ | ---------------------- | ----------------------------------------------------------- | -------------------------------------------------------- |
+| **Git**                  | `git`                  | Commit-to-PR pipeline                                       | commit, merge-main, pr, review-branch, use-git           |
+| **Issues and Worktrees** | `issues-and-worktrees` | Multi-agent and issue-driven work                           | create-worktree, suggest-next-issue                      |
+| **Code Review**          | `code-review`          | Responding to external feedback                             | address-review, resolve-copilot-pr-feedback              |
+| **Code Quality**         | `code-quality`         | Style guides for code, linting, formatting                  | lint-and-fix, write-go-code                              |
+| **Writing**              | `writing`              | Style and structure guides for prose and document artifacts | write-markdown, write-pandoc-markdown                    |
+| **Scaffolding**          | `scaffolding`          | Project and repo scaffolding                                | scaffold-go-cli, bootstrap-project                       |
+| **CI and Release**       | `ci-and-release`       | CI workflows, installers, release automation, repo audits   | setup-ci, add-goreleaser-homebrew, setup-secret-scanning |
+| **Agents**               | `agents`               | Meta-tools for the agent ecosystem                          | clean-up-agent-config, create-plugin                     |
 
 ### Adding a New Skill
 

--- a/plugins/create-plugin/skills/create-plugin/references/readme-updates.md
+++ b/plugins/create-plugin/skills/create-plugin/references/readme-updates.md
@@ -17,10 +17,14 @@ The ToC is at the top of the file, organized by type and subcategory. Each entry
 [Skill D](#skill-d)
 <br>Code Quality:
 [Skill E](#skill-e)
-<br>Scaffolding:
+<br>Writing:
 [Skill F](#skill-f)
-<br>Agents:
+<br>Scaffolding:
 [Skill G](#skill-g)
+<br>CI and Release:
+[Skill H](#skill-h)
+<br>Agents:
+[Skill I](#skill-i)
 
 **Hooks**
 <br>Security:
@@ -33,7 +37,7 @@ Format rules:
 
 - **One entry per line.** This is critical for avoiding merge conflicts.
 - **Skills** and **Hooks** are separated by a blank line.
-- Skills are grouped into subcategories: Git, Issues and Worktrees, Code Review, Code Quality, Scaffolding, Agents.
+- Skills are grouped into subcategories: Git, Issues and Worktrees, Code Review, Code Quality, Writing, Scaffolding, CI and Release, Agents.
 - Hooks are grouped into subcategories: Security, Workflow.
 - Subcategory labels use `<br>Name:` format (plain text with trailing colon) on their own line.
 - The first link in each subcategory has no leading middle dot; subsequent links start with `∙` (middle dot, space).


### PR DESCRIPTION
## Summary

- Replace the catchall `productivity` marketplace category with seven granular categories that mirror the README ToC subcategories: `git`, `issues-and-worktrees`, `code-review`, `scaffolding`, `ci-and-release`, `agents`, and `workflow`. Also realign four entries that were filed under `code-quality` but belonged elsewhere per the README ToC (`block-rm-rf` → `security`, `use-git` → `git`, `resolve-copilot-pr-feedback` → `code-review`, `setup-secret-scanning` → `ci-and-release`). After this change, every plugin's marketplace `category` matches its README ToC subcategory 1:1.
- Sync the `create-plugin` reference docs: expand `marketplace-json.md`'s Valid Categories list from 3 entries to all 10, and add a Marketplace category column to the Subcategory Guide tables in `readme-updates.md`. Rename the existing "Subcategory Guide" to "Subcategory Guide for Skills" (mirroring the existing "Subcategory Guide for Commands" pattern) and add a parallel "Subcategory Guide for Hooks" table covering the new `security` and `workflow` hook categories.
- Bump `create-plugin` 1.2.1 → 1.2.2 (patch, documentation update). The marketplace `metadata.version` stays at 1.33.0 per the documented rule (recategorization is plugin content change, not catalog add/remove).

## Test plan

- [ ] `yarn lint` reports 0 errors and prettier sees no formatting drift.
- [ ] `bin/validate-json` and `bin/validate-plugins` both pass.
- [ ] `bin/build-opencode-mirror` produces no diff under `dist/`.
- [ ] All 48 plugin `version` values match between `plugin.json` and `marketplace.json`.
- [ ] Spot-check that no plugin still has `"category": "productivity"`, and that each plugin's marketplace `category` matches its README ToC subcategory.

## Closes

Closes #245
