### PR TITLE
Replace zig-version workaround with zig-version-file in Zig CI template

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -413,7 +413,7 @@
       "name": "setup-ci",
       "repository": "https://github.com/cboone/cboone-cc-plugins",
       "source": "./plugins/setup-ci",
-      "version": "1.8.0"
+      "version": "1.9.0"
     },
     {
       "author": {

--- a/plugins/setup-ci/.claude-plugin/plugin.json
+++ b/plugins/setup-ci/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "name": "setup-ci",
   "repository": "https://github.com/cboone/cboone-cc-plugins",
   "skills": "./skills",
-  "version": "1.8.0"
+  "version": "1.9.0"
 }

--- a/plugins/setup-ci/skills/setup-ci/references/ci-multi-language.md
+++ b/plugins/setup-ci/skills/setup-ci/references/ci-multi-language.md
@@ -93,4 +93,4 @@ jobs:
 - Non-reusable languages (JS/TS, Python, Ruby) use inline jobs with language-prefixed IDs (e.g., `js-test`, `js-lint`)
 - Prefix job display names with the language (e.g., `"JS: Test"`, `"JS: Lint"`)
 - Only include jobs relevant to each detected language
-- Zig requires the `zig-version` input. Pass `zig-version: ""` to make the wrapped `mlugg/setup-zig` read `minimum_zig_version` from `build.zig.zon` (the version-file equivalent until `zig-ci.yml` exposes a dedicated input). Go and Rust work with defaults.
+- For Zig, pass `zig-version-file: build.zig.zon` to make the wrapped `mlugg/setup-zig` read `minimum_zig_version` from `build.zig.zon`. Go and Rust work with defaults.

--- a/plugins/setup-ci/skills/setup-ci/references/ci-zig.md
+++ b/plugins/setup-ci/skills/setup-ci/references/ci-zig.md
@@ -38,15 +38,15 @@ permissions:
 
 jobs:
   ci:
-    uses: cboone/gh-actions/.github/workflows/zig-ci.yml@f69487c36f4e217afe28ea631de39edf17d35238 # v2.1.4
+    uses: cboone/gh-actions/.github/workflows/zig-ci.yml@7371f5d84ff9f0b0e38bfde10ab7a46ddb331e92 # v2.2.0
     with:
-      zig-version: ""
+      zig-version-file: build.zig.zon
       run-cross-compile: true
 ```
 
 ## Notes
 
-- An empty `zig-version: ""` causes the wrapped `mlugg/setup-zig` action to read `minimum_zig_version` from `build.zig.zon`, so the project's Zig version is the single source of truth. Until `zig-ci.yml` exposes a dedicated `zig-version-file` input, this empty-string passthrough is the version-file equivalent.
+- `zig-version-file: build.zig.zon` makes the wrapped `mlugg/setup-zig` action read `minimum_zig_version` from `build.zig.zon`, so the project's Zig version is the single source of truth.
 - The reusable workflow creates parallel jobs internally for test, format check (`zig fmt --check`), build, and cross-compilation
 - All checks are enabled by default except cross-compilation. Set `run-cross-compile: true` to validate release targets on every PR. Cross-compilation is cheap with Zig (single runner, no extra toolchains).
 - To disable a specific check, set its input to `false` (e.g., `run-test: false`, `run-fmt: false`, `run-build: false`)


### PR DESCRIPTION
## Summary

- Replace the `zig-version: ""` empty-string workaround in the Zig CI template with the proper `zig-version-file: build.zig.zon` input, now that `cboone/gh-actions` v2.2.0 exposes it (cboone/gh-actions#41).
- Bump the pinned `zig-ci.yml` reusable workflow ref from v2.1.4 to v2.2.0 in the Zig template (other gh-actions pins are unchanged and will be bumped separately).
- Update the explanatory note in `ci-zig.md` and the Zig prose in `ci-multi-language.md` to describe the proper input rather than the workaround.
- Bump `setup-ci` from 1.8.0 to 1.9.0 to reflect the meaningful template change.

## Test plan

- [ ] `bin/version-audit` exits cleanly (pre-existing `cboone/gh-actions` v2.1.4 → v2.2.0 drift on Go/Rust/scrut pins is out of scope for this PR).
- [ ] `bin/validate-plugins` passes.
- [ ] `bin/validate-json` passes.
- [ ] `yarn lint` passes (markdownlint + prettier).

## Closes

Closes #249
