### PR TITLE
Replace third-party action refs in skill templates with cboone/gh-actions wrappers

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -245,7 +245,7 @@
       "name": "manage-repo-licensing",
       "repository": "https://github.com/cboone/cboone-cc-plugins",
       "source": "./plugins/manage-repo-licensing",
-      "version": "1.0.0"
+      "version": "1.0.1"
     },
     {
       "author": {
@@ -441,7 +441,7 @@
       "name": "setup-installers",
       "repository": "https://github.com/cboone/cboone-cc-plugins",
       "source": "./plugins/setup-installers",
-      "version": "2.2.0"
+      "version": "2.2.1"
     },
     {
       "author": {
@@ -455,7 +455,7 @@
       "name": "setup-linters",
       "repository": "https://github.com/cboone/cboone-cc-plugins",
       "source": "./plugins/setup-linters",
-      "version": "1.10.0"
+      "version": "1.10.1"
     },
     {
       "author": {
@@ -511,7 +511,7 @@
       "name": "update-everything",
       "repository": "https://github.com/cboone/cboone-cc-plugins",
       "source": "./plugins/update-everything",
-      "version": "1.1.0"
+      "version": "1.1.1"
     },
     {
       "author": {

--- a/plugins/manage-repo-licensing/.claude-plugin/plugin.json
+++ b/plugins/manage-repo-licensing/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "name": "manage-repo-licensing",
   "repository": "https://github.com/cboone/cboone-cc-plugins",
   "skills": "./skills",
-  "version": "1.0.0"
+  "version": "1.0.1"
 }

--- a/plugins/manage-repo-licensing/skills/manage-repo-licensing/references/verification.md
+++ b/plugins/manage-repo-licensing/skills/manage-repo-licensing/references/verification.md
@@ -61,7 +61,7 @@ For repos that run CI, add a `reuse lint` step to the lint workflow. Example (Gi
 
 ```yaml
 - name: REUSE compliance
-  uses: fsfe/reuse-action@676e2d560c9a403aa252096d99fcab3e1132b0f5 # v6.0.0
+  uses: cboone/gh-actions/actions/run-reuse@7371f5d84ff9f0b0e38bfde10ab7a46ddb331e92 # v2.2.0
 ```
 
 or inline:

--- a/plugins/setup-installers/.claude-plugin/plugin.json
+++ b/plugins/setup-installers/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "name": "setup-installers",
   "repository": "https://github.com/cboone/cboone-cc-plugins",
   "skills": "./skills",
-  "version": "2.2.0"
+  "version": "2.2.1"
 }

--- a/plugins/setup-installers/skills/setup-installers/SKILL.md
+++ b/plugins/setup-installers/skills/setup-installers/SKILL.md
@@ -279,8 +279,8 @@ All release workflow templates share:
 - Trigger: push tags matching `v*`
 - `permissions: contents: write` (needed to create releases)
 - Build matrix producing tarballs in the format `BINARY-VERSION-OS-ARCH.tar.gz`
-- A `publish` job that downloads all artifacts, generates `checksums.txt`, and creates a GitHub Release via `softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0`
-- `generate_release_notes: true` for auto-generated release notes
+- A `publish` job that downloads all artifacts, generates `checksums.txt`, and creates a GitHub Release via `cboone/gh-actions/actions/gh-release@7371f5d84ff9f0b0e38bfde10ab7a46ddb331e92 # v2.2.0`
+- `generate-release-notes: true` for auto-generated release notes
 
 Replace `PROJECT-NAME` with the actual binary name in all templates.
 
@@ -357,12 +357,12 @@ jobs:
         run: sha256sum *.tar.gz > checksums.txt
 
       - name: Create release
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
+        uses: cboone/gh-actions/actions/gh-release@7371f5d84ff9f0b0e38bfde10ab7a46ddb331e92 # v2.2.0
         with:
           files: |
             *.tar.gz
             checksums.txt
-          generate_release_notes: true
+          generate-release-notes: true
 ```
 
 Notes:
@@ -438,12 +438,12 @@ jobs:
         run: sha256sum *.tar.gz > checksums.txt
 
       - name: Create release
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
+        uses: cboone/gh-actions/actions/gh-release@7371f5d84ff9f0b0e38bfde10ab7a46ddb331e92 # v2.2.0
         with:
           files: |
             *.tar.gz
             checksums.txt
-          generate_release_notes: true
+          generate-release-notes: true
 ```
 
 Notes:
@@ -540,12 +540,12 @@ jobs:
         run: sha256sum *.tar.gz > checksums.txt
 
       - name: Create release
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
+        uses: cboone/gh-actions/actions/gh-release@7371f5d84ff9f0b0e38bfde10ab7a46ddb331e92 # v2.2.0
         with:
           files: |
             *.tar.gz
             checksums.txt
-          generate_release_notes: true
+          generate-release-notes: true
 ```
 
 Notes:
@@ -637,13 +637,13 @@ jobs:
         run: sha256sum *.tar.gz *.zip > checksums.txt
 
       - name: Create release
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
+        uses: cboone/gh-actions/actions/gh-release@7371f5d84ff9f0b0e38bfde10ab7a46ddb331e92 # v2.2.0
         with:
           files: |
             *.tar.gz
             *.zip
             checksums.txt
-          generate_release_notes: true
+          generate-release-notes: true
 ```
 
 Notes:

--- a/plugins/setup-linters/.claude-plugin/plugin.json
+++ b/plugins/setup-linters/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "name": "setup-linters",
   "repository": "https://github.com/cboone/cboone-cc-plugins",
   "skills": "./skills",
-  "version": "1.10.0"
+  "version": "1.10.1"
 }

--- a/plugins/setup-linters/skills/setup-linters/SKILL.md
+++ b/plugins/setup-linters/skills/setup-linters/SKILL.md
@@ -217,7 +217,7 @@ For **Lean projects**, scan `.github/workflows/*.yml` for the `leanprover/lean-a
 | typos         | `crate-ci/typos@7c572958218557a3272c2d6719629443b5cc26fd # v1.45.2`                                                       |
 | hadolint      | `hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5 # v3.3.0`                                              |
 | actionlint    | `raven-actions/actionlint@205b530c5d9fa8f44ae9ed59f341a0db994aa6f8 # v2.1.2`                                              |
-| cspell        | `streetsidesoftware/cspell-action@de2a73e963e7443969755b648a1008f77033c5b2 # v8.4.0`                                      |
+| cspell        | `cboone/gh-actions/actions/run-cspell@7371f5d84ff9f0b0e38bfde10ab7a46ddb331e92 # v2.2.0`                                  |
 | lake lint     | `leanprover/lean-action@<sha> # <tag>` (with `lint: true`); refresh both SHA and tag to current latest before emitting    |
 
 ### 10. Run Initial Lint (Optional)

--- a/plugins/setup-linters/skills/setup-linters/references/tools/github-actions-ci.md
+++ b/plugins/setup-linters/skills/setup-linters/references/tools/github-actions-ci.md
@@ -491,7 +491,7 @@ As an inline step:
 
 ```yaml
 - name: cspell
-  uses: streetsidesoftware/cspell-action@de2a73e963e7443969755b648a1008f77033c5b2 # v8.4.0
+  uses: cboone/gh-actions/actions/run-cspell@7371f5d84ff9f0b0e38bfde10ab7a46ddb331e92 # v2.2.0
 ```
 
 Or as a reusable workflow job (also covers markdownlint, prettier, yamllint):

--- a/plugins/update-everything/.claude-plugin/plugin.json
+++ b/plugins/update-everything/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "name": "update-everything",
   "repository": "https://github.com/cboone/cboone-cc-plugins",
   "skills": "./skills",
-  "version": "1.1.0"
+  "version": "1.1.1"
 }

--- a/plugins/update-everything/skills/update-everything/SKILL.md
+++ b/plugins/update-everything/skills/update-everything/SKILL.md
@@ -180,7 +180,6 @@ The target versions for GitHub Actions that repositories should be updated to. W
 | `mfinelli/setup-shfmt`          | `v4`            |
 | `oven-sh/setup-bun`             | `v2`            |
 | `ruby/setup-ruby`               | `v1`            |
-| `softprops/action-gh-release`   | `v2`            |
 | `Swatinem/rust-cache`           | `v2`            |
 | `trufflesecurity/trufflehog`    | `v3`            |
 


### PR DESCRIPTION
## Summary

- Swap three third-party action refs in skill templates for the new `cboone/gh-actions` composite-action wrappers (released in v2.2.0): `softprops/action-gh-release` → `actions/gh-release`, `streetsidesoftware/cspell-action` → `actions/run-cspell`, `fsfe/reuse-action` → `actions/run-reuse`.
- Rename `generate_release_notes` → `generate-release-notes` in the four release-workflow templates under `setup-installers` to match the wrapper's kebab-case input.
- Drop the `softprops/action-gh-release` row from `update-everything`'s Action Versions audit table since our scaffolds no longer emit it.
- Patch-bump `setup-installers` (2.2.0 → 2.2.1), `setup-linters` (1.9.0 → 1.9.1), `manage-repo-licensing` (1.0.0 → 1.0.1), and `update-everything` (1.1.0 → 1.1.1) in both `plugin.json` and `marketplace.json`.

## Test plan

- [ ] `bin/version-audit` no longer reports `softprops/action-gh-release`, `streetsidesoftware/cspell-action`, or `fsfe/reuse-action`.
- [ ] `bin/validate-plugins` passes.
- [ ] `actionlint` against each of the four extracted release-workflow templates is clean (only the pre-existing `SC2035` info on `sha256sum *.tar.gz` remains, which is out of scope here).
- [ ] Spot-check a scaffolded release workflow against a real tag push to confirm `cboone/gh-actions/actions/gh-release` produces the expected GitHub Release with attached files and auto-generated notes.

## Closes

Closes #248
