### PR TITLE
Add OpenCode versions of the three hook plugins

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -91,7 +91,7 @@
       "name": "block-rm-rf",
       "repository": "https://github.com/cboone/cboone-cc-plugins",
       "source": "./plugins/block-rm-rf",
-      "version": "1.0.0"
+      "version": "1.1.0"
     },
     {
       "author": {
@@ -273,7 +273,7 @@
       "name": "notify",
       "repository": "https://github.com/cboone/cboone-cc-plugins",
       "source": "./plugins/notify",
-      "version": "1.0.3"
+      "version": "1.1.0"
     },
     {
       "author": {
@@ -483,7 +483,7 @@
       "name": "update-docs-reminder",
       "repository": "https://github.com/cboone/cboone-cc-plugins",
       "source": "./plugins/update-docs-reminder",
-      "version": "1.0.0"
+      "version": "1.1.0"
     },
     {
       "author": {

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -6,7 +6,7 @@
     "extends": ".markdownlint.jsonc",
   },
 
-  "ignores": [".workmux/", "node_modules/"],
+  "ignores": [".workmux/", "**/node_modules/**"],
 
   // customRules are in cli.markdownlint-cli2.jsonc, loaded via --config in
   // package.json scripts. They cannot live here because the VSCode

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Or, from within `claude`, run:
 
 ### Using with OpenCode
 
-This repository is primarily a Claude Code plugin marketplace, but the skills and commands also work in [OpenCode](https://opencode.ai) via a committed mirror at [`dist/opencode/`](./dist/opencode/).
+This repository is primarily a Claude Code plugin marketplace, but the skills, commands, and hooks also work in [OpenCode](https://opencode.ai) via a committed mirror at [`dist/opencode/`](./dist/opencode/).
 
 ```bash
 export OPENCODE_CONFIG_DIR="$(pwd)/dist/opencode"
@@ -477,18 +477,18 @@ Analyzes git commits for changes that typically need documentation updates and p
 
 ## Using with OpenCode
 
-This repository is primarily a Claude Code plugin marketplace, but the skills and commands also work in [OpenCode](https://opencode.ai) via a committed mirror at [`dist/opencode/`](./dist/opencode/).
+This repository is primarily a Claude Code plugin marketplace, but the skills, commands, and hooks also work in [OpenCode](https://opencode.ai) via a committed mirror at [`dist/opencode/`](./dist/opencode/).
 
 ```bash
 export OPENCODE_CONFIG_DIR="$(pwd)/dist/opencode"
 ```
 
-When adding or removing a plugin, regenerate the mirror with `bin/build-opencode-mirror` and commit the result. CI fails if the mirror drifts from the source plugins.
+When adding or removing a plugin, regenerate the mirror with `bin/build-opencode-mirror` and commit the result. CI fails if the mirror drifts from the source plugins. Hooks are mirrored to `dist/opencode/plugins/` as TypeScript plugins, sourced from each plugin's `opencode/index.ts`.
 
 ### Known limitations
 
-- **Hooks are not ported.** OpenCode's hook system is incompatible with Claude Code's. Skills and commands are.
 - **`${CLAUDE_PLUGIN_ROOT}` references do not expand.** Some commands and one skill use Claude Code's `@${CLAUDE_PLUGIN_ROOT}/references/...` pattern to inline reference files at runtime. OpenCode does not expand this variable, so those inclusions appear to the agent as literal path strings rather than inlined content. The inline workflow text in each affected file still loads correctly. Affected commands: `/add-goreleaser-homebrew`, `/scaffold-go-cli`, `/scaffold-go-library`, `/scaffold-new-repo`, `/scaffold-rust-cli`, `/setup-ci`, `/setup-secret-scanning`. Affected skill: `create-plugin`. For full fidelity in these cases, run them in Claude Code.
+- **Hook event parity is approximate.** OpenCode's event model collapses several distinct Claude Code notification matchers (`idle_prompt`, `elicitation_dialog`, `permission_prompt`) and the `PreCompact` event is mapped to an experimental OpenCode hook. See each hook's README for the specific mapping.
 
 ## License
 

--- a/bin/build-opencode-mirror
+++ b/bin/build-opencode-mirror
@@ -115,17 +115,45 @@ if [[ ${#command_names[@]} -gt 0 ]]; then
   done < <(printf '%s\n' "${command_names[@]}" | sort | uniq -d)
 fi
 
-# ─── 3. Bail on validation errors ────────────────────────────────────────────
+# ─── 3. Discover and validate plugins ────────────────────────────────────────
+
+plugin_names=()
+plugin_paths=()
+
+for plugin_ts in plugins/*/opencode/index.ts; do
+  if [[ ! -f "${plugin_ts}" ]]; then
+    continue
+  fi
+
+  plugin_name="$(basename "$(dirname "$(dirname "${plugin_ts}")")")"
+
+  if [[ ! "${plugin_name}" =~ ${SKILL_NAME_REGEX} ]]; then
+    error "Plugin directory '${plugin_name}' does not match OpenCode regex ${SKILL_NAME_REGEX}"
+    continue
+  fi
+
+  plugin_names+=("${plugin_name}")
+  plugin_paths+=("${plugin_ts}")
+done
+
+if [[ ${#plugin_names[@]} -gt 0 ]]; then
+  while IFS= read -r dup; do
+    [[ -z "${dup}" ]] && continue
+    error "Duplicate plugin name '${dup}' across plugins"
+  done < <(printf '%s\n' "${plugin_names[@]}" | sort | uniq -d)
+fi
+
+# ─── 4. Bail on validation errors ────────────────────────────────────────────
 
 if [[ ${errors} -gt 0 ]]; then
   echo "${errors} validation error(s); refusing to build mirror." >&2
   exit 1
 fi
 
-# ─── 4. Recreate the mirror ──────────────────────────────────────────────────
+# ─── 5. Recreate the mirror ──────────────────────────────────────────────────
 
 rm -rf "${OUTPUT_DIR}"
-mkdir -p "${OUTPUT_DIR}/skills" "${OUTPUT_DIR}/commands"
+mkdir -p "${OUTPUT_DIR}/skills" "${OUTPUT_DIR}/commands" "${OUTPUT_DIR}/plugins"
 
 for ((i = 0; i < ${#skill_names[@]}; i++)); do
   skill_name="${skill_names[${i}]}"
@@ -139,8 +167,15 @@ for ((i = 0; i < ${#command_names[@]}; i++)); do
   ln -s "../../../${source_path}" "${OUTPUT_DIR}/commands/${command_name}.md"
 done
 
-# ─── 5. Summary ──────────────────────────────────────────────────────────────
+for ((i = 0; i < ${#plugin_names[@]}; i++)); do
+  plugin_name="${plugin_names[${i}]}"
+  source_path="${plugin_paths[${i}]}"
+  ln -s "../../../${source_path}" "${OUTPUT_DIR}/plugins/${plugin_name}.ts"
+done
+
+# ─── 6. Summary ──────────────────────────────────────────────────────────────
 
 echo "Built OpenCode mirror at ${OUTPUT_DIR}"
 echo "  skills:   ${#skill_names[@]}"
 echo "  commands: ${#command_names[@]}"
+echo "  plugins:  ${#plugin_names[@]}"

--- a/cli.markdownlint-cli2.jsonc
+++ b/cli.markdownlint-cli2.jsonc
@@ -15,7 +15,7 @@
     "extends": ".markdownlint.jsonc",
   },
 
-  "ignores": [".workmux/", "node_modules/"],
+  "ignores": [".workmux/", "**/node_modules/**"],
 
   "customRules": ["@github/markdownlint-github", "markdownlint-rule-force-align-table-columns", "markdownlint-rule-relative-links"],
 }

--- a/dist/opencode/plugins/block-rm-rf.ts
+++ b/dist/opencode/plugins/block-rm-rf.ts
@@ -1,0 +1,1 @@
+../../../plugins/block-rm-rf/opencode/index.ts

--- a/dist/opencode/plugins/notify.ts
+++ b/dist/opencode/plugins/notify.ts
@@ -1,0 +1,1 @@
+../../../plugins/notify/opencode/index.ts

--- a/dist/opencode/plugins/update-docs-reminder.ts
+++ b/dist/opencode/plugins/update-docs-reminder.ts
@@ -1,0 +1,1 @@
+../../../plugins/update-docs-reminder/opencode/index.ts

--- a/docs/plans/done/2026-04-29-add-opencode-versions-of-hooks.md
+++ b/docs/plans/done/2026-04-29-add-opencode-versions-of-hooks.md
@@ -1,0 +1,217 @@
+# Add OpenCode versions of the three hook plugins
+
+## Context
+
+This repository already mirrors all skills and commands into `dist/opencode/` (built by `bin/build-opencode-mirror` and validated by CI), so the `OPENCODE_CONFIG_DIR=dist/opencode` install path works for everything except hooks. The root README states:
+
+> Hooks are not ported. OpenCode's hook system is incompatible with Claude Code's. Skills and commands are.
+
+This branch closes that gap by shipping OpenCode-native equivalents of `block-rm-rf`, `update-docs-reminder`, and `notify` so users on either harness get the same behavior from the same repo.
+
+OpenCode does not have Claude Code's stdin-JSON-plus-exit-code subprocess hook model. It exposes plugins instead: TypeScript modules loaded into OpenCode's Bun runtime that return a typed `Hooks` object. The relevant hook keys are `tool.execute.before`, `tool.execute.after`, `event` (filtered by `event.type`), and a separate declarative `permission` system in `opencode.json`. OpenCode has no plugin manifest, no marketplace, and no `${CLAUDE_PLUGIN_ROOT}` variable; instead the plugin function receives `{ client, project, directory, worktree, $, ... }`. Source: `https://opencode.ai/docs/plugins/`, `https://opencode.ai/docs/permissions/`, types in `@opencode-ai/plugin@1.14.x`.
+
+## Approach
+
+Co-locate the OpenCode implementation under each existing plugin directory (one TypeScript file per hook), extend the existing mirror builder to symlink the OpenCode source into `dist/opencode/plugin/`, and rewrite (not wrap) the bash logic in TypeScript. The existing Claude Code paths (`hooks/`, `scripts/`) stay untouched so the marketplace registration and Claude Code behavior are unaffected.
+
+Rewriting in TypeScript rather than shelling to the existing bash via Bun's `$` is the right call because:
+
+- `notify` cannot reuse the existing transcript-extraction logic at all. OpenCode's `session.idle` event does not carry a transcript path, so the plugin must call the SDK (`client.session.messages.list`) to find the last user message.
+- `update-docs-reminder` already shells out to `git` for every check. Doing that orchestration in TS is shorter and clearer than the 412-line bash, and the regexes/skip rules port verbatim.
+- `block-rm-rf` is a single regex.
+- It removes the hard runtime dependency on `bash` and `jq` being available inside OpenCode's environment.
+
+The trade-off is that we now maintain two implementations per hook. Mitigation: keep regexes, skip rules, and config schema identical so behavior stays in lock-step, and verify both paths during testing.
+
+## Repository layout changes
+
+```text
+plugins/block-rm-rf/
+├── .claude-plugin/plugin.json     unchanged
+├── hooks/hooks.json               unchanged
+├── scripts/check-rm               unchanged
+├── opencode/
+│   └── index.ts                   NEW
+└── README.md                      updated
+
+plugins/notify/
+├── .claude-plugin/plugin.json     unchanged
+├── hooks/hooks.json               unchanged
+├── scripts/notify                 unchanged
+├── opencode/
+│   └── index.ts                   NEW
+└── README.md                      updated
+
+plugins/update-docs-reminder/
+├── .claude-plugin/plugin.json     unchanged
+├── hooks/hooks.json               unchanged
+├── scripts/check-docs             unchanged
+├── opencode/
+│   └── index.ts                   NEW
+└── README.md                      updated
+```
+
+The existing Claude Code structure is preserved exactly, so `.claude-plugin/marketplace.json` does not change.
+
+## Per-plugin design
+
+### `plugins/block-rm-rf/opencode/index.ts`
+
+Hook key: `tool.execute.before`, filtered to `input.tool === "bash"`. Read `output.args.command` and apply the same regex the bash script uses (`/\brm\s+(-[a-zA-Z]*r|-R|--recursive)/`). On match, `throw new Error("Use 'trash' instead of recursive rm. ...")`. The thrown message is what OpenCode surfaces as the rejection reason, mirroring the Claude Code stderr-plus-exit-2 contract.
+
+Source of the regex and message: `plugins/block-rm-rf/scripts/check-rm`.
+
+The README will also document the declarative alternative for users who want zero-code coverage:
+
+```jsonc
+// opencode.json
+{
+  "permission": {
+    "bash": { "rm -*r*": "deny", "rm --recursive*": "deny" }
+  }
+}
+```
+
+This is glob-not-regex and does not surface a custom remediation message, so the TS plugin is the higher-fidelity option and remains the recommendation.
+
+### `plugins/update-docs-reminder/opencode/index.ts`
+
+Hook key: `tool.execute.after`, filtered to `input.tool === "bash"` and `input.args.command` matching `\bgit\s+commit\b`. Port the eight heuristic checks from `plugins/update-docs-reminder/scripts/check-docs` verbatim:
+
+- `check_new_scripts` (added files in `bin/`, `scripts/`, `cmd/`)
+- `check_new_directories` (top-level dirs not present at HEAD~1)
+- `check_dependency_changes` (lockfiles, manifests)
+- `check_config_changes` (`.env.example`, `docker-compose`, `Dockerfile`)
+- `check_ci_changes` (`.github/workflows/`, `.github/actions/`)
+- `check_new_env_vars` (diff scan for `os.Getenv`, `process.env`, etc.)
+- `check_cli_flags` (diff scan for argparse/clap/cobra/pflag patterns)
+- `check_public_api` (diff scan for new exported symbols)
+
+Reuse the same `SKIP_PREFIXES`, `TEST_FILE_PATTERNS`, `DOC_FILE_PATTERNS` constants and the same per-project `.update-docs-reminder.json` config schema (with `enabled`, `skip_prefixes`, `checks`).
+
+Surface the reminder by appending it to `output.output` so the agent reads it on the next turn. OpenCode has no `additionalContext` equivalent; this is the closest analogue to Claude Code's PostToolUse stdout behavior.
+
+Run git commands via Bun's `$` shell helper, e.g. `await $\`git diff-tree --no-commit-id --name-only -r HEAD\``.
+
+Skip conditions are identical to the bash script: merge commits, conventional `style/chore/docs/ci/test` prefixes, test-only changes, doc-only changes, first commit (no `HEAD~1`).
+
+### `plugins/notify/opencode/index.ts`
+
+Hook key: `event`, dispatching by `event.type`:
+
+| OpenCode event                    | Maps from Claude Code                                      | Notification                                                                                                             |
+| --------------------------------- | ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `session.idle`                    | `Stop`                                                     | Title `Claude Code`, subtitle `<project> @ <branch>`, message = last user message (truncated to 80 chars), sound `Glass` |
+| `permission.asked`                | `Notification:permission_prompt` and `:elicitation_dialog` | Subtitle empty, message `Needs permission…`, sound `Ping`                                                                |
+| `experimental.session.compacting` | `PreCompact:auto`                                          | Subtitle empty, message `Auto-compacting…`, sound `Ping`                                                                 |
+
+Fidelity loss to document in the README:
+
+- OpenCode does not distinguish `idle_prompt` vs `elicitation_dialog` vs `permission_prompt` the way Claude Code does. We collapse the latter two into `permission.asked` and drop the standalone `idle_prompt` (its closest analogue, `session.idle`, is already used for the Stop notification).
+- `experimental.session.compacting` is marked experimental in OpenCode; the README notes this may break with OpenCode upgrades.
+- The last-user-message lookup uses `client.session.messages.list({ id: event.properties.sessionId })` (or whichever shape the SDK exposes for the event payload — confirm during implementation by reading `@opencode-ai/sdk` types). If unavailable, fall back to a generic "Task completed" message, matching the bash fallback.
+
+`terminal-notifier` is invoked via Bun's `$` with the same flags as the bash script (`-title`, `-subtitle`, `-message`, `-sound`, `-group claude-code`, `-activate com.apple.Terminal`). macOS-only, same as the existing plugin.
+
+## Mirror builder changes
+
+`bin/build-opencode-mirror` currently scans `plugins/*/skills/*/SKILL.md` and `plugins/*/commands/*.md`. Add a third pass:
+
+1. For each `plugins/*/opencode/index.ts`, take the parent plugin name as the symlink name.
+2. Symlink it into `dist/opencode/plugin/<plugin-name>/index.ts` as a relative path back to the canonical source.
+3. Validate that no two plugins claim the same name (unlikely since they live under unique dirs, but keep the duplicate-detection pattern from skills/commands for consistency).
+4. Add the count to the summary at the bottom of the script.
+
+Rationale for `dist/opencode/plugin/<plugin-name>/index.ts` rather than `dist/opencode/plugin/<plugin-name>.ts`: OpenCode's auto-load directory takes flat `.ts` files, but using a subdirectory leaves room for future per-plugin assets (a co-located `package.json` if any plugin grows npm deps, locally-defined types, etc.). Confirm OpenCode resolves directory entries with an `index.ts` during implementation; if it does not, fall back to flat `<plugin-name>.ts` symlinks.
+
+The exact subdirectory name (`plugin` vs `plugins`) needs one verification step against OpenCode's own loader: docs reference `.opencode/plugins/` (project) and `~/.config/opencode/plugins/` (global), but with `OPENCODE_CONFIG_DIR=dist/opencode` set, OpenCode treats the dir as the global config root and the lookup path may differ by one character. Resolve before merging by reading the loader code in `github.com/anomalyco/opencode` (the repo `github.com/sst/opencode` redirects there) or by running OpenCode against the mirror.
+
+CI already runs `bin/build-opencode-mirror && git diff --exit-code dist/` in `.github/workflows/ci.yml` (line 43), so the new symlinks get validated for free; no CI change needed.
+
+## README changes
+
+Per-plugin READMEs (`plugins/block-rm-rf/README.md`, `plugins/notify/README.md`, `plugins/update-docs-reminder/README.md`): add an "OpenCode" section after the existing Claude Code section, documenting:
+
+- Installation: rely on `OPENCODE_CONFIG_DIR=$(pwd)/dist/opencode` (or symlink the `opencode/index.ts` into `~/.config/opencode/plugin/`).
+- Behavior parity and any documented fidelity gaps.
+- Required runtime tools (still `trash`, still `terminal-notifier`).
+- For `block-rm-rf`: include the alternative declarative `permission` config snippet.
+
+Root `README.md`:
+
+- Remove the "Hooks are not ported" bullet from "Known limitations" (line 490).
+- Optionally annotate each Hooks subsection (Security / Workflow) noting that OpenCode versions are included.
+- The "Using with OpenCode" section (line 478) needs a short mention that hooks are now mirrored alongside skills and commands.
+
+## Versioning
+
+Per the repo's versioning rules in `CLAUDE.md`:
+
+- `plugins/block-rm-rf/.claude-plugin/plugin.json`: `1.0.0` → `1.1.0` (new capability)
+- `plugins/notify/.claude-plugin/plugin.json`: `1.0.3` → `1.1.0` (new capability)
+- `plugins/update-docs-reminder/.claude-plugin/plugin.json`: `1.0.0` → `1.1.0` (new capability)
+- Mirror these three bumps in `.claude-plugin/marketplace.json` entries.
+- Marketplace `metadata.version` does not bump (catalog unchanged — same plugins, expanded surface).
+
+Run `check-versions` skill before opening the PR to confirm.
+
+## Files to modify or create
+
+Create:
+
+- `plugins/block-rm-rf/opencode/index.ts`
+- `plugins/notify/opencode/index.ts`
+- `plugins/update-docs-reminder/opencode/index.ts`
+
+Modify:
+
+- `bin/build-opencode-mirror` (add the third discovery pass and symlink loop)
+- `plugins/block-rm-rf/README.md` (OpenCode section)
+- `plugins/notify/README.md` (OpenCode section)
+- `plugins/update-docs-reminder/README.md` (OpenCode section)
+- `plugins/block-rm-rf/.claude-plugin/plugin.json` (version bump)
+- `plugins/notify/.claude-plugin/plugin.json` (version bump)
+- `plugins/update-docs-reminder/.claude-plugin/plugin.json` (version bump)
+- `.claude-plugin/marketplace.json` (mirror the three version bumps)
+- `README.md` (drop the "Hooks are not ported" limitation; brief note in "Using with OpenCode")
+
+Auto-regenerated (committed):
+
+- `dist/opencode/plugin/block-rm-rf/index.ts` (symlink)
+- `dist/opencode/plugin/notify/index.ts` (symlink)
+- `dist/opencode/plugin/update-docs-reminder/index.ts` (symlink)
+
+Do not modify:
+
+- `plugins/*/hooks/hooks.json`, `plugins/*/scripts/*` (Claude Code paths stay byte-identical)
+- `dist/opencode/skills/`, `dist/opencode/commands/`
+
+Cleanup decision: the research subagent created `docs/plans/todo/2026-04-29-opencode-hooks-research.md` as a side effect during planning. Either keep it as supporting reference for the implementer or delete it before merging. Recommend deleting unless you want a permanent OpenCode-format reference in the repo.
+
+## Reference material to reread during implementation
+
+- `plugins/block-rm-rf/scripts/check-rm` — regex and message
+- `plugins/notify/scripts/notify` — `terminal-notifier` flag set, truncation logic, last-user-message extraction
+- `plugins/update-docs-reminder/scripts/check-docs` — eight heuristic regexes, skip rules, per-project config schema
+- `bin/build-opencode-mirror` — symlink-and-validate pattern to copy from
+- `.github/workflows/ci.yml` line 43 — mirror validation step
+- `https://opencode.ai/docs/plugins/` and `@opencode-ai/plugin` types — current `Hooks` interface
+
+## Verification
+
+1. `bin/build-opencode-mirror && git diff dist/` — exits clean (matches what CI checks).
+2. In a scratch repo with `OPENCODE_CONFIG_DIR=$(pwd)/dist/opencode` set:
+   - Ask OpenCode to run `rm -rf foo` → expect rejection with the trash remediation message.
+   - Stage a meaningful change, run a non-skip-prefixed `git commit`, expect the documentation reminder to appear in the agent's next turn.
+   - Trigger `session.idle` (finish a turn), expect a macOS notification with project + branch + last user message.
+   - Trigger a permission prompt, expect a "Needs permission…" notification.
+3. In Claude Code on the same checkout: confirm `block-rm-rf`, `notify`, and `update-docs-reminder` still behave exactly as before (no regression in the unchanged Claude Code paths).
+4. Run the `check-versions` skill before opening the PR.
+
+## Out of scope
+
+- Publishing OpenCode plugins to npm.
+- Extracting shared logic between bash and TypeScript implementations.
+- Adding scrut tests for the new TypeScript plugins (could be follow-up work).
+- A unified harness-agnostic plugin manifest format.
+- Porting any non-hook plugin behavior.

--- a/plugins/block-rm-rf/.claude-plugin/plugin.json
+++ b/plugins/block-rm-rf/.claude-plugin/plugin.json
@@ -8,5 +8,5 @@
   "license": "MIT",
   "name": "block-rm-rf",
   "repository": "https://github.com/cboone/cboone-cc-plugins",
-  "version": "1.0.0"
+  "version": "1.1.0"
 }

--- a/plugins/block-rm-rf/README.md
+++ b/plugins/block-rm-rf/README.md
@@ -15,6 +15,26 @@ Add the [`cboone/cboone-cc-plugins`](https://github.com/cboone/cboone-cc-plugins
 
 Then select **Block rm -rf** from the available plugins.
 
+### Using with OpenCode
+
+OpenCode loads the plugin automatically when [`OPENCODE_CONFIG_DIR`](../../README.md#using-with-opencode) is set to this repository's `dist/opencode/` mirror. The TypeScript plugin lives at [`opencode/index.ts`](./opencode/index.ts) and uses the `tool.execute.before` hook to apply the same regex and rejection message as the Claude Code version.
+
+For users who prefer declarative permission rules over a custom message, this snippet in `opencode.json` blocks recursive `rm` natively:
+
+```jsonc
+{
+  "$schema": "https://opencode.ai/config.json",
+  "permission": {
+    "bash": {
+      "rm -*r*": "deny",
+      "rm --recursive*": "deny"
+    }
+  }
+}
+```
+
+The plugin remains the higher-fidelity option because it preserves the "use `trash` instead" remediation hint.
+
 ## What It Does
 
 Intercepts `rm -rf`, `rm -r`, `rm -R`, `rm --recursive`, and variants before they run. Rejects the command and suggests using `trash` instead, which moves files to the system Trash rather than permanently deleting them.

--- a/plugins/block-rm-rf/opencode/index.ts
+++ b/plugins/block-rm-rf/opencode/index.ts
@@ -1,0 +1,15 @@
+import type { Plugin } from "@opencode-ai/plugin";
+
+const RECURSIVE_RM = /\brm\s+(-[a-zA-Z]*r|-R|--recursive)/;
+
+export const BlockRmRf: Plugin = async () => {
+  return {
+    "tool.execute.before": async (input, output) => {
+      if (input.tool !== "bash") return;
+      const command = typeof output.args?.command === "string" ? output.args.command : "";
+      if (RECURSIVE_RM.test(command)) {
+        throw new Error("Use 'trash' instead of recursive rm. It moves files to the system Trash instead of permanently deleting them.");
+      }
+    },
+  };
+};

--- a/plugins/notify/.claude-plugin/plugin.json
+++ b/plugins/notify/.claude-plugin/plugin.json
@@ -8,5 +8,5 @@
   "license": "MIT",
   "name": "notify",
   "repository": "https://github.com/cboone/cboone-cc-plugins",
-  "version": "1.0.3"
+  "version": "1.1.0"
 }

--- a/plugins/notify/README.md
+++ b/plugins/notify/README.md
@@ -15,6 +15,20 @@ Add the [`cboone/cboone-cc-plugins`](https://github.com/cboone/cboone-cc-plugins
 
 Then select **Notify** from the available plugins.
 
+### Using with OpenCode
+
+OpenCode loads the plugin automatically when [`OPENCODE_CONFIG_DIR`](../../README.md#using-with-opencode) is set to this repository's `dist/opencode/` mirror. The TypeScript plugin lives at [`opencode/index.ts`](./opencode/index.ts) and dispatches on OpenCode's event stream rather than Claude Code's named matchers.
+
+OpenCode's event model differs from Claude Code's, so the parity is approximate:
+
+| OpenCode event                     | Notification          | Claude Code equivalent                                     |
+| ---------------------------------- | --------------------- | ---------------------------------------------------------- |
+| `session.idle`                     | Task completed        | `Stop` (with project + branch + last user message)         |
+| `permission.updated`               | "Needs permission…"   | `Notification` (`permission_prompt`, `elicitation_dialog`) |
+| `experimental.session.compacting`  | "Auto-compacting…"    | `PreCompact` (`auto`)                                      |
+
+The standalone "Waiting for input…" notification (Claude Code's `Notification:idle_prompt`) is not separately representable: OpenCode's `session.idle` already carries the Stop semantics. The compacting hook depends on an experimental OpenCode API and may break on upgrades.
+
 ## What It Does
 
 Delivers native macOS notifications so you can work in other apps while Claude runs. Notifies you when Claude is waiting for input, needs a permission decision, needs your response to a question, is about to auto-compact, or has finished its current task.

--- a/plugins/notify/opencode/index.ts
+++ b/plugins/notify/opencode/index.ts
@@ -1,0 +1,77 @@
+import type { Plugin, PluginInput } from "@opencode-ai/plugin";
+import type { TextPart } from "@opencode-ai/sdk";
+
+const TITLE = "Claude Code";
+const PING = "Ping";
+const GLASS = "Glass";
+const TASK_LIMIT = 80;
+
+type BunShell = PluginInput["$"];
+type Client = PluginInput["client"];
+
+const seenPermissions = new Set<string>();
+const seenCompactions = new Set<string>();
+
+export const Notify: Plugin = async ({ $, client, directory }) => {
+  return {
+    event: async ({ event }) => {
+      if (event.type === "session.idle") {
+        const sessionID = event.properties.sessionID;
+        const subtitle = await projectAndBranch($, directory);
+        const task = await lastUserMessage(client, sessionID);
+        await notify($, TITLE, subtitle, task ?? "Task completed", GLASS);
+        return;
+      }
+
+      if (event.type === "permission.updated") {
+        const id = event.properties.id;
+        if (seenPermissions.has(id)) return;
+        seenPermissions.add(id);
+        await notify($, TITLE, "", "Needs permission…", PING);
+        return;
+      }
+    },
+
+    "experimental.session.compacting": async (input) => {
+      if (seenCompactions.has(input.sessionID)) return;
+      seenCompactions.add(input.sessionID);
+      await notify($, TITLE, "", "Auto-compacting…", PING);
+    },
+  };
+};
+
+async function notify($: BunShell, title: string, subtitle: string, message: string, sound: string): Promise<void> {
+  await $`terminal-notifier -title ${title} -subtitle ${subtitle} -message ${message} -sound ${sound} -group claude-code -activate com.apple.Terminal`.nothrow().quiet();
+}
+
+async function projectAndBranch($: BunShell, directory: string): Promise<string> {
+  const project = directory.split("/").filter(Boolean).pop() ?? "";
+  const result = await $`git -C ${directory} branch --show-current`.nothrow().quiet();
+  const branch = result.exitCode === 0 ? result.text().trim() || "unknown" : "unknown";
+  return `${project} @ ${branch}`;
+}
+
+async function lastUserMessage(client: Client, sessionID: string): Promise<string | null> {
+  try {
+    const result = await client.session.messages({ path: { id: sessionID } });
+    const messages = result?.data ?? [];
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const m = messages[i];
+      if (m?.info?.role !== "user") continue;
+      const text = (m.parts ?? [])
+        .filter((p): p is TextPart => p?.type === "text")
+        .map((p) => p.text)
+        .join(" ")
+        .trim();
+      if (text) return truncate(text, TASK_LIMIT);
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+function truncate(text: string, limit: number): string {
+  if (text.length <= limit) return text;
+  return text.slice(0, limit) + "…";
+}

--- a/plugins/update-docs-reminder/.claude-plugin/plugin.json
+++ b/plugins/update-docs-reminder/.claude-plugin/plugin.json
@@ -8,5 +8,5 @@
   "license": "MIT",
   "name": "update-docs-reminder",
   "repository": "https://github.com/cboone/cboone-cc-plugins",
-  "version": "1.0.0"
+  "version": "1.1.0"
 }

--- a/plugins/update-docs-reminder/README.md
+++ b/plugins/update-docs-reminder/README.md
@@ -19,6 +19,12 @@ Add the [`cboone/cboone-cc-plugins`](https://github.com/cboone/cboone-cc-plugins
 
 Then select **Update Docs Reminder** from the available plugins.
 
+### Using with OpenCode
+
+OpenCode loads the plugin automatically when [`OPENCODE_CONFIG_DIR`](../../README.md#using-with-opencode) is set to this repository's `dist/opencode/` mirror. The TypeScript plugin lives at [`opencode/index.ts`](./opencode/index.ts) and uses the `tool.execute.after` hook with the same skip rules, file patterns, and per-project `.update-docs-reminder.json` schema as the Claude Code version.
+
+OpenCode has no surface comparable to Claude Code's PostToolUse stdout, so the reminder is appended to the bash tool's `output.output` instead. The agent reads it on its next turn, with the same wording and bullet structure.
+
 ## What It Does
 
 Analyzes each git commit for changes that typically require documentation updates and provides specific, actionable reminders. Detects new scripts, CLI flags, directories, dependencies, environment variables, configuration changes, and public API additions, then maps each to the relevant documentation files.

--- a/plugins/update-docs-reminder/opencode/index.ts
+++ b/plugins/update-docs-reminder/opencode/index.ts
@@ -1,0 +1,186 @@
+import type { Plugin, PluginInput } from "@opencode-ai/plugin";
+
+type BunShell = PluginInput["$"];
+type BunShellPromise = ReturnType<BunShell>;
+type ShellExpression = Parameters<BunShell>[1];
+
+const DEFAULT_SKIP_PREFIXES = ["style", "chore", "docs", "ci", "test"];
+const TEST_FILE_PATTERN = /(_test\.go|\.test\.[jt]sx?|\.spec\.[jt]sx?|test_[^/]+\.py|^tests\/|\/__tests__\/|^spec\/)/;
+const DOC_FILE_PATTERN = /\.(md|rst|txt|adoc)$/;
+const DEPENDENCY_FILE_PATTERN = /^(go\.(mod|sum)|package(-lock)?\.json|yarn\.lock|pnpm-lock\.yaml|Cargo\.(toml|lock)|requirements\.txt|pyproject\.toml|Gemfile(\.lock)?|Pipfile(\.lock)?|poetry\.lock)$/;
+const CONFIG_FILE_PATTERN = /(\.env\.example|\.env\.sample|docker-compose|Dockerfile)/;
+const CI_FILE_PATTERN = /^\.github\/(workflows|actions)\//;
+const SOURCE_FILE_PATTERN = /\.(go|ts|js|py|rs|rb)$/;
+const SOURCE_FILE_PATTERN_NO_RB = /\.(go|ts|js|py|rs)$/;
+const ENV_VAR_PATTERN = /(os\.Getenv|process\.env\.|os\.environ|ENV\[|getenv\(|\$ENV\{)/;
+const CLI_FLAG_PATTERN = /(StringVar|BoolVar|IntVar|flag\.|pflag\.|\.option\(|\.argument\(|add_argument|argparse|clap::Arg|cobra\.Command)/;
+const PUBLIC_API_PATTERN = /(^\+func [A-Z]|^\+export (function|class|const|type|interface) |^\+pub fn |^\+pub struct |^\+pub enum )/m;
+
+type CheckKey = "scripts" | "directories" | "dependencies" | "config" | "ci" | "env_vars" | "cli_flags" | "public_api";
+
+type Config = {
+  enabled?: boolean;
+  skip_prefixes?: string[];
+  checks?: Partial<Record<CheckKey, boolean>>;
+};
+
+type Run = (parts: TemplateStringsArray, ...args: ShellExpression[]) => BunShellPromise;
+
+export const UpdateDocsReminder: Plugin = async ({ $, directory }) => {
+  return {
+    "tool.execute.after": async (input, output) => {
+      if (input.tool !== "bash") return;
+      const command = typeof input.args?.command === "string" ? input.args.command : "";
+      if (!/\bgit\s+commit(\s|$)/.test(command)) return;
+
+      const reminder = await analyze($, directory);
+      if (reminder) {
+        output.output = output.output ? `${output.output}\n${reminder}` : reminder;
+      }
+    },
+  };
+};
+
+async function analyze($: BunShell, directory: string): Promise<string | null> {
+  const run: Run = (parts, ...args) =>
+    $(parts, ...args)
+      .cwd(directory)
+      .nothrow()
+      .quiet();
+
+  const gitRoot = (await run`git rev-parse --show-toplevel`).text().trim();
+  if (!gitRoot) return null;
+
+  const config = await loadConfig(gitRoot);
+  if (config.enabled === false) return null;
+
+  const head1 = await run`git rev-parse --verify HEAD~1`;
+  if (head1.exitCode !== 0) return null;
+
+  const commitMsg = (await run`git log -1 --format=%s HEAD`).text().trim();
+  if (!commitMsg) return null;
+
+  const skipPrefixes = config.skip_prefixes?.length ? config.skip_prefixes : DEFAULT_SKIP_PREFIXES;
+  const skipRegex = new RegExp(`^(${skipPrefixes.join("|")})(\\(.+\\))?:`, "i");
+  if (skipRegex.test(commitMsg)) return null;
+
+  const parents = (await run`git log -1 --format=%P HEAD`).text().trim();
+  if (parents.split(/\s+/).filter(Boolean).length > 1) return null;
+
+  const changedFiles = splitLines((await run`git diff-tree --no-commit-id --name-only -r HEAD`).text());
+  if (changedFiles.length === 0) return null;
+
+  const addedFiles = splitLines((await run`git diff-tree --no-commit-id --diff-filter=A --name-only -r HEAD`).text());
+
+  if (changedFiles.every((f) => TEST_FILE_PATTERN.test(f))) return null;
+  if (changedFiles.every((f) => DOC_FILE_PATTERN.test(f))) return null;
+
+  const enabled = (key: CheckKey) => config.checks?.[key] !== false;
+
+  const reminders: string[] = [];
+
+  if (enabled("scripts")) {
+    const matches = addedFiles.filter((f) => /^(bin|scripts|cmd)\//.test(f));
+    if (matches.length > 0) {
+      const list = matches
+        .slice(0, 3)
+        .map((f) => `    ${f}`)
+        .join("\n");
+      reminders.push(`New script(s) or command entrypoint(s) added:\n${list}\n    Consider updating README.md usage / CLI reference sections`);
+    }
+  }
+
+  if (enabled("directories")) {
+    const newTopDirs: string[] = Array.from(new Set(addedFiles.filter((f) => f.includes("/")).map((f) => f.split("/")[0] as string)));
+    const genuinelyNew: string[] = [];
+    for (const dir of newTopDirs) {
+      const prior = await run`git ls-tree --name-only HEAD~1 ${`${dir}/`}`;
+      if (prior.text().trim() === "") {
+        genuinelyNew.push(dir);
+      }
+    }
+    if (genuinelyNew.length > 0) {
+      const list = genuinelyNew.map((d) => `    ${d}/`).join("\n");
+      reminders.push(`New top-level directory detected:\n${list}\n    Consider updating CLAUDE.md structure section and README.md`);
+    }
+  }
+
+  if (enabled("dependencies")) {
+    const matches = changedFiles.filter((f) => DEPENDENCY_FILE_PATTERN.test(f));
+    if (matches.length > 0) {
+      const list = matches.map((f) => `    ${f}`).join("\n");
+      reminders.push(`Dependency files changed:\n${list}\n    Consider updating README.md installation/requirements section`);
+    }
+  }
+
+  if (enabled("config")) {
+    const matches = changedFiles.filter((f) => CONFIG_FILE_PATTERN.test(f));
+    if (matches.length > 0) {
+      const list = matches.map((f) => `    ${f}`).join("\n");
+      reminders.push(`Configuration files changed:\n${list}\n    Consider updating README.md configuration section`);
+    }
+  }
+
+  if (enabled("ci")) {
+    if (changedFiles.some((f) => CI_FILE_PATTERN.test(f))) {
+      reminders.push("CI/CD workflows changed: consider updating README.md CI section if applicable");
+    }
+  }
+
+  const sourceFiles = changedFiles.filter((f) => SOURCE_FILE_PATTERN.test(f)).slice(0, 5);
+  const sourceFilesNoRb = changedFiles.filter((f) => SOURCE_FILE_PATTERN_NO_RB.test(f)).slice(0, 5);
+
+  const additions = async (files: string[]): Promise<string> => {
+    if (files.length === 0) return "";
+    const diff = (await run`git diff HEAD~1..HEAD -- ${files}`).text();
+    return splitLines(diff)
+      .filter((l) => l.startsWith("+") && !l.startsWith("++"))
+      .slice(0, 200)
+      .join("\n");
+  };
+
+  if (enabled("env_vars") && sourceFiles.length > 0) {
+    const adds = await additions(sourceFiles);
+    if (ENV_VAR_PATTERN.test(adds)) {
+      reminders.push("New environment variable reference(s) detected: consider updating README.md configuration section");
+    }
+  }
+
+  if (enabled("cli_flags") && sourceFiles.length > 0) {
+    const adds = await additions(sourceFiles);
+    if (CLI_FLAG_PATTERN.test(adds)) {
+      reminders.push("CLI flag/argument definitions changed: consider updating README.md usage/options section");
+    }
+  }
+
+  if (enabled("public_api") && sourceFilesNoRb.length > 0) {
+    const diff = (await run`git diff HEAD~1..HEAD -- ${sourceFilesNoRb}`).text();
+    const addLines = splitLines(diff)
+      .filter((l) => l.startsWith("+") && !l.startsWith("++"))
+      .slice(0, 200)
+      .join("\n");
+    if (PUBLIC_API_PATTERN.test(addLines)) {
+      reminders.push("New public API exports detected: consider updating README.md or API documentation");
+    }
+  }
+
+  if (reminders.length === 0) return null;
+
+  const formatted = reminders.map((r) => `  - ${r}`).join("\n");
+  return ["", "Documentation reminder: the committed changes may need documentation updates:", formatted, "", "Review the relevant documentation files and update them if needed."].join("\n");
+}
+
+function splitLines(text: string): string[] {
+  return text.split("\n").filter((line) => line.length > 0);
+}
+
+async function loadConfig(gitRoot: string): Promise<Config> {
+  const configPath = `${gitRoot}/.update-docs-reminder.json`;
+  try {
+    const file = Bun.file(configPath);
+    if (!(await file.exists())) return {};
+    return (await file.json()) as Config;
+  } catch {
+    return {};
+  }
+}


### PR DESCRIPTION
## Summary

- Port `block-rm-rf`, `notify`, and `update-docs-reminder` to OpenCode as TypeScript modules under `plugins/<name>/opencode/index.ts`. Claude Code's `hooks/` and `scripts/` paths are byte-identical to before.
- Extend `bin/build-opencode-mirror` with a third pass that symlinks each `opencode/index.ts` into `dist/opencode/plugins/<name>.ts`, so the existing CI mirror-drift check covers hooks for free.
- Update each hook's README with an "Using with OpenCode" section, drop the "Hooks are not ported" limitation from the root README, and bump each hook plugin's version to `1.1.0` in both `plugin.json` and `marketplace.json`.
- Broaden the markdownlint-cli2 `node_modules` ignore to `**/node_modules/**` so the new `dist/opencode/node_modules/` tree (auto-installed by OpenCode at startup, already gitignored) does not break the lint pass.

## Test plan

- [ ] `bin/build-opencode-mirror && git diff --exit-code dist/` reports no drift.
- [ ] In a scratch repo with `OPENCODE_CONFIG_DIR=$(pwd)/dist/opencode`, run a recursive `rm` and confirm rejection with the trash remediation message.
- [ ] In the same scratch repo, make a meaningful change, run a non-skip-prefixed `git commit`, and confirm the documentation reminder appears in the agent's next turn.
- [ ] In the same scratch repo, finish a turn (Stop equivalent) and confirm a macOS notification with project + branch + last user message; trigger a permission prompt and confirm a "Needs permission…" notification.
- [ ] In Claude Code on the same checkout, confirm `block-rm-rf`, `notify`, and `update-docs-reminder` still behave exactly as before.
