### PR TITLE
Validate marketplace source paths start with ./

### DIFF
--- a/bin/validate-plugins
+++ b/bin/validate-plugins
@@ -86,6 +86,16 @@ for ((i = 0; i < marketplace_count; i++)); do
   fi
 done
 
+# ─── 6b. Source paths start with ./ ──────────────────────────────────────────
+
+for ((i = 0; i < marketplace_count; i++)); do
+  entry_name="$(jq -r ".plugins[${i}].name" "${MARKETPLACE}")"
+  entry_source="$(jq -r ".plugins[${i}].source" "${MARKETPLACE}")"
+  if [[ "${entry_source}" != ./* ]]; then
+    error "Marketplace entry '${entry_name}': source '${entry_source}' must start with ./"
+  fi
+done
+
 # ─── 7. Required fields in marketplace entries ───────────────────────────────
 
 MARKETPLACE_REQUIRED_FIELDS=("author" "category" "description" "homepage" "keywords" "license" "name" "repository" "source" "version")


### PR DESCRIPTION
## Summary

- Add a check (6b) to `bin/validate-plugins` that errors if any marketplace entry's `source` does not start with `./`.
- Closes a gap where the existing directory-existence check accepts both `plugins/foo` and `./plugins/foo`, letting a missing `./` prefix slip through and fail at install time with `plugins.0.source: Invalid input`.

## Test plan

- [ ] Run `bin/validate-plugins` on `main`: passes (current marketplace entries already use `./`).
- [ ] Temporarily strip the `./` prefix from a `source` in `.claude-plugin/marketplace.json` and re-run: errors with `source '...' must start with ./`.
- [ ] Confirm CI's `Validate plugin structure` step still passes.

## Closes

Fixes #217
