### PR TITLE
Warn that swiftlint --fix can break compilation on double-optionals

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -441,7 +441,7 @@
       "name": "setup-linters",
       "repository": "https://github.com/cboone/cboone-cc-plugins",
       "source": "./plugins/setup-linters",
-      "version": "1.9.0"
+      "version": "1.9.1"
     },
     {
       "author": {

--- a/plugins/setup-linters/.claude-plugin/plugin.json
+++ b/plugins/setup-linters/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "name": "setup-linters",
   "repository": "https://github.com/cboone/cboone-cc-plugins",
   "skills": "./skills",
-  "version": "1.9.0"
+  "version": "1.9.1"
 }

--- a/plugins/setup-linters/skills/setup-linters/SKILL.md
+++ b/plugins/setup-linters/skills/setup-linters/SKILL.md
@@ -203,7 +203,7 @@ Ask whether to commit the setup. Suggest `chore: set up <tool list>` as the comm
 - **Package manager not found**: If a Node.js project has no lockfile, default to npm. For non-Node projects, guide installation via Homebrew, Cargo, or the appropriate system package manager.
 - **Install failure**: If a tool fails to install, report the error and continue with the next tool.
 - **Config conflict**: If a generated config would overwrite an existing file, ask before overwriting.
-- **Auto-fix introduces compilation errors**: Some linter auto-fix rules can produce incorrect code in edge cases (notably SwiftLint's `redundant_nil_coalescing` rule, which can break double-optional expressions). After any auto-fix pass, re-run the project's compiler or test command (`swift build`, `cargo build`, `go build`, `tsc`, etc.) to verify that the auto-fixes did not introduce compilation errors. The language-specific reference files include this verification step in their suggested `lint-fix` Makefile targets.
+- **Auto-fix introduces compilation errors**: Some linter auto-fix rules can produce incorrect code in edge cases (notably SwiftLint's `redundant_nil_coalescing` rule, which can break double-optional expressions). After any auto-fix pass, re-run the project's compiler or test command (`swift test --build-tests`, `cargo build`, `go build`, `tsc`, etc.) to verify that the auto-fixes did not introduce compilation errors. Where applicable, include a compile or test verification step in the language reference's suggested auto-fix target.
 - **Pre-commit hook failure on commit**: Fix the issue, re-stage, and create a new commit (never amend).
 
 ## Refresh `cboone/gh-actions` SHAs before scaffolding

--- a/plugins/setup-linters/skills/setup-linters/SKILL.md
+++ b/plugins/setup-linters/skills/setup-linters/SKILL.md
@@ -203,6 +203,7 @@ Ask whether to commit the setup. Suggest `chore: set up <tool list>` as the comm
 - **Package manager not found**: If a Node.js project has no lockfile, default to npm. For non-Node projects, guide installation via Homebrew, Cargo, or the appropriate system package manager.
 - **Install failure**: If a tool fails to install, report the error and continue with the next tool.
 - **Config conflict**: If a generated config would overwrite an existing file, ask before overwriting.
+- **Auto-fix introduces compilation errors**: Some linter auto-fix rules can produce incorrect code in edge cases (notably SwiftLint's `redundant_nil_coalescing` rule, which can break double-optional expressions). After any auto-fix pass, re-run the project's compiler or test command (`swift build`, `cargo build`, `go build`, `tsc`, etc.) to verify that the auto-fixes did not introduce compilation errors. The language-specific reference files include this verification step in their suggested `lint-fix` Makefile targets.
 - **Pre-commit hook failure on commit**: Fix the issue, re-stage, and create a new commit (never amend).
 
 ## Refresh `cboone/gh-actions` SHAs before scaffolding

--- a/plugins/setup-linters/skills/setup-linters/references/languages/swift.md
+++ b/plugins/setup-linters/skills/setup-linters/references/languages/swift.md
@@ -78,8 +78,8 @@ Adjust to match the project's minimum Swift version.
 # SwiftLint (lint)
 swiftlint lint --strict
 
-# SwiftLint (auto-fix then verify)
-swiftlint lint --fix && swiftlint lint --strict
+# SwiftLint (auto-fix, verify lint, then verify compilation)
+swiftlint lint --fix && swiftlint lint --strict && swift build
 
 # SwiftFormat (check)
 swiftformat --lint .
@@ -101,6 +101,7 @@ lint-fix: ## Auto-fix then verify
 	swiftlint lint --fix
 	swiftlint lint --strict
 	swiftformat .
+	swift build
 
 fmt: ## Format Swift code
 	swiftformat .
@@ -109,7 +110,8 @@ fmt: ## Format Swift code
 ## Notes
 
 - **Trailing comma conflict**: SwiftLint and SwiftFormat disagree on trailing commas by default. SwiftLint's `trailing_comma` rule warns against trailing commas, while SwiftFormat's `trailingCommas` rule adds them. To resolve this, set `mandatory_comma: true` in `.swiftlint.yml` and `--trailingCommas always` in `.swiftformat`. This makes both tools agree that trailing commas are required.
-- **Lint-fix verification pattern**: The `lint-fix` target runs `swiftlint lint --fix` followed by `swiftlint lint --strict`. The first pass auto-corrects fixable violations; the second pass verifies that no unfixable violations remain. Without the verification pass, unfixable lint errors would go unnoticed.
+- **Lint-fix verification pattern**: The `lint-fix` target runs `swiftlint lint --fix`, then `swiftlint lint --strict`, then `swift build`. The first pass auto-corrects fixable violations; the second pass verifies that no unfixable violations remain; the third pass verifies that the auto-fixes did not introduce compilation errors (see the next note). Without the verification passes, unfixable lint errors and broken auto-fixes would go unnoticed.
+- **Auto-fix can break compilation**: Some SwiftLint auto-fix rules produce incorrect code in edge cases. The most common offender is `redundant_nil_coalescing`: it strips `?? nil` from expressions like `dict[key] ?? nil`, but when the dictionary's value type is itself optional (`[K: V?]`), the `?? nil` is doing real work (flattening `V??` to `V?`) and removing it changes the return type and breaks the build. After running `swiftlint lint --fix`, always re-run `swift build` (or `swift test`) to verify the auto-fixes did not introduce compilation errors. When you hit a case like this, restore the expression and disable the rule on that line: `// swiftlint:disable:next redundant_nil_coalescing`.
 - SwiftLint uses `--strict` to treat warnings as errors, ensuring CI catches all violations.
 - SwiftFormat handles all formatting concerns (indentation, braces, whitespace), while SwiftLint focuses on style rules and code quality checks.
 - The `.swift-version` file is used by SwiftFormat and Swift toolchain managers (such as `swiftenv`) to determine the Swift language version. SwiftLint does not read `.swift-version`; configure its Swift version explicitly via the `swift_version` setting in `.swiftlint.yml` or the `--swift-version` CLI flag if needed.

--- a/plugins/setup-linters/skills/setup-linters/references/languages/swift.md
+++ b/plugins/setup-linters/skills/setup-linters/references/languages/swift.md
@@ -78,8 +78,8 @@ Adjust to match the project's minimum Swift version.
 # SwiftLint (lint)
 swiftlint lint --strict
 
-# SwiftLint (auto-fix, verify lint, then verify compilation)
-swiftlint lint --fix && swiftlint lint --strict && swift build
+# SwiftLint (auto-fix, verify lint, then verify compilation of sources and tests)
+swiftlint lint --fix && swiftlint lint --strict && swift test --build-tests
 
 # SwiftFormat (check)
 swiftformat --lint .
@@ -101,7 +101,7 @@ lint-fix: ## Auto-fix then verify
 	swiftlint lint --fix
 	swiftlint lint --strict
 	swiftformat .
-	swift build
+	swift test --build-tests
 
 fmt: ## Format Swift code
 	swiftformat .
@@ -110,8 +110,8 @@ fmt: ## Format Swift code
 ## Notes
 
 - **Trailing comma conflict**: SwiftLint and SwiftFormat disagree on trailing commas by default. SwiftLint's `trailing_comma` rule warns against trailing commas, while SwiftFormat's `trailingCommas` rule adds them. To resolve this, set `mandatory_comma: true` in `.swiftlint.yml` and `--trailingCommas always` in `.swiftformat`. This makes both tools agree that trailing commas are required.
-- **Lint-fix verification pattern**: The `lint-fix` target runs `swiftlint lint --fix`, then `swiftlint lint --strict`, then `swift build`. The first pass auto-corrects fixable violations; the second pass verifies that no unfixable violations remain; the third pass verifies that the auto-fixes did not introduce compilation errors (see the next note). Without the verification passes, unfixable lint errors and broken auto-fixes would go unnoticed.
-- **Auto-fix can break compilation**: Some SwiftLint auto-fix rules produce incorrect code in edge cases. The most common offender is `redundant_nil_coalescing`: it strips `?? nil` from expressions like `dict[key] ?? nil`, but when the dictionary's value type is itself optional (`[K: V?]`), the `?? nil` is doing real work (flattening `V??` to `V?`) and removing it changes the return type and breaks the build. After running `swiftlint lint --fix`, always re-run `swift build` (or `swift test`) to verify the auto-fixes did not introduce compilation errors. When you hit a case like this, restore the expression and disable the rule on that line: `// swiftlint:disable:next redundant_nil_coalescing`.
+- **Lint-fix verification pattern**: The `lint-fix` target runs `swiftlint lint --fix`, then `swiftlint lint --strict`, then `swift test --build-tests`. The first pass auto-corrects fixable violations; the second pass verifies that no unfixable violations remain; the third pass verifies that the auto-fixes did not introduce compilation errors (see the next note). `swift test --build-tests` is preferred over `swift build` because it compiles both sources and test targets, catching auto-fix breakage in `Tests/` that `swift build` misses. Without the verification passes, unfixable lint errors and broken auto-fixes would go unnoticed.
+- **Auto-fix can break compilation**: Some SwiftLint auto-fix rules produce incorrect code in edge cases. The most common offender is `redundant_nil_coalescing`: it strips `?? nil` from expressions like `dict[key] ?? nil`, but when the dictionary's value type is itself optional (`[K: V?]`), the `?? nil` is doing real work (flattening `V??` to `V?`) and removing it changes the return type and breaks the build. After running `swiftlint lint --fix`, always re-run `swift test --build-tests` (or `swift test`) to verify the auto-fixes did not introduce compilation errors in either sources or tests. `swift build` alone is insufficient because it does not compile SwiftPM test targets. When you hit a case like this, restore the expression and disable the rule on that line: `// swiftlint:disable:next redundant_nil_coalescing`.
 - SwiftLint uses `--strict` to treat warnings as errors, ensuring CI catches all violations.
 - SwiftFormat handles all formatting concerns (indentation, braces, whitespace), while SwiftLint focuses on style rules and code quality checks.
 - The `.swift-version` file is used by SwiftFormat and Swift toolchain managers (such as `swiftenv`) to determine the Swift language version. SwiftLint does not read `.swift-version`; configure its Swift version explicitly via the `swift_version` setting in `.swiftlint.yml` or the `--swift-version` CLI flag if needed.


### PR DESCRIPTION
## Summary

- Add a cautionary note in the Swift language reference explaining that SwiftLint's `redundant_nil_coalescing` auto-fix can break double-optional code (`[K: V?]` lookups), with the recommended `// swiftlint:disable:next` workaround.
- Add `swift build` to the suggested `lint-fix` Makefile target so auto-fix breakage is caught locally rather than in CI, and update the lint-fix verification note to match.
- Add a generalized "Auto-fix introduces compilation errors" bullet to the skill's error handling section pointing readers at the per-language verification step.

## Test plan

- [ ] Read `plugins/setup-linters/skills/setup-linters/references/languages/swift.md` and confirm the new `swift build` step and the two notes (lint-fix verification pattern, auto-fix can break compilation) read clearly.
- [ ] Confirm the new bullet in `plugins/setup-linters/skills/setup-linters/SKILL.md` Error Handling reads as a general principle rather than a Swift-specific note.
- [ ] `yarn lint:fix && yarn validate` pass cleanly.
- [ ] `setup-linters` version bumped from `1.9.0` to `1.9.1` in both `plugins/setup-linters/.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json`; marketplace `metadata.version` unchanged.

## Closes

Closes #127
