### PR TITLE
Document SKIP_SETOPT_CHECK env var in check-zsh-scripts skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -119,7 +119,7 @@
       "name": "check-zsh-scripts",
       "repository": "https://github.com/cboone/cboone-cc-plugins",
       "source": "./plugins/check-zsh-scripts",
-      "version": "2.1.1"
+      "version": "2.1.2"
     },
     {
       "author": {

--- a/plugins/check-zsh-scripts/.claude-plugin/plugin.json
+++ b/plugins/check-zsh-scripts/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "name": "check-zsh-scripts",
   "repository": "https://github.com/cboone/cboone-cc-plugins",
   "skills": "./skills",
-  "version": "2.1.1"
+  "version": "2.1.2"
 }

--- a/plugins/check-zsh-scripts/skills/check-zsh-scripts/SKILL.md
+++ b/plugins/check-zsh-scripts/skills/check-zsh-scripts/SKILL.md
@@ -132,6 +132,18 @@ zsh -c 'emulate -L zsh; setopt warn_create_global warn_nested_var; source <file>
 
 This sources the file, so review its contents for side effects first. For `.zshrc` and similar config files that intentionally set global state, many warnings are expected. Note this context when reporting.
 
+Because this step executes code (it is not purely static analysis), generated `check-zsh.zsh` scripts and any wrapper that runs this check should support a `SKIP_SETOPT_CHECK=1` opt-out. The check runs by default during local development; CI workflows set `SKIP_SETOPT_CHECK=1` to keep lint jobs purely static. Use the guard pattern:
+
+```zsh
+if [[ "${SKIP_SETOPT_CHECK:-}" == "1" ]]; then
+  print "==> setopt warnings: skipped (SKIP_SETOPT_CHECK=1)"
+else
+  # run the setopt check
+fi
+```
+
+The `setup-ci` zsh CI template sets `SKIP_SETOPT_CHECK: "1"` in the workflow `env`, so generated check scripts must honor this env var to interoperate with that template.
+
 See `./references/tools/setopt-warnings.md`.
 
 #### 3g. Shell Formatting
@@ -197,4 +209,4 @@ rm -f <file>.zwc
 - **shellcheck excessive false positives**: If more than half the output is filtered, note this and suggest focusing on native zsh tools.
 - **setopt warnings in config files**: For `.zshrc`, `.zshenv`, and similar files that set global state by design, note that `warn_create_global` warnings are expected.
 - **shfmt parse error**: If shfmt cannot parse a zsh-specific construct, skip that file. The parse error is informational, not a bug in the script.
-- **Source side effects**: Before running the setopt check (step 3f), review the file for commands that modify state. Skip this check for files with significant side effects if the user prefers.
+- **Source side effects**: Before running the setopt check (step 3f), review the file for commands that modify state. Skip this check for files with significant side effects if the user prefers, or set `SKIP_SETOPT_CHECK=1` to disable the step in generated check scripts.

--- a/plugins/check-zsh-scripts/skills/check-zsh-scripts/references/tools/setopt-warnings.md
+++ b/plugins/check-zsh-scripts/skills/check-zsh-scripts/references/tools/setopt-warnings.md
@@ -53,6 +53,24 @@ This command **sources the file**, which means:
 
 Review the file's contents before running this check on untrusted scripts. For files with significant side effects, consider extracting functions into a separate file for testing, or skip this check.
 
+## SKIP_SETOPT_CHECK
+
+Because this step is the only part of the pipeline that executes code, generated `check-zsh.zsh` scripts (and any wrapper invoking this check) should honor a `SKIP_SETOPT_CHECK=1` opt-out:
+
+```zsh
+if [[ "${SKIP_SETOPT_CHECK:-}" == "1" ]]; then
+  print "==> setopt warnings: skipped (SKIP_SETOPT_CHECK=1)"
+else
+  # run the setopt check
+fi
+```
+
+Design rationale:
+
+- **Opt-out, not opt-in**: The check is a core part of the 7-tool pipeline and runs by default during local development. Do not invert this to require an opt-in flag.
+- **CI compatibility**: The `setup-ci` zsh CI workflow template sets `SKIP_SETOPT_CHECK: "1"` in the job `env` to keep lint jobs purely static analysis. Generated check scripts must honor this env var to interoperate.
+- **Local override**: Users with significant side effects in their scripts (or sandboxed environments) can also set `SKIP_SETOPT_CHECK=1` interactively.
+
 ## Notes
 
 - Most useful for library-style zsh scripts with multiple functions.


### PR DESCRIPTION
## Summary

- Document the `SKIP_SETOPT_CHECK=1` opt-out env var in step 3f of the `check-zsh-scripts` skill, including the guard pattern and rationale (the setopt step is the only part of the pipeline that executes code).
- Add a dedicated `SKIP_SETOPT_CHECK` section to `references/tools/setopt-warnings.md` covering the opt-out design choice, CI compatibility with the `setup-ci` zsh template (which sets `SKIP_SETOPT_CHECK: "1"`), and local override use cases.
- Bump `check-zsh-scripts` to `2.1.2` in both `plugin.json` and `marketplace.json`.

## Test plan

- [ ] Verify `plugins/check-zsh-scripts/skills/check-zsh-scripts/SKILL.md` step 3f references `SKIP_SETOPT_CHECK=1` with the guard pattern and notes the `setup-ci` cross-reference.
- [ ] Verify `references/tools/setopt-warnings.md` has a `SKIP_SETOPT_CHECK` section with opt-out rationale.
- [ ] Confirm `plugin.json` and `marketplace.json` versions both read `2.1.2`.
- [ ] Confirm CI passes (`yarn lint`, shellcheck, shfmt, actionlint, `bin/validate-json`, `bin/validate-plugins`, OpenCode mirror).

## Closes

Closes #221
