### PR TITLE
Add rebase-onto-main skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "metadata": {
     "description": "Claude Code commands, hooks, and skills from Christopher Boone (cboone.github.io)",
-    "version": "1.33.0"
+    "version": "1.34.0"
   },
   "name": "cboone-cc-plugins",
   "owner": {
@@ -302,6 +302,20 @@
       "repository": "https://github.com/cboone/cboone-cc-plugins",
       "source": "./plugins/pr",
       "version": "1.5.1"
+    },
+    {
+      "author": {
+        "name": "Christopher Boone"
+      },
+      "category": "git",
+      "description": "Fetch and rebase the current feature branch onto the base branch with automatic conflict resolution and force-with-lease push.",
+      "homepage": "https://github.com/cboone/cboone-cc-plugins",
+      "keywords": ["branch", "conflicts", "git", "rebase"],
+      "license": "MIT",
+      "name": "rebase-onto-main",
+      "repository": "https://github.com/cboone/cboone-cc-plugins",
+      "source": "./plugins/rebase-onto-main",
+      "version": "1.0.0"
     },
     {
       "author": {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -209,6 +209,13 @@ cboone-cc-plugins/
     │   └── skills/
     │       └── pr/
     │           └── SKILL.md
+    ├── rebase-onto-main/             # Base branch rebase skill
+    │   ├── .claude-plugin/
+    │   │   └── plugin.json
+    │   ├── README.md
+    │   └── skills/
+    │       └── rebase-onto-main/
+    │           └── SKILL.md
     ├── release/                     # Versioned release preparation skill
     │   ├── .claude-plugin/
     │   │   └── plugin.json

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A collection of plugins for [Claude Code](https://docs.anthropic.com/en/docs/cla
 [Commit](#commit)
 ∙ [Merge Main](#merge-main)
 ∙ [PR](#pr)
+∙ [Rebase Onto Main](#rebase-onto-main)
 ∙ [Release](#release)
 ∙ [Review Branch](#review-branch)
 ∙ [Use Git](#use-git)
@@ -112,6 +113,14 @@ Commit all changes, push to remote, and create a GitHub pull request in one auto
 > **Trigger:** `/pr`
 > **Requires:** [`gh`](https://cli.github.com/)
 > **Details:** [README](./plugins/pr/README.md)
+
+#### Rebase Onto Main
+
+Fetch and rebase the current feature branch onto the repository's base branch. Automatically detects the default branch, handles uncommitted changes, resolves conflicts per replayed commit, and force-with-lease pushes after a successful rebase. The merge-main counterpart for projects that prefer a linear history.
+
+> **Trigger:** `/rebase-onto-main`
+> **Requires:** [`gh`](https://cli.github.com/) (falls back to `git remote show origin` if unavailable)
+> **Details:** [README](./plugins/rebase-onto-main/README.md)
 
 #### Release
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Commit all changes, push to remote, and create a GitHub pull request in one auto
 
 #### Rebase Onto Main
 
-Fetch and rebase the current feature branch onto the repository's base branch. Automatically detects the default branch, handles uncommitted changes, resolves conflicts per replayed commit, and force-with-lease pushes after a successful rebase. The merge-main counterpart for projects that prefer a linear history.
+Fetch and rebase the current feature branch onto the repository's base branch. Automatically detects the default branch, handles uncommitted changes, resolves conflicts per replayed commit, and pushes after a successful rebase (using `--force-with-lease` only when the rebase rewrote history). The merge-main counterpart for projects that prefer a linear history.
 
 > **Trigger:** `/rebase-onto-main`
 > **Requires:** [`gh`](https://cli.github.com/) (falls back to `git remote show origin` if unavailable)

--- a/dist/opencode/skills/rebase-onto-main
+++ b/dist/opencode/skills/rebase-onto-main
@@ -1,0 +1,1 @@
+../../../plugins/rebase-onto-main/skills/rebase-onto-main

--- a/plugins/rebase-onto-main/.claude-plugin/plugin.json
+++ b/plugins/rebase-onto-main/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "author": {
+    "name": "Christopher Boone"
+  },
+  "description": "Fetch and rebase the current feature branch onto the base branch with automatic conflict resolution and force-with-lease push.",
+  "homepage": "https://github.com/cboone/cboone-cc-plugins",
+  "keywords": ["branch", "conflicts", "git", "rebase"],
+  "license": "MIT",
+  "name": "rebase-onto-main",
+  "repository": "https://github.com/cboone/cboone-cc-plugins",
+  "skills": "./skills",
+  "version": "1.0.0"
+}

--- a/plugins/rebase-onto-main/README.md
+++ b/plugins/rebase-onto-main/README.md
@@ -1,0 +1,69 @@
+# Rebase Onto Main
+
+Fetch and rebase the current feature branch onto the repository's base branch.
+
+**Type:** Skill
+**Trigger:** `/rebase-onto-main`
+**Requires:** [`gh`](https://cli.github.com/) (falls back to `git remote show origin` if unavailable)
+
+## Installation
+
+Add the [`cboone/cboone-cc-plugins`](https://github.com/cboone/cboone-cc-plugins) marketplace in Claude Code:
+
+```text
+/plugin marketplace add cboone/cboone-cc-plugins
+```
+
+Then select **Rebase Onto Main** from the available plugins.
+
+## What It Does
+
+Automatically detects the default branch, handles uncommitted changes (stash, commit, or abort), resolves conflicts per replayed commit, and force-with-lease pushes after a successful rebase. Suggests running install commands when lockfiles change.
+
+Unlike a merge, a rebase rewrites history: each commit on the feature branch is replayed on top of the base branch. Conflicts are resolved per commit, and any branch that has already been pushed requires a `--force-with-lease` push afterward. The skill never uses plain `--force`.
+
+## Usage
+
+```text
+/rebase-onto-main
+/rebase-onto-main --base develop
+```
+
+| Option            | Description                            |
+| ----------------- | -------------------------------------- |
+| `--base <branch>` | Override the auto-detected base branch |
+
+## Recommended Permissions
+
+This skill runs git and GitHub CLI commands that trigger permission prompts. To allow them automatically, add these rules to your `.claude/settings.json` (project-wide) or `~/.claude/settings.json` (global):
+
+```json
+{
+  "permissions": {
+    "allow": ["Bash(git status*)", "Bash(git branch *)", "Bash(git fetch *)", "Bash(git rebase *)", "Bash(git commit *)", "Bash(git push*)", "Bash(git stash*)", "Bash(git log *)", "Bash(git diff*)", "Bash(git add *)", "Bash(git remote *)", "Bash(git rev-parse *)", "Bash(gh repo view *)"]
+  }
+}
+```
+
+If you already have a `permissions.allow` array, merge these entries into it. Review and adjust the rules to match your security preferences.
+
+## Examples
+
+- "rebase onto main": fetches the default branch and rebases the current branch on top
+- "rebase onto main --base develop": rebases onto `develop` instead
+- "update branch via rebase": same as "rebase onto main"
+
+## Force-Push Safety
+
+After a rebase, the local branch's history diverges from any previously pushed copy. Pushing requires either:
+
+- `git push --force-with-lease` (preferred, refuses to overwrite if the remote moved), or
+- `git push -u origin HEAD` (only valid if the branch has no upstream yet).
+
+The skill always uses `--force-with-lease` and never plain `--force`. The default branch is never force-pushed.
+
+## See Also
+
+- [Merge Main](../merge-main/README.md): merge the base branch into the current branch instead of rebasing
+- [Review Branch](../review-branch/README.md): summarize what changed on the current branch
+- [All plugins](../../README.md)

--- a/plugins/rebase-onto-main/README.md
+++ b/plugins/rebase-onto-main/README.md
@@ -18,7 +18,7 @@ Then select **Rebase Onto Main** from the available plugins.
 
 ## What It Does
 
-Automatically detects the default branch, handles uncommitted changes (stash, commit, or abort), resolves conflicts per replayed commit, and force-with-lease pushes after a successful rebase. Suggests running install commands when lockfiles change.
+Automatically detects the default branch, handles uncommitted changes (stash, commit, or abort), resolves conflicts per replayed commit, and pushes after a successful rebase (using `--force-with-lease` only when the rebase rewrote history). Suggests running install commands when lockfiles change.
 
 Unlike a merge, a rebase rewrites history: each commit on the feature branch is replayed on top of the base branch. Conflicts are resolved per commit, and any branch that has already been pushed requires a `--force-with-lease` push afterward. The skill never uses plain `--force`.
 
@@ -55,12 +55,13 @@ If you already have a `permissions.allow` array, merge these entries into it. Re
 
 ## Force-Push Safety
 
-After a rebase, the local branch's history diverges from any previously pushed copy. Pushing requires either:
+After a rebase, the local branch's history may diverge from any previously pushed copy. The skill picks the push command based on whether the rebase actually rewrote history:
 
-- `git push --force-with-lease` (preferred, refuses to overwrite if the remote moved), or
-- `git push -u origin HEAD` (only valid if the branch has no upstream yet).
+- **History rewritten** (commits replayed onto a new base): `git push --force-with-lease`, which refuses to overwrite the remote if someone else has pushed in the meantime.
+- **No-op or fast-forward only** (HEAD unchanged after rebase): a plain `git push`, since nothing was rewritten.
+- **No upstream yet** (fresh branch never pushed): `git push -u origin HEAD`, no force needed.
 
-The skill always uses `--force-with-lease` and never plain `--force`. The default branch is never force-pushed.
+The skill never uses plain `--force`, and never force-pushes the default branch.
 
 ## See Also
 

--- a/plugins/rebase-onto-main/README.md
+++ b/plugins/rebase-onto-main/README.md
@@ -40,7 +40,7 @@ This skill runs git and GitHub CLI commands that trigger permission prompts. To 
 ```json
 {
   "permissions": {
-    "allow": ["Bash(git status*)", "Bash(git branch *)", "Bash(git fetch *)", "Bash(git rebase *)", "Bash(git commit *)", "Bash(git push*)", "Bash(git stash*)", "Bash(git log *)", "Bash(git diff*)", "Bash(git add *)", "Bash(git remote *)", "Bash(git rev-parse *)", "Bash(gh repo view *)"]
+    "allow": ["Bash(git status*)", "Bash(git branch *)", "Bash(git fetch *)", "Bash(git rebase *)", "Bash(git commit *)", "Bash(git push*)", "Bash(git stash*)", "Bash(git log *)", "Bash(git diff*)", "Bash(git add *)", "Bash(git remote *)", "Bash(git rev-parse *)", "Bash(git merge-base *)", "Bash(gh repo view *)"]
   }
 }
 ```

--- a/plugins/rebase-onto-main/skills/rebase-onto-main/SKILL.md
+++ b/plugins/rebase-onto-main/skills/rebase-onto-main/SKILL.md
@@ -64,6 +64,14 @@ Rebase will refuse to start with a dirty working tree, so this step is mandatory
 
 ### 3. Fetch and Rebase
 
+Capture the current HEAD so the post-rebase step can detect whether history was actually rewritten:
+
+```bash
+git rev-parse HEAD
+```
+
+Record this as `<pre-rebase-head>`. Then:
+
 ```bash
 git fetch origin <base-branch>
 git rebase origin/<base-branch>
@@ -88,7 +96,7 @@ If the branch has no upstream yet, fall back to `git log origin/<base-branch>..H
 
 #### Already Up to Date
 
-If git reports "Current branch <branch> is up to date." or "Fast-forwarded ...", report the result and continue to the post-rebase steps.
+If git reports "Current branch <branch> is up to date." or "Fast-forwarded ...", report the result and continue to the post-rebase steps. In this case the local HEAD is unchanged (or only fast-forwarded), so the push step uses a normal `git push` rather than `--force-with-lease`.
 
 #### Conflicts
 
@@ -164,21 +172,37 @@ After a successful rebase (with or without conflict resolution):
 
 1. **Push**:
 
-   Rebase rewrites history, so any branch that has already been pushed needs a force push. **Always use `--force-with-lease`, never plain `--force`.** `--force-with-lease` refuses to overwrite the remote if someone else has pushed in the meantime; plain `--force` clobbers their work without checking.
-
-   The user's CLAUDE.md forbids using force flags as a workaround without explicit instruction. Force-pushing after a rebase is the documented exception: it is required by the rebase workflow itself, not a workaround for an unexpected failure. Still prefer `--force-with-lease` over `--force` and surface the command before running it.
-
-   If the branch already has an upstream:
+   First decide whether a force push is actually required by comparing the current HEAD against `<pre-rebase-head>` from step 3:
 
    ```bash
-   git push --force-with-lease
+   git rev-parse HEAD
    ```
 
-   If the branch has no upstream (fresh branch never pushed), no force is needed:
+   If the commit hash changed, history was rewritten and any already-published copy of the branch needs a force push. If the hash is unchanged (no-op rebase) or only fast-forwarded onto upstream commits that were already pushed, a normal push is sufficient.
 
-   ```bash
-   git push -u origin HEAD
-   ```
+   Choose the push command based on three cases:
+
+   - **No upstream** (fresh branch never pushed): no force needed.
+
+     ```bash
+     git push -u origin HEAD
+     ```
+
+   - **Upstream exists, HEAD unchanged after rebase** (no-op or fast-forward only, nothing to push): skip the push entirely, or run a plain `git push` if there are local commits ahead of upstream that haven't been pushed yet.
+
+     ```bash
+     git push
+     ```
+
+   - **Upstream exists, HEAD rewritten by rebase**: force-with-lease is required to replace the previously pushed history.
+
+     ```bash
+     git push --force-with-lease
+     ```
+
+   **Always use `--force-with-lease`, never plain `--force`.** `--force-with-lease` refuses to overwrite the remote if someone else has pushed in the meantime; plain `--force` clobbers their work without checking.
+
+   The user's CLAUDE.md forbids using force flags as a workaround without explicit instruction. Force-pushing after a rebase that rewrote history is the documented exception: it is required by the rebase workflow itself, not a workaround for an unexpected failure. Still prefer `--force-with-lease` over `--force` and surface the command before running it.
 
    **Never** run `git push --force` (without `--force-with-lease`) and **never** force-push the default branch.
 

--- a/plugins/rebase-onto-main/skills/rebase-onto-main/SKILL.md
+++ b/plugins/rebase-onto-main/skills/rebase-onto-main/SKILL.md
@@ -89,10 +89,10 @@ If the rebase completes without conflicts:
 1. Show a summary of the replayed commits:
 
 ```bash
-git log @{u}..HEAD --oneline
+git log origin/<base-branch>..HEAD --oneline
 ```
 
-If the branch has no upstream yet, fall back to `git log origin/<base-branch>..HEAD --oneline`.
+This range lists exactly the commits that now sit on top of the rebased base, regardless of whether the branch has an upstream. Avoid `@{u}..HEAD` here: it fails when the branch has no upstream, and after a rebase it can also include base-branch commits the rebase moved onto, not just the replayed feature commits.
 
 #### Already Up to Date
 

--- a/plugins/rebase-onto-main/skills/rebase-onto-main/SKILL.md
+++ b/plugins/rebase-onto-main/skills/rebase-onto-main/SKILL.md
@@ -37,7 +37,7 @@ gh repo view --json defaultBranchRef -q '.defaultBranchRef.name'
 git branch --show-current
 
 # Check whether the branch has been pushed to a remote
-git rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null
+git rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null || echo "no upstream"
 ```
 
 If `--base <branch>` was specified, use that value instead of the detected default branch.
@@ -172,13 +172,14 @@ After a successful rebase (with or without conflict resolution):
 
 1. **Push**:
 
-   First decide whether a force push is actually required by comparing the current HEAD against `<pre-rebase-head>` from step 3:
+   First decide whether a force push is actually required. A change in HEAD alone is not enough to conclude that history was rewritten: when the local branch had no commits beyond the base, `git rebase` simply fast-forwards HEAD onto the new tip without rewriting anything. Distinguish the two cases by checking whether `<pre-rebase-head>` from step 3 is still reachable from the post-rebase HEAD:
 
    ```bash
    git rev-parse HEAD
+   git merge-base --is-ancestor <pre-rebase-head> HEAD
    ```
 
-   If the commit hash changed, history was rewritten and any already-published copy of the branch needs a force push. If the hash is unchanged (no-op rebase) or only fast-forwarded onto upstream commits that were already pushed, a normal push is sufficient.
+   If `git merge-base --is-ancestor` exits 0, the pre-rebase commit is an ancestor of the new HEAD, so the rebase was a no-op or a fast-forward and no force push is needed. If it exits non-zero, the original commits are no longer on the branch's history line, so the rebase rewrote history and any already-published copy of the branch must be replaced with a force push.
 
    Choose the push command based on three cases:
 
@@ -188,13 +189,13 @@ After a successful rebase (with or without conflict resolution):
      git push -u origin HEAD
      ```
 
-   - **Upstream exists, HEAD unchanged after rebase** (no-op or fast-forward only, nothing to push): skip the push entirely, or run a plain `git push` if there are local commits ahead of upstream that haven't been pushed yet.
+   - **Upstream exists, no-op or fast-forward only** (`<pre-rebase-head>` is an ancestor of the post-rebase HEAD): history was not rewritten. Skip the push entirely if HEAD is unchanged, or run a plain `git push` if there are local commits ahead of upstream that haven't been pushed yet.
 
      ```bash
      git push
      ```
 
-   - **Upstream exists, HEAD rewritten by rebase**: force-with-lease is required to replace the previously pushed history.
+   - **Upstream exists, history rewritten by rebase** (`<pre-rebase-head>` is no longer an ancestor of the post-rebase HEAD): force-with-lease is required to replace the previously pushed history.
 
      ```bash
      git push --force-with-lease

--- a/plugins/rebase-onto-main/skills/rebase-onto-main/SKILL.md
+++ b/plugins/rebase-onto-main/skills/rebase-onto-main/SKILL.md
@@ -1,0 +1,204 @@
+---
+name: rebase-onto-main
+description: >-
+  Fetch and rebase the current feature branch onto the base branch (usually
+  main), handling conflicts per commit and force-with-lease pushing. Use when
+  the user says "rebase onto main", "rebase on main", "rebase against main",
+  "rebase from main", "rebase main", "rebase branch", "update branch via
+  rebase", "rebase against base branch", "replay commits onto main", or any
+  variant involving rebasing the current working branch onto the default
+  branch.
+---
+
+# Rebase Onto Main
+
+Fetch and rebase the current feature branch onto the repository's base branch.
+
+## Options
+
+The user may provide these options inline:
+
+- **--base `<branch>`**: Override the auto-detected base branch (e.g., `--base develop`)
+
+## Workflow
+
+### 1. Pre-Flight Checks
+
+Run these commands in parallel to understand the current state:
+
+```bash
+# Check for uncommitted changes
+git status
+
+# Detect the repository's default branch
+gh repo view --json defaultBranchRef -q '.defaultBranchRef.name'
+
+# Confirm which branch we are on
+git branch --show-current
+
+# Check whether the branch has been pushed to a remote
+git rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null
+```
+
+If `--base <branch>` was specified, use that value instead of the detected default branch.
+
+**If `gh` is not available**, fall back to detecting the default branch with:
+
+```bash
+git remote show origin | grep 'HEAD branch' | sed 's/.*: //'
+```
+
+**If the current branch is the default branch itself**, warn the user that rebasing the base branch onto itself is a no-op and stop.
+
+### 2. Handle Uncommitted Changes
+
+If `git status` shows uncommitted changes (staged or unstaged):
+
+1. Warn the user that there are uncommitted changes.
+1. Ask whether to:
+   - **Stash**: Run `git stash` before proceeding, then `git stash pop` after the rebase completes.
+   - **Commit first**: Invoke the `/commit` skill, then continue with the rebase.
+   - **Abort**: Stop without doing anything.
+
+Rebase will refuse to start with a dirty working tree, so this step is mandatory before fetching.
+
+### 3. Fetch and Rebase
+
+```bash
+git fetch origin <base-branch>
+git rebase origin/<base-branch>
+```
+
+Where `<base-branch>` is the detected or overridden base branch name.
+
+### 4. Handle Rebase Result
+
+#### Clean Rebase
+
+If the rebase completes without conflicts:
+
+1. Report success.
+1. Show a summary of the replayed commits:
+
+```bash
+git log @{u}..HEAD --oneline
+```
+
+If the branch has no upstream yet, fall back to `git log origin/<base-branch>..HEAD --oneline`.
+
+#### Already Up to Date
+
+If git reports "Current branch <branch> is up to date." or "Fast-forwarded ...", report the result and continue to the post-rebase steps.
+
+#### Conflicts
+
+If the rebase produces conflicts, proceed to the conflict resolution workflow below.
+
+### 5. Conflict Resolution
+
+Rebase resolves conflicts **per commit**, not as a single merge. For each conflicting commit, git pauses the rebase, marks the conflicting files, and waits for resolution before continuing.
+
+For each pause:
+
+1. **Identify the conflicting commit**:
+
+```bash
+git status
+```
+
+The status output names the commit currently being applied (e.g., "You are currently rebasing branch '...' on '<sha>'."). Read it and look at the commit being replayed:
+
+```bash
+git log -1 --oneline REBASE_HEAD
+```
+
+1. **List conflicted files**:
+
+```bash
+git diff --name-only --diff-filter=U
+```
+
+1. **Resolve each conflicted file**:
+   - Read the file and examine the conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`).
+   - Use the surrounding code context, the intent of both sides, and the project's conventions to determine the correct resolution.
+   - For trivial conflicts (whitespace, import ordering, adjacent non-overlapping changes), resolve automatically.
+   - For non-trivial conflicts where the correct resolution is ambiguous, show the user both sides and ask which to keep or how to combine them.
+
+1. **Stage resolved files**:
+
+```bash
+git add <resolved-file>
+```
+
+1. **Continue the rebase**:
+
+```bash
+git rebase --continue
+```
+
+This re-applies the commit with the resolved content. Git will reuse the original commit message; if the commit becomes empty after resolution, it prompts to skip with `git rebase --skip`.
+
+1. **Repeat** until git reports the rebase complete. Each subsequent commit may produce its own conflicts.
+
+If at any point the situation becomes unrecoverable, abort cleanly:
+
+```bash
+git rebase --abort
+```
+
+This restores the branch to its pre-rebase state.
+
+### 6. Post-Rebase Steps
+
+After a successful rebase (with or without conflict resolution):
+
+1. **Lockfile changes**: If any lockfiles changed during the rebase (e.g., `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, `go.sum`, `Gemfile.lock`, `poetry.lock`, `Cargo.lock`, `composer.lock`), suggest running the appropriate install command:
+   - `package-lock.json` -> `npm install`
+   - `yarn.lock` -> `yarn install`
+   - `pnpm-lock.yaml` -> `pnpm install`
+   - `go.sum` -> `go mod tidy`
+   - `Gemfile.lock` -> `bundle install`
+   - `poetry.lock` -> `poetry install`
+   - `Cargo.lock` -> `cargo build`
+   - `composer.lock` -> `composer install`
+
+1. **Push**:
+
+   Rebase rewrites history, so any branch that has already been pushed needs a force push. **Always use `--force-with-lease`, never plain `--force`.** `--force-with-lease` refuses to overwrite the remote if someone else has pushed in the meantime; plain `--force` clobbers their work without checking.
+
+   The user's CLAUDE.md forbids using force flags as a workaround without explicit instruction. Force-pushing after a rebase is the documented exception: it is required by the rebase workflow itself, not a workaround for an unexpected failure. Still prefer `--force-with-lease` over `--force` and surface the command before running it.
+
+   If the branch already has an upstream:
+
+   ```bash
+   git push --force-with-lease
+   ```
+
+   If the branch has no upstream (fresh branch never pushed), no force is needed:
+
+   ```bash
+   git push -u origin HEAD
+   ```
+
+   **Never** run `git push --force` (without `--force-with-lease`) and **never** force-push the default branch.
+
+### 7. Stash Recovery
+
+If changes were stashed in step 2, pop the stash after the rebase completes:
+
+```bash
+git stash pop
+```
+
+If the stash pop produces conflicts, warn the user and list the conflicted files.
+
+## Error Handling
+
+- **On the default branch**: Warn that rebasing the base branch onto itself is a no-op and stop.
+- **No remote configured**: Report the error and stop.
+- **Dirty working tree**: Rebase refuses to start. Step 2 must resolve this before fetching.
+- **Rebase aborted by user**: Clean up with `git rebase --abort`, which restores the pre-rebase state.
+- **Empty commit during rebase** (the commit's changes are already present in the base): Use `git rebase --skip` to drop it, after confirming with the user.
+- **Fetch failure** (network issues, authentication): Report the error clearly and stop.
+- **`--force-with-lease` rejection** (someone else pushed to the remote branch since you last fetched): Do **not** escalate to `--force`. Stop, report the divergence, and ask the user how to proceed (typically: fetch, inspect the upstream changes, decide whether to integrate them).
+- **Stash pop conflicts**: Warn the user and list conflicted files so they can resolve manually.


### PR DESCRIPTION
## Summary

- Add new `rebase-onto-main` plugin: a sibling to `merge-main` that rebases the current feature branch onto the base branch instead of merging it in.
- Adapt the workflow for rebase semantics: per-commit conflict resolution (`git rebase --continue` / `--abort` / `--skip`) instead of a single merge commit, and post-rebase push via `git push --force-with-lease` for already-published branches.
- Document the force-push safety rule explicitly: never plain `--force`, never the default branch, and treat the rebase post-push as the documented exception to the global rule against force flags.
- Register the plugin in `marketplace.json` (bumping `metadata.version` minor to `1.34.0`), update the root `README.md` ToC and description, refresh `AGENTS.md`/`CLAUDE.md` structure tree, and regenerate the OpenCode mirror.

## Test plan

- [ ] Install the new plugin via `/plugin marketplace add cboone/cboone-cc-plugins` and confirm `/rebase-onto-main` appears.
- [ ] On a feature branch with no upstream, run `/rebase-onto-main` and verify it rebases onto `origin/main` and pushes via `git push -u origin HEAD`.
- [ ] On a feature branch already pushed, run `/rebase-onto-main` and verify the final push uses `--force-with-lease` (and never plain `--force`).
- [ ] Trigger a per-commit conflict during rebase and verify the skill walks through `git rebase --continue` / `--abort` / `--skip` correctly.
- [ ] Run `/rebase-onto-main` while on `main` and confirm it warns and stops.
- [ ] Run `/rebase-onto-main --base develop` and confirm it rebases onto `develop` instead of the default branch.
