### PR TITLE
Add native Codex CLI plugin support

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -497,7 +497,7 @@
       "name": "update-docs-reminder",
       "repository": "https://github.com/cboone/cboone-cc-plugins",
       "source": "./plugins/update-docs-reminder",
-      "version": "1.1.0"
+      "version": "1.2.0"
     },
     {
       "author": {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -273,7 +273,7 @@
       "name": "notify",
       "repository": "https://github.com/cboone/cboone-cc-plugins",
       "source": "./plugins/notify",
-      "version": "1.1.0"
+      "version": "1.1.1"
     },
     {
       "author": {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "metadata": {
     "description": "Claude Code commands, hooks, and skills from Christopher Boone (cboone.github.io)",
-    "version": "catalog-M55-m101-p59-n49"
+    "version": "catalog-M55-m102-p60-n49"
   },
   "name": "cboone-cc-plugins",
   "owner": {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -587,6 +587,8 @@ When adding new plugins:
 1. Create a per-plugin `README.md` in the plugin directory
 1. Update the root `README.md` with the new plugin description and details link
 
+If the plugin uses hook events that Codex CLI does not support (`Notification`, `PreCompact`, `SubagentStop`, `SessionEnd`), add a `.codex-plugin/plugin.json` sibling to `.claude-plugin/plugin.json` that points at a codex-compatible hooks file via the `hooks` field. See `plugins/notify/` for the pattern. Codex's strict hook schema (`PreToolUse`, `PermissionRequest`, `PostToolUse`, `SessionStart`, `UserPromptSubmit`, `Stop`) will reject the entire `hooks.json` if any unsupported event is present.
+
 ### README ToC Format
 
 The README table of contents uses **one entry per line** to prevent merge conflicts when multiple branches add plugins simultaneously. Skills are organized into subcategories (Git, Issues and Worktrees, Code Review, Code Quality, Scaffolding, Agents). Hooks are organized into subcategories (Security, Workflow). Each continuation link starts with `∙` (middle dot, space) at the beginning of the line:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -587,7 +587,7 @@ When adding new plugins:
 1. Create a per-plugin `README.md` in the plugin directory
 1. Update the root `README.md` with the new plugin description and details link
 
-If the plugin uses hook events that Codex CLI does not support (`Notification`, `PreCompact`, `SubagentStop`, `SessionEnd`), add a `.codex-plugin/plugin.json` sibling to `.claude-plugin/plugin.json` that points at a codex-compatible hooks file via the `hooks` field. See `plugins/notify/` for the pattern. Codex's strict hook schema (`PreToolUse`, `PermissionRequest`, `PostToolUse`, `SessionStart`, `UserPromptSubmit`, `Stop`) will reject the entire `hooks.json` if any unsupported event is present.
+Hook plugins that should work in Codex CLI must include a `.codex-plugin/plugin.json` sibling to `.claude-plugin/plugin.json` with a non-empty `hooks` field pointing at the Codex hook file, usually `./hooks/hooks.json`. If the Claude Code hook file uses hook events that Codex CLI does not support (`Notification`, `PreCompact`, `SubagentStop`, `SessionEnd`), point the Codex manifest at a separate compatible hooks file instead. See `plugins/notify/` for the split-manifest pattern. Codex's strict hook schema (`PreToolUse`, `PermissionRequest`, `PostToolUse`, `SessionStart`, `UserPromptSubmit`, `Stop`) will reject the entire hook file if any unsupported event is present.
 
 ### README ToC Format
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Claude Code Plugins
 
-A collection of plugins for [Claude Code](https://docs.anthropic.com/en/docs/claude-code) (and skills and commands for [OpenCode](https://opencode.ai/docs/skills/)), from [Christopher Boone](https://cboone.github.io).
+A collection of plugins for [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [OpenAI's Codex CLI](https://developers.openai.com/codex/cli), and [OpenCode](https://opencode.ai/docs/skills/), from [Christopher Boone](https://cboone.github.io).
 
 **Skills**
 <br>Git:
@@ -75,15 +75,26 @@ Or, from within `claude`, run:
 /plugin marketplace add cboone/cboone-cc-plugins
 ```
 
+### Using with Codex CLI
+
+This repository is also a native [Codex CLI](https://developers.openai.com/codex/cli) plugin marketplace.
+
+```bash
+codex plugin marketplace add cboone/cboone-cc-plugins
+codex plugin install <plugin-name>@cboone-cc-plugins
+```
+
+See below for [more details](#using-with-codex-cli-1) and [known limitations](#codex-cli-known-limitations).
+
 ### Using with OpenCode
 
-This repository is primarily a Claude Code plugin marketplace, but the skills, commands, and hooks also work in [OpenCode](https://opencode.ai) via a committed mirror at [`dist/opencode/`](./dist/opencode/).
+The skills, commands, and hooks also work in [OpenCode](https://opencode.ai) via a committed mirror at [`dist/opencode/`](./dist/opencode/).
 
 ```bash
 export OPENCODE_CONFIG_DIR="$(pwd)/dist/opencode"
 ```
 
-See below for [more details](#using-with-opencode-1) and [known limitations](#known-limitations).
+See below for [more details](#using-with-opencode-1) and [known limitations](#opencode-known-limitations).
 
 ## Skills
 
@@ -484,9 +495,25 @@ Analyzes git commits for changes that typically need documentation updates and p
 > **Requires:** [`jq`](https://jqlang.github.io/jq/)
 > **Details:** [README](./plugins/update-docs-reminder/README.md)
 
+## Using with Codex CLI
+
+This repository works as a native [Codex CLI](https://developers.openai.com/codex/cli) plugin marketplace. Codex reads `.claude-plugin/marketplace.json` and `.claude-plugin/plugin.json` directly, and exposes `${CLAUDE_PLUGIN_ROOT}` to plugin-bundled hook commands for backward compatibility with existing Claude Code plugins.
+
+Add the marketplace and install plugins by name:
+
+```bash
+codex plugin marketplace add cboone/cboone-cc-plugins
+codex plugin install <plugin-name>@cboone-cc-plugins
+```
+
+### Codex CLI known limitations
+
+- **`Notification` and `PreCompact` hook events are not supported.** Codex CLI's hook schema only supports `PreToolUse`, `PermissionRequest`, `PostToolUse`, `SessionStart`, `UserPromptSubmit`, and `Stop`. The `notify` plugin therefore wires only the turn-completion notification on Codex (its other Claude Code events have no Codex equivalent). For idle, elicitation, and permission alerts, enable Codex's built-in `tui.notifications = true` in `~/.codex/config.toml`. See the [`notify` plugin README](./plugins/notify/README.md) for details.
+- **No custom prompts shipped.** Codex's `~/.codex/prompts/` mechanism is officially deprecated in favor of skills. This repository ships skills (and hooks), not prompts.
+
 ## Using with OpenCode
 
-This repository is primarily a Claude Code plugin marketplace, but the skills, commands, and hooks also work in [OpenCode](https://opencode.ai) via a committed mirror at [`dist/opencode/`](./dist/opencode/).
+This repository also works with the skills, commands, and hooks in [OpenCode](https://opencode.ai) via a committed mirror at [`dist/opencode/`](./dist/opencode/).
 
 ```bash
 export OPENCODE_CONFIG_DIR="$(pwd)/dist/opencode"
@@ -494,7 +521,7 @@ export OPENCODE_CONFIG_DIR="$(pwd)/dist/opencode"
 
 When adding or removing a plugin, regenerate the mirror with `bin/build-opencode-mirror` and commit the result. CI fails if the mirror drifts from the source plugins. Hooks are mirrored to `dist/opencode/plugins/` as TypeScript plugins, sourced from each plugin's `opencode/index.ts`.
 
-### Known limitations
+### OpenCode known limitations
 
 - **`${CLAUDE_PLUGIN_ROOT}` references do not expand.** Some commands and one skill use Claude Code's `@${CLAUDE_PLUGIN_ROOT}/references/...` pattern to inline reference files at runtime. OpenCode does not expand this variable, so those inclusions appear to the agent as literal path strings rather than inlined content. The inline workflow text in each affected file still loads correctly. Affected commands: `/add-goreleaser-homebrew`, `/scaffold-go-cli`, `/scaffold-go-library`, `/scaffold-new-repo`, `/scaffold-rust-cli`, `/setup-ci`, `/setup-secret-scanning`. Affected skill: `create-plugin`. For full fidelity in these cases, run them in Claude Code.
 - **Hook event parity is approximate.** OpenCode's event model collapses several distinct Claude Code notification matchers (`idle_prompt`, `elicitation_dialog`, `permission_prompt`) and the `PreCompact` event is mapped to an experimental OpenCode hook. See each hook's README for the specific mapping.

--- a/README.md
+++ b/README.md
@@ -496,7 +496,7 @@ Analyzes git commits for changes that typically need documentation updates and p
 
 ## Using with Codex CLI
 
-This repository works as a native [Codex CLI](https://developers.openai.com/codex/cli) plugin marketplace. Codex reads `.claude-plugin/marketplace.json` for catalog metadata and `.claude-plugin/plugin.json` for shared plugin metadata. Hook registration requires a per-plugin `.codex-plugin/plugin.json` with a non-empty `hooks` path, such as `"hooks": "./hooks/hooks.json"`; this lets hook plugins point Codex at a Codex-compatible hook file. Codex exposes `${CLAUDE_PLUGIN_ROOT}` to plugin-bundled hook commands for backward compatibility with existing Claude Code plugins.
+This repository works as a native [Codex CLI](https://developers.openai.com/codex/cli) plugin marketplace. Codex reads `.claude-plugin/marketplace.json` for catalog metadata. For per-plugin metadata it prefers `.codex-plugin/plugin.json` when present and falls back to `.claude-plugin/plugin.json` otherwise. Hook registration requires a `.codex-plugin/plugin.json` with a non-empty `hooks` path (for example `"hooks": "./hooks/hooks.json"`); this lets hook plugins point Codex at a Codex-compatible hook file. Codex exposes `${CLAUDE_PLUGIN_ROOT}` to plugin-bundled hook commands for backward compatibility with existing Claude Code plugins.
 
 Add the marketplace:
 
@@ -519,6 +519,8 @@ Refresh a Git-backed marketplace after pulling repository updates or after a pub
 ```bash
 codex plugin marketplace upgrade cboone-cc-plugins
 ```
+
+`codex plugin marketplace upgrade` and `remove` take the marketplace name (`cboone-cc-plugins`, derived from the repository name), not the `owner/repo` identifier used by `add`.
 
 For a local-path marketplace, restart Codex after changing plugin files so it can rebuild cached plugin copies from the local source.
 

--- a/README.md
+++ b/README.md
@@ -81,10 +81,9 @@ This repository is also a native [Codex CLI](https://developers.openai.com/codex
 
 ```bash
 codex plugin marketplace add cboone/cboone-cc-plugins
-codex plugin install <plugin-name>@cboone-cc-plugins
 ```
 
-See below for [more details](#using-with-codex-cli-1) and [known limitations](#codex-cli-known-limitations).
+See below for [more details](#using-with-codex-cli-1), including refresh commands and [known limitations](#codex-cli-known-limitations).
 
 ### Using with OpenCode
 
@@ -497,13 +496,28 @@ Analyzes git commits for changes that typically need documentation updates and p
 
 ## Using with Codex CLI
 
-This repository works as a native [Codex CLI](https://developers.openai.com/codex/cli) plugin marketplace. Codex reads `.claude-plugin/marketplace.json` and `.claude-plugin/plugin.json` directly, and exposes `${CLAUDE_PLUGIN_ROOT}` to plugin-bundled hook commands for backward compatibility with existing Claude Code plugins.
+This repository works as a native [Codex CLI](https://developers.openai.com/codex/cli) plugin marketplace. Codex reads `.claude-plugin/marketplace.json` for catalog metadata and `.claude-plugin/plugin.json` for shared plugin metadata. Hook registration requires a per-plugin `.codex-plugin/plugin.json` with a non-empty `hooks` path, such as `"hooks": "./hooks/hooks.json"`; this lets hook plugins point Codex at a Codex-compatible hook file. Codex exposes `${CLAUDE_PLUGIN_ROOT}` to plugin-bundled hook commands for backward compatibility with existing Claude Code plugins.
 
-Add the marketplace and install plugins by name:
+Add the marketplace:
 
 ```bash
 codex plugin marketplace add cboone/cboone-cc-plugins
-codex plugin install <plugin-name>@cboone-cc-plugins
+```
+
+Codex CLI currently manages plugins at the marketplace level. In Codex CLI 0.128.0, `codex plugin` exposes the `marketplace` subcommand with `add`, `upgrade`, and `remove`; it does not expose a separate `codex plugin install` subcommand.
+
+Refresh a Git-backed marketplace after pulling repository updates or after a published release:
+
+```bash
+codex plugin marketplace upgrade cboone-cc-plugins
+```
+
+For a local-path marketplace, restart Codex after changing plugin files so it can rebuild cached plugin copies from the local source.
+
+Remove the configured marketplace by name:
+
+```bash
+codex plugin marketplace remove cboone-cc-plugins
 ```
 
 ### Codex CLI known limitations

--- a/README.md
+++ b/README.md
@@ -506,6 +506,14 @@ codex plugin marketplace add cboone/cboone-cc-plugins
 
 Codex CLI currently manages plugins at the marketplace level. In Codex CLI 0.128.0, `codex plugin` exposes the `marketplace` subcommand with `add`, `upgrade`, and `remove`; it does not expose a separate `codex plugin install` subcommand.
 
+Enable plugin-bundled hooks once per host so the `notify` and `update-docs-reminder` hooks fire:
+
+```bash
+codex features enable plugin_hooks
+```
+
+Plugin-bundled hooks are gated behind the `plugin_hooks` feature flag (listed as `under development` in Codex CLI 0.128.0). Without it the marketplace add and skill discovery still work, but `hooks/hooks.json` files inside installed plugins are silently ignored.
+
 Refresh a Git-backed marketplace after pulling repository updates or after a published release:
 
 ```bash
@@ -522,6 +530,7 @@ codex plugin marketplace remove cboone-cc-plugins
 
 ### Codex CLI known limitations
 
+- **Plugin-bundled hooks are gated behind a feature flag.** `plugin_hooks` is `under development` in Codex CLI 0.128.0 and is `false` by default. Run `codex features enable plugin_hooks` once before expecting `notify` or `update-docs-reminder` to fire on Codex; see the install section above.
 - **`Notification` and `PreCompact` hook events are not supported.** Codex CLI's hook schema only supports `PreToolUse`, `PermissionRequest`, `PostToolUse`, `SessionStart`, `UserPromptSubmit`, and `Stop`. The `notify` plugin therefore wires only the turn-completion notification on Codex (its other Claude Code events have no Codex equivalent). For idle, elicitation, and permission alerts, enable Codex's built-in `tui.notifications = true` in `~/.codex/config.toml`. See the [`notify` plugin README](./plugins/notify/README.md) for details.
 - **No custom prompts shipped.** Codex's `~/.codex/prompts/` mechanism is officially deprecated in favor of skills. This repository ships skills (and hooks), not prompts.
 

--- a/bin/validate-plugins
+++ b/bin/validate-plugins
@@ -12,6 +12,24 @@ function error() {
   errors=$((errors + 1))
 }
 
+# Deprecated or Claude-only hook plugins that intentionally skip Codex hook registration.
+# block-rm-rf is pending removal, so it remains exempt instead of receiving Codex compatibility work.
+CODEX_HOOK_MANIFEST_EXEMPTIONS=("block-rm-rf")
+readonly CODEX_HOOK_MANIFEST_EXEMPTIONS
+
+function is_codex_hook_manifest_exempt() {
+  local plugin_name="${1}"
+  local exempt_name
+
+  for exempt_name in "${CODEX_HOOK_MANIFEST_EXEMPTIONS[@]}"; do
+    if [[ "${plugin_name}" == "${exempt_name}" ]]; then
+      return 0
+    fi
+  done
+
+  return 1
+}
+
 # ─── 1. Every plugin directory has plugin.json ───────────────────────────────
 
 for dir in plugins/*/; do
@@ -223,6 +241,32 @@ for dir in plugins/*/; do
       error "Plugin '${local_name}': field '${field}' differs between .claude-plugin/plugin.json (${claude_value}) and .codex-plugin/plugin.json (${codex_value})"
     fi
   done
+done
+
+# ─── 14. Hook plugins declare Codex hook registration ───────────────────────
+
+for dir in plugins/*/; do
+  local_name="$(basename "${dir}")"
+  hooks_json="${dir}hooks/hooks.json"
+  codex_json="${dir}.codex-plugin/plugin.json"
+
+  if [[ ! -f "${hooks_json}" ]]; then
+    continue
+  fi
+
+  if is_codex_hook_manifest_exempt "${local_name}"; then
+    continue
+  fi
+
+  if [[ ! -f "${codex_json}" ]]; then
+    error "Plugin '${local_name}': hooks/hooks.json requires .codex-plugin/plugin.json for Codex hook registration"
+    continue
+  fi
+
+  codex_hooks="$(jq -r 'if (.hooks | type) == "string" then .hooks else "" end' "${codex_json}")"
+  if [[ -z "${codex_hooks}" ]]; then
+    error "Plugin '${local_name}': .codex-plugin/plugin.json missing non-empty string field 'hooks'"
+  fi
 done
 
 # ─── Summary ────────────────────────────────────────────────────────────────

--- a/bin/validate-plugins
+++ b/bin/validate-plugins
@@ -167,6 +167,64 @@ else
   fi
 fi
 
+# ─── 11. .codex-plugin/plugin.json name matches directory name ──────────────
+
+for dir in plugins/*/; do
+  local_name="$(basename "${dir}")"
+  codex_json="${dir}.codex-plugin/plugin.json"
+  if [[ ! -f "${codex_json}" ]]; then
+    continue
+  fi
+
+  json_name="$(jq -r '.name' "${codex_json}")"
+  if [[ "${json_name}" != "${local_name}" ]]; then
+    error "Plugin '${local_name}': .codex-plugin/plugin.json name '${json_name}' does not match directory name"
+  fi
+done
+
+# ─── 12. Required fields in .codex-plugin/plugin.json ───────────────────────
+
+for dir in plugins/*/; do
+  local_name="$(basename "${dir}")"
+  codex_json="${dir}.codex-plugin/plugin.json"
+  if [[ ! -f "${codex_json}" ]]; then
+    continue
+  fi
+
+  for field in "${PLUGIN_REQUIRED_FIELDS[@]}"; do
+    value="$(jq -r ".${field} // empty" "${codex_json}")"
+    if [[ -z "${value}" ]]; then
+      error "Plugin '${local_name}': .codex-plugin/plugin.json missing required field '${field}'"
+    fi
+  done
+done
+
+# ─── 13. Dual manifests agree on shared fields ──────────────────────────────
+# When both .claude-plugin/plugin.json and .codex-plugin/plugin.json exist,
+# they must agree on identity and metadata fields. `description` and `hooks`
+# are allowed to differ (description for system-specific phrasing; hooks is
+# the whole reason for a separate codex manifest).
+
+DUAL_MANIFEST_SHARED_FIELDS=("author" "homepage" "keywords" "license" "name" "repository" "version")
+readonly DUAL_MANIFEST_SHARED_FIELDS
+
+for dir in plugins/*/; do
+  local_name="$(basename "${dir}")"
+  claude_json="${dir}.claude-plugin/plugin.json"
+  codex_json="${dir}.codex-plugin/plugin.json"
+  if [[ ! -f "${claude_json}" ]] || [[ ! -f "${codex_json}" ]]; then
+    continue
+  fi
+
+  for field in "${DUAL_MANIFEST_SHARED_FIELDS[@]}"; do
+    claude_value="$(jq -cS ".${field}" "${claude_json}")"
+    codex_value="$(jq -cS ".${field}" "${codex_json}")"
+    if [[ "${claude_value}" != "${codex_value}" ]]; then
+      error "Plugin '${local_name}': field '${field}' differs between .claude-plugin/plugin.json (${claude_value}) and .codex-plugin/plugin.json (${codex_value})"
+    fi
+  done
+done
+
 # ─── Summary ────────────────────────────────────────────────────────────────
 
 if [[ ${errors} -gt 0 ]]; then

--- a/docs/plans/todo/2026-05-02-codex-cli-native-plugins.md
+++ b/docs/plans/todo/2026-05-02-codex-cli-native-plugins.md
@@ -1,0 +1,161 @@
+# 2026-05-02: Make plugins installable natively via Codex CLI
+
+## Context
+
+This repository ships Claude Code plugins (skills + three hook plugins) and produces a parallel `dist/opencode/` mirror of the skills for [OpenCode](https://opencode.ai), since OpenCode has no native plugin marketplace and instead consumes the `OPENCODE_CONFIG_DIR` environment variable. A separate worktree is in progress to extend the OpenCode mirror with hooks support.
+
+OpenAI's [Codex CLI](https://developers.openai.com/codex/cli) takes the opposite approach: it has its own first-class plugin marketplace system and was designed for Claude Code source compatibility. The relevant compatibility points were verified directly against the openai/codex source (verified at `main` on 2026-05-02):
+
+- **Marketplace discovery** (`codex-rs/core-plugins/src/marketplace.rs`): codex scans both `.agents/plugins/marketplace.json` and `.claude-plugin/marketplace.json`, returning the first one found. Our existing `.claude-plugin/marketplace.json` is read as-is.
+- **Per-plugin manifest discovery** (`codex-rs/utils/plugins/src/plugin_namespace.rs`): codex scans both `.codex-plugin/plugin.json` and `.claude-plugin/plugin.json`, returning the first one found. With both present, `.codex-plugin/` wins. Our existing `.claude-plugin/plugin.json` files are read as-is when no `.codex-plugin/` sibling exists.
+- **Hook environment variables** (`codex-rs/hooks/src/engine/discovery.rs`): codex sets `PLUGIN_ROOT`, `CLAUDE_PLUGIN_ROOT` (with the comment `// For OOTB compat with existing plugins that use this env var.`), `PLUGIN_DATA`, and `CLAUDE_PLUGIN_DATA` in the environment of plugin-bundled hook commands. Existing `${CLAUDE_PLUGIN_ROOT}/scripts/...` references resolve correctly with no rewrite.
+- **Hook events** (`codex-rs/hooks/src/schema.rs`): codex defines a strict `HookEventNameWire` enum with exactly six variants: `PreToolUse`, `PermissionRequest`, `PostToolUse`, `SessionStart`, `UserPromptSubmit`, `Stop`. Claude-only events (`Notification`, `PreCompact`, `SubagentStop`, `SessionEnd`) are not in the enum and will fail to deserialize, breaking the entire `hooks.json` for that plugin on codex.
+- **Plugin install:** `codex plugin marketplace add cboone/cboone-cc-plugins` clones the repo into `~/.codex/plugins/cache/cboone-cc-plugins/<plugin>/<version>/` and reads our existing `.claude-plugin/marketplace.json`. Then `codex plugin install <name>@cboone-cc-plugins` activates the plugin.
+
+Net effect: most of this repository is already a working codex plugin marketplace. The `dist/codex/` mirror, `bin/build-codex-mirror`, and `bin/install-codex-hooks` ideas from the previous draft of this plan are unnecessary and have been dropped.
+
+The only real compatibility gap is the `notify` plugin, whose `hooks/hooks.json` uses the Claude-only events `Notification` (3 matchers) and `PreCompact`. Loading it under codex would fail at deserialize time. The other two hook plugins are unaffected:
+
+| Plugin                 | Events used                               | Codex status                                                              |
+| ---------------------- | ----------------------------------------- | ------------------------------------------------------------------------- |
+| `block-rm-rf`          | `PreToolUse` matcher `Bash`               | Out of scope for this plan: user is removing the plugin in separate work. |
+| `update-docs-reminder` | `PostToolUse` matcher `Bash`              | Already compatible. No changes required.                                  |
+| `notify`               | `Notification` (×3), `PreCompact`, `Stop` | Codex rejects the file. Needs a codex-specific hooks variant.             |
+
+Goal: each plugin in this repo installs cleanly via `codex plugin marketplace add cboone/cboone-cc-plugins` and `codex plugin install <name>@cboone-cc-plugins`. README documents the codex install path. CI verifies dual-manifest consistency for plugins that need it.
+
+## Approach
+
+Lean on codex's native Claude-style compatibility. Touch only the files that need to differ:
+
+1. **Add a `.codex-plugin/plugin.json` for `notify` only**, pointing at a codex-compatible hooks file (`hooks/codex.hooks.json`) that contains the `Stop` event only. Claude Code continues to use the existing `.claude-plugin/plugin.json` and the original `hooks/hooks.json`. All other plugins keep their single `.claude-plugin/plugin.json`.
+2. **Document codex's `notify = [...]` config and `tui.notifications` settings** in `plugins/notify/README.md` as the way codex users get the `Notification`/`PreCompact` behavior they would otherwise lose. These are codex-native mechanisms, not part of our plugin.
+3. **Update the top-level `README.md`** with a "Using with Codex CLI" section parallel to the OpenCode one, with its own self-contained "Known limitations" subsection (per earlier user direction: do not merge with the OpenCode limitations).
+4. **Update `CLAUDE.md`** so the "When adding new plugins" checklist mentions the codex compat consideration (only relevant when a plugin uses Claude-only hook events).
+5. **Add CI validation** for dual-manifest consistency: when a plugin has both `.claude-plugin/plugin.json` and `.codex-plugin/plugin.json`, their `name`, `version`, `author`, `homepage`, `repository`, `license`, and `description` must match. Extend `bin/validate-plugins`.
+6. **Bump `notify` plugin version** (minor) and **mirror in `marketplace.json`**, since the notify plugin gains codex-specific behavior. Per `CLAUDE.md` versioning rules: "Minor: new capabilities or meaningful behavior changes."
+7. **Do not bump `metadata.version` in `marketplace.json`** for this work — no plugins are added or removed from the catalog.
+
+## Files to create
+
+### `plugins/notify/.codex-plugin/plugin.json`
+
+A minimal codex-specific manifest. Mirrors the existing `.claude-plugin/plugin.json` byte-for-byte except for the addition of an explicit `hooks` field:
+
+```json
+{
+  "author": { "name": "Christopher Boone" },
+  "description": "Notifies you when Codex finishes a task or needs your attention.",
+  "homepage": "https://github.com/cboone/cboone-cc-plugins",
+  "hooks": "./hooks/codex.hooks.json",
+  "keywords": ["alerts", "macos", "notifications"],
+  "license": "MIT",
+  "name": "notify",
+  "repository": "https://github.com/cboone/cboone-cc-plugins",
+  "version": "1.1.0"
+}
+```
+
+Note: `description` mentions Codex instead of Claude. Everything else matches the Claude manifest. Version bumps to `1.1.0` (see versioning section).
+
+### `plugins/notify/hooks/codex.hooks.json`
+
+Codex-compatible hooks file. Contains only the `Stop` event from the original `hooks.json` (verbatim, including the `${CLAUDE_PLUGIN_ROOT}` reference, which codex sets correctly):
+
+```json
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/notify stop",
+            "type": "command"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+The dropped `Notification` and `PreCompact` events are documented in `plugins/notify/README.md` as covered by codex's native `notify = [...]` and `tui.notifications` configuration.
+
+## Files to modify
+
+### `plugins/notify/.claude-plugin/plugin.json`
+
+Bump `version` from `1.0.3` to `1.1.0`. No other changes.
+
+### `plugins/notify/README.md`
+
+Add a "Using with Codex CLI" section that explains:
+
+- Install via `codex plugin marketplace add cboone/cboone-cc-plugins` then `codex plugin install notify@cboone-cc-plugins`.
+- The plugin only wires the `Stop` event on codex (turn-end notification), since codex's hook schema does not include `Notification` or `PreCompact`.
+- For idle/elicitation/permission notifications, recommend codex's built-in `tui.notifications = true` (and `tui.notification_method`, `tui.notification_condition`) in `~/.codex/config.toml`.
+- Do not mention codex's `notify = [...]` config: it is officially deprecated in the codex source (`codex-rs/config/src/config_toml.rs`: "Deprecated optional external command to spawn for end-user notifications.") in favor of lifecycle hooks. Our `Stop` hook is the same mechanism for new automation.
+
+### `.claude-plugin/marketplace.json`
+
+Bump the `notify` entry's `version` from `1.0.3` to `1.1.0`. No other changes (no `metadata.version` bump).
+
+### `README.md`
+
+Two parallel insertions:
+
+1. **Top-of-README pointer** (after the existing OpenCode subsection at lines 78-86). New "Using with Codex CLI" subsection: a heading, a one-sentence description, a fenced `bash` block with `codex plugin marketplace add cboone/cboone-cc-plugins` and `codex plugin install <plugin-name>@cboone-cc-plugins`, and a "see below" pointer linking to the detailed section and to the codex known-limitations subsection.
+
+2. **Tail-of-README detailed section** (new section after the existing OpenCode section at lines 487-500, before `## License`). Sibling to "Using with OpenCode," same depth and structure, **separate** "Known limitations" subsection (no merge with the OpenCode one). Includes:
+
+   - `codex plugin marketplace add` / `codex plugin install` examples.
+   - Note that codex reads `.claude-plugin/marketplace.json` and `.claude-plugin/plugin.json` natively (cite the upstream source paths once for credibility), and sets `CLAUDE_PLUGIN_ROOT` for hook commands "for OOTB compat with existing plugins."
+   - **Codex CLI known limitations** subsection (scoped to this section only):
+     - **No `Notification` or `PreCompact` events.** Codex has a strict hook event enum (`PreToolUse`, `PermissionRequest`, `PostToolUse`, `SessionStart`, `UserPromptSubmit`, `Stop`). The `notify` plugin therefore wires only the `Stop` hook on codex; for idle / elicitation / permission notifications, enable codex's native `tui.notifications` in `~/.codex/config.toml`.
+     - **No custom prompts shipped.** Codex's `~/.codex/prompts/` mechanism is documented as deprecated; the repo only ships skills and hooks.
+
+### `CLAUDE.md`
+
+Update the "When adding new plugins" section (currently 5 numbered steps) with one extra bullet: "If the plugin has hooks that use Claude-only events (`Notification`, `PreCompact`, `SubagentStop`, `SessionEnd`), add a `.codex-plugin/plugin.json` that points at a codex-compatible hooks variant. See `plugins/notify/` for the pattern."
+
+### `bin/validate-plugins`
+
+Extend with a new validation rule: for each plugin directory, if both `.claude-plugin/plugin.json` and `.codex-plugin/plugin.json` exist, verify that these fields match across the two: `name`, `version`, `author`, `homepage`, `repository`, `license`, `keywords`. The `description` and `hooks` fields are allowed to differ (description for system-specific phrasing; hooks because that's the whole point). Use `jq` (already a dep). Failure prints `::error::` and increments the existing error counter.
+
+## Files explicitly NOT changed
+
+- **`bin/build-opencode-mirror`, `dist/opencode/`, the OpenCode CI step:** unchanged. OpenCode has no native plugin marketplace; the mirror remains the right approach for it.
+- **No `dist/codex/`, no `bin/build-codex-mirror`, no `bin/install-codex-hooks`:** none of these get created. Codex's native plugin install handles distribution.
+- **`.agents/plugins/marketplace.json`:** not added. Codex reads `.claude-plugin/marketplace.json` directly per the source (`MARKETPLACE_MANIFEST_RELATIVE_PATHS`); a parallel file would just be dead weight to keep in sync.
+- **All other plugins' `.claude-plugin/plugin.json`:** unchanged. Codex reads them as-is (verified at `plugin_namespace.rs:DISCOVERABLE_PLUGIN_MANIFEST_PATHS`). No `.codex-plugin/plugin.json` siblings needed except for `notify`.
+- **`plugins/notify/hooks/hooks.json`:** unchanged. Claude Code continues to use it.
+- **`plugins/notify/scripts/notify`:** unchanged. The same script is used by both systems via `${CLAUDE_PLUGIN_ROOT}` resolution.
+- **`block-rm-rf`:** out of scope. User is removing the plugin in separate work.
+- **`update-docs-reminder`:** unchanged. Already codex-compatible.
+- **`.gitignore`, `.prettierignore`, `cli.markdownlint-cli2.jsonc`:** no change.
+
+## Verification
+
+End-to-end sanity, in order:
+
+1. **Static checks pass.** `yarn lint`, `bin/validate-json`, `bin/validate-plugins` (with the new dual-manifest consistency rule) all succeed locally and in CI.
+2. **Marketplace structure check.** `jq '.plugins[] | select(.name == "notify") | .version' .claude-plugin/marketplace.json` returns `"1.1.0"`. `cmp <(jq -S 'del(.description, .hooks)' plugins/notify/.claude-plugin/plugin.json) <(jq -S 'del(.description, .hooks)' plugins/notify/.codex-plugin/plugin.json)` returns no diff.
+3. **JSON syntax of new files.** `jq . plugins/notify/.codex-plugin/plugin.json plugins/notify/hooks/codex.hooks.json` exits 0.
+4. **Local marketplace install (codex CLI required, manual).** From a separate clean directory:
+   - `codex plugin marketplace add /path/to/this/repo` (local source).
+   - `codex plugin list` shows all our plugins under the `cboone-cc-plugins` marketplace.
+   - `codex plugin install commit@cboone-cc-plugins`, then in a codex session run `/skills` and confirm `commit` appears with the expected description.
+   - `codex plugin install update-docs-reminder@cboone-cc-plugins` and trigger a Bash tool call from codex — confirm the `PostToolUse` hook fires (script writes its log line; `${CLAUDE_PLUGIN_ROOT}` resolves to the cached plugin path).
+   - `codex plugin install notify@cboone-cc-plugins` and end a turn — confirm the `Stop` hook fires. Verify codex does not log a deserialize error for `Notification`/`PreCompact` (since the codex-flavored manifest points at `hooks/codex.hooks.json` which has neither).
+5. **Negative test for dual-manifest divergence.** Temporarily edit `plugins/notify/.codex-plugin/plugin.json` to change `version` to `9.9.9` and confirm `bin/validate-plugins` flags the inconsistency. Revert.
+6. **Remote marketplace install (manual, after merge).** Once merged: `codex plugin marketplace add cboone/cboone-cc-plugins` from the repo root URL succeeds.
+
+## Out-of-scope but adjacent
+
+- **GitHub Actions test job that exercises codex install.** Could add later if a codex CLI is reliably installable in CI. Not part of this PR.
+- **`.agents/plugins/marketplace.json` parallel catalog.** Codex's source treats it as the preferred path. We could generate it from `.claude-plugin/marketplace.json` for forward-compat, but every byte gets validated by both mechanisms today via the second alternate path; defer until codex deprecates the Claude-style fallback.
+
+## Decisions
+
+- **System-specific phrasing kept in dual `description` fields** (Claude vs Codex). The validate-plugins consistency check ignores `description` so this is fine.
+- **Codex's `notify = [...]` config is not documented.** Deprecated upstream; the `Stop` hook covers the same case via the current API.

--- a/docs/plans/todo/2026-05-02-codex-cli-native-plugins.md
+++ b/docs/plans/todo/2026-05-02-codex-cli-native-plugins.md
@@ -32,9 +32,9 @@ Lean on codex's native Claude-style compatibility. Touch only the files that nee
 2. **Document codex's `notify = [...]` config and `tui.notifications` settings** in `plugins/notify/README.md` as the way codex users get the `Notification`/`PreCompact` behavior they would otherwise lose. These are codex-native mechanisms, not part of our plugin.
 3. **Update the top-level `README.md`** with a "Using with Codex CLI" section parallel to the OpenCode one, with its own self-contained "Known limitations" subsection (per earlier user direction: do not merge with the OpenCode limitations).
 4. **Update `CLAUDE.md`** so the "When adding new plugins" checklist mentions the codex compat consideration (only relevant when a plugin uses Claude-only hook events).
-5. **Add CI validation** for dual-manifest consistency: when a plugin has both `.claude-plugin/plugin.json` and `.codex-plugin/plugin.json`, their `name`, `version`, `author`, `homepage`, `repository`, `license`, and `description` must match. Extend `bin/validate-plugins`.
+5. **Add CI validation** for dual-manifest consistency: when a plugin has both `.claude-plugin/plugin.json` and `.codex-plugin/plugin.json`, their `name`, `version`, `author`, `homepage`, `repository`, `license`, and `keywords` must match. The `description` and `hooks` fields are allowed to differ (description for system-specific phrasing, hooks because divergence is the whole point). Extend `bin/validate-plugins`.
 6. **Bump `notify` plugin version** (minor) and **mirror in `marketplace.json`**, since the notify plugin gains codex-specific behavior. Per `CLAUDE.md` versioning rules: "Minor: new capabilities or meaningful behavior changes."
-7. **Do not bump `metadata.version` in `marketplace.json`** for this work — no plugins are added or removed from the catalog.
+7. **Recompute `metadata.version` in `marketplace.json`** to reflect the new sum of plugin version components. `bin/validate-plugins` enforces that `metadata.version` matches the computed `catalog-M<sum>-m<sum>-p<sum>-n<count>` value, so any plugin version bump in this PR requires recomputing the catalog state tag.
 
 ## Files to create
 

--- a/docs/plans/todo/2026-05-02-codex-cli-native-plugins.md
+++ b/docs/plans/todo/2026-05-02-codex-cli-native-plugins.md
@@ -10,7 +10,7 @@ OpenAI's [Codex CLI](https://developers.openai.com/codex/cli) takes the opposite
 - **Per-plugin manifest discovery** (`codex-rs/utils/plugins/src/plugin_namespace.rs`): codex scans both `.codex-plugin/plugin.json` and `.claude-plugin/plugin.json`, returning the first one found. With both present, `.codex-plugin/` wins. Our existing `.claude-plugin/plugin.json` files are read as-is when no `.codex-plugin/` sibling exists.
 - **Hook environment variables** (`codex-rs/hooks/src/engine/discovery.rs`): codex sets `PLUGIN_ROOT`, `CLAUDE_PLUGIN_ROOT` (with the comment `// For OOTB compat with existing plugins that use this env var.`), `PLUGIN_DATA`, and `CLAUDE_PLUGIN_DATA` in the environment of plugin-bundled hook commands. Existing `${CLAUDE_PLUGIN_ROOT}/scripts/...` references resolve correctly with no rewrite.
 - **Hook events** (`codex-rs/hooks/src/schema.rs`): codex defines a strict `HookEventNameWire` enum with exactly six variants: `PreToolUse`, `PermissionRequest`, `PostToolUse`, `SessionStart`, `UserPromptSubmit`, `Stop`. Claude-only events (`Notification`, `PreCompact`, `SubagentStop`, `SessionEnd`) are not in the enum and will fail to deserialize, breaking the entire `hooks.json` for that plugin on codex.
-- **Plugin install:** `codex plugin marketplace add cboone/cboone-cc-plugins` clones the repo into `~/.codex/plugins/cache/cboone-cc-plugins/<plugin>/<version>/` and reads our existing `.claude-plugin/marketplace.json`. Then `codex plugin install <name>@cboone-cc-plugins` activates the plugin.
+- **Plugin install:** `codex plugin marketplace add cboone/cboone-cc-plugins` clones the repo into `~/.codex/plugins/cache/cboone-cc-plugins/<plugin>/<version>/` and reads our existing `.claude-plugin/marketplace.json`. Codex CLI 0.128.0 does not expose a separate `codex plugin install` subcommand; `marketplace add` is the activation step. Plugin-bundled hooks are additionally gated behind the `plugin_hooks` feature flag (`codex features enable plugin_hooks`).
 
 Net effect: most of this repository is already a working codex plugin marketplace. The `dist/codex/` mirror, `bin/build-codex-mirror`, and `bin/install-codex-hooks` ideas from the previous draft of this plan are unnecessary and have been dropped.
 
@@ -22,7 +22,7 @@ The only real compatibility gap is the `notify` plugin, whose `hooks/hooks.json`
 | `update-docs-reminder` | `PostToolUse` matcher `Bash`              | Already compatible. No changes required.                                  |
 | `notify`               | `Notification` (×3), `PreCompact`, `Stop` | Codex rejects the file. Needs a codex-specific hooks variant.             |
 
-Goal: each plugin in this repo installs cleanly via `codex plugin marketplace add cboone/cboone-cc-plugins` and `codex plugin install <name>@cboone-cc-plugins`. README documents the codex install path. CI verifies dual-manifest consistency for plugins that need it.
+Goal: each plugin in this repo installs cleanly via `codex plugin marketplace add cboone/cboone-cc-plugins` (the only plugin install path exposed in Codex CLI 0.128.0). README documents the codex install path. CI verifies dual-manifest consistency for plugins that need it.
 
 ## Approach
 
@@ -91,7 +91,7 @@ Bump `version` from `1.0.3` to `1.1.0`. No other changes.
 
 Add a "Using with Codex CLI" section that explains:
 
-- Install via `codex plugin marketplace add cboone/cboone-cc-plugins` then `codex plugin install notify@cboone-cc-plugins`.
+- Install via `codex plugin marketplace add cboone/cboone-cc-plugins` (Codex CLI 0.128.0 has no separate `codex plugin install` subcommand). Plugin-bundled hooks also require `codex features enable plugin_hooks`.
 - The plugin only wires the `Stop` event on codex (turn-end notification), since codex's hook schema does not include `Notification` or `PreCompact`.
 - For idle/elicitation/permission notifications, recommend codex's built-in `tui.notifications = true` (and `tui.notification_method`, `tui.notification_condition`) in `~/.codex/config.toml`.
 - Do not mention codex's `notify = [...]` config: it is officially deprecated in the codex source (`codex-rs/config/src/config_toml.rs`: "Deprecated optional external command to spawn for end-user notifications.") in favor of lifecycle hooks. Our `Stop` hook is the same mechanism for new automation.
@@ -104,11 +104,11 @@ Bump the `notify` entry's `version` from `1.0.3` to `1.1.0`. No other changes (n
 
 Two parallel insertions:
 
-1. **Top-of-README pointer** (after the existing OpenCode subsection at lines 78-86). New "Using with Codex CLI" subsection: a heading, a one-sentence description, a fenced `bash` block with `codex plugin marketplace add cboone/cboone-cc-plugins` and `codex plugin install <plugin-name>@cboone-cc-plugins`, and a "see below" pointer linking to the detailed section and to the codex known-limitations subsection.
+1. **Top-of-README pointer** (after the existing OpenCode subsection at lines 78-86). New "Using with Codex CLI" subsection: a heading, a one-sentence description, a fenced `bash` block with `codex plugin marketplace add cboone/cboone-cc-plugins`, and a "see below" pointer linking to the detailed section and to the codex known-limitations subsection.
 
 2. **Tail-of-README detailed section** (new section after the existing OpenCode section at lines 487-500, before `## License`). Sibling to "Using with OpenCode," same depth and structure, **separate** "Known limitations" subsection (no merge with the OpenCode one). Includes:
 
-   - `codex plugin marketplace add` / `codex plugin install` examples.
+   - `codex plugin marketplace add` example (Codex CLI 0.128.0 has no separate `codex plugin install` subcommand; `marketplace add` is the activation step). Note that plugin-bundled hooks require `codex features enable plugin_hooks` (the flag is `under development` and `false` by default in 0.128.0).
    - Note that codex reads `.claude-plugin/marketplace.json` and `.claude-plugin/plugin.json` natively (cite the upstream source paths once for credibility), and sets `CLAUDE_PLUGIN_ROOT` for hook commands "for OOTB compat with existing plugins."
    - **Codex CLI known limitations** subsection (scoped to this section only):
      - **No `Notification` or `PreCompact` events.** Codex has a strict hook event enum (`PreToolUse`, `PermissionRequest`, `PostToolUse`, `SessionStart`, `UserPromptSubmit`, `Stop`). The `notify` plugin therefore wires only the `Stop` hook on codex; for idle / elicitation / permission notifications, enable codex's native `tui.notifications` in `~/.codex/config.toml`.
@@ -143,10 +143,10 @@ End-to-end sanity, in order:
 3. **JSON syntax of new files.** `jq . plugins/notify/.codex-plugin/plugin.json plugins/notify/hooks/codex.hooks.json` exits 0.
 4. **Local marketplace install (codex CLI required, manual).** From a separate clean directory:
    - `codex plugin marketplace add /path/to/this/repo` (local source).
-   - `codex plugin list` shows all our plugins under the `cboone-cc-plugins` marketplace.
-   - `codex plugin install commit@cboone-cc-plugins`, then in a codex session run `/skills` and confirm `commit` appears with the expected description.
-   - `codex plugin install update-docs-reminder@cboone-cc-plugins` and trigger a Bash tool call from codex — confirm the `PostToolUse` hook fires (script writes its log line; `${CLAUDE_PLUGIN_ROOT}` resolves to the cached plugin path).
-   - `codex plugin install notify@cboone-cc-plugins` and end a turn — confirm the `Stop` hook fires. Verify codex does not log a deserialize error for `Notification`/`PreCompact` (since the codex-flavored manifest points at `hooks/codex.hooks.json` which has neither).
+   - `codex plugin list` shows all our plugins under the `cboone-cc-plugins` marketplace. (Codex CLI 0.128.0 has no separate `codex plugin install` subcommand; `marketplace add` is the activation step.)
+   - In a codex session run `/skills` and confirm `commit` appears with the expected description.
+   - With `codex features enable plugin_hooks` set, trigger a Bash tool call from codex, confirm the `update-docs-reminder` `PostToolUse` hook fires (script writes its log line; `${CLAUDE_PLUGIN_ROOT}` resolves to the cached plugin path).
+   - End a turn in codex and confirm the `notify` `Stop` hook fires. Verify codex does not log a deserialize error for `Notification`/`PreCompact` (since the codex-flavored manifest points at `hooks/codex.hooks.json` which has neither).
 5. **Negative test for dual-manifest divergence.** Temporarily edit `plugins/notify/.codex-plugin/plugin.json` to change `version` to `9.9.9` and confirm `bin/validate-plugins` flags the inconsistency. Revert.
 6. **Remote marketplace install (manual, after merge).** Once merged: `codex plugin marketplace add cboone/cboone-cc-plugins` from the repo root URL succeeds.
 

--- a/plugins/notify/.claude-plugin/plugin.json
+++ b/plugins/notify/.claude-plugin/plugin.json
@@ -8,5 +8,5 @@
   "license": "MIT",
   "name": "notify",
   "repository": "https://github.com/cboone/cboone-cc-plugins",
-  "version": "1.1.0"
+  "version": "1.1.1"
 }

--- a/plugins/notify/.codex-plugin/plugin.json
+++ b/plugins/notify/.codex-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "author": {
+    "name": "Christopher Boone"
+  },
+  "description": "Notifies you when Codex finishes a task or needs your attention.",
+  "homepage": "https://github.com/cboone/cboone-cc-plugins",
+  "hooks": "./hooks/codex.hooks.json",
+  "keywords": ["alerts", "macos", "notifications"],
+  "license": "MIT",
+  "name": "notify",
+  "repository": "https://github.com/cboone/cboone-cc-plugins",
+  "version": "1.1.0"
+}

--- a/plugins/notify/.codex-plugin/plugin.json
+++ b/plugins/notify/.codex-plugin/plugin.json
@@ -9,5 +9,5 @@
   "license": "MIT",
   "name": "notify",
   "repository": "https://github.com/cboone/cboone-cc-plugins",
-  "version": "1.1.0"
+  "version": "1.1.1"
 }

--- a/plugins/notify/README.md
+++ b/plugins/notify/README.md
@@ -21,8 +21,9 @@ Then select **Notify** from the available plugins.
 
 ```bash
 codex plugin marketplace add cboone/cboone-cc-plugins
-codex plugin install notify@cboone-cc-plugins
 ```
+
+Codex CLI manages this plugin through the marketplace. For a Git-backed marketplace, refresh it after repository updates with `codex plugin marketplace upgrade cboone-cc-plugins`. For a local-path marketplace, restart Codex after changing plugin files so it can rebuild cached plugin copies from the local source.
 
 ### Using with OpenCode
 

--- a/plugins/notify/README.md
+++ b/plugins/notify/README.md
@@ -1,11 +1,13 @@
 # Notify (macOS)
 
-Sends macOS notifications when Claude finishes a task or needs your attention.
+Sends macOS notifications when the agent finishes a task or needs your attention.
 
 **Type:** Hook
 **Requires:** [`terminal-notifier`](https://github.com/julienXX/terminal-notifier). Install via [Homebrew](https://brew.sh): `brew install terminal-notifier`
 
 ## Installation
+
+### Claude Code
 
 Add the [`cboone/cboone-cc-plugins`](https://github.com/cboone/cboone-cc-plugins) marketplace in Claude Code:
 
@@ -14,6 +16,13 @@ Add the [`cboone/cboone-cc-plugins`](https://github.com/cboone/cboone-cc-plugins
 ```
 
 Then select **Notify** from the available plugins.
+
+### Codex CLI
+
+```bash
+codex plugin marketplace add cboone/cboone-cc-plugins
+codex plugin install notify@cboone-cc-plugins
+```
 
 ### Using with OpenCode
 
@@ -31,9 +40,13 @@ The standalone "Waiting for input…" notification (Claude Code's `Notification:
 
 ## What It Does
 
-Delivers native macOS notifications so you can work in other apps while Claude runs. Notifies you when Claude is waiting for input, needs a permission decision, needs your response to a question, is about to auto-compact, or has finished its current task.
+Delivers native macOS notifications so you can work in other apps while the agent runs.
 
 ## When It Fires
+
+### Claude Code
+
+Notifies you when Claude is waiting for input, needs a permission decision, needs your response to a question, is about to auto-compact, or has finished its current task.
 
 | Event                       | Notification                |
 | --------------------------- | --------------------------- |
@@ -42,6 +55,23 @@ Delivers native macOS notifications so you can work in other apps while Claude r
 | `Notification` (permission) | "Needs permission..."       |
 | `PreCompact` (auto)         | "Auto-compacting..."        |
 | `Stop`                      | Task completed notification |
+
+### Codex CLI
+
+Codex's hook schema only supports the `Stop` event for our use cases (the `Notification` and `PreCompact` events do not exist). The plugin therefore wires the turn-completion notification only.
+
+| Event  | Notification                |
+| ------ | --------------------------- |
+| `Stop` | Task completed notification |
+
+For the cases that fall outside `Stop`, codex provides built-in TUI notifications. Enable them in `~/.codex/config.toml`:
+
+```toml
+[tui]
+notifications = true
+```
+
+See [`tui.notifications`, `tui.notification_method`, `tui.notification_condition`](https://developers.openai.com/codex/config-advanced) for fine-grained control over which terminal events trigger desktop alerts and how they are delivered.
 
 ## See Also
 

--- a/plugins/notify/README.md
+++ b/plugins/notify/README.md
@@ -25,6 +25,14 @@ codex plugin marketplace add cboone/cboone-cc-plugins
 
 Codex CLI manages this plugin through the marketplace. For a Git-backed marketplace, refresh it after repository updates with `codex plugin marketplace upgrade cboone-cc-plugins`. For a local-path marketplace, restart Codex after changing plugin files so it can rebuild cached plugin copies from the local source.
 
+Enable plugin-bundled hooks once per host so the `Stop` hook fires:
+
+```bash
+codex features enable plugin_hooks
+```
+
+Without this flag the plugin installs successfully but the hook is ignored. See [Codex CLI known limitations](../../README.md#codex-cli-known-limitations) for context.
+
 ### Using with OpenCode
 
 OpenCode loads the plugin automatically when [`OPENCODE_CONFIG_DIR`](../../README.md#using-with-opencode) is set to this repository's `dist/opencode/` mirror. The TypeScript plugin lives at [`opencode/index.ts`](./opencode/index.ts) and dispatches on OpenCode's event stream rather than Claude Code's named matchers.

--- a/plugins/notify/README.md
+++ b/plugins/notify/README.md
@@ -23,7 +23,7 @@ Then select **Notify** from the available plugins.
 codex plugin marketplace add cboone/cboone-cc-plugins
 ```
 
-Codex CLI manages this plugin through the marketplace. For a Git-backed marketplace, refresh it after repository updates with `codex plugin marketplace upgrade cboone-cc-plugins`. For a local-path marketplace, restart Codex after changing plugin files so it can rebuild cached plugin copies from the local source.
+Codex CLI manages this plugin through the marketplace. For a Git-backed marketplace, refresh it after repository updates with `codex plugin marketplace upgrade cboone-cc-plugins` (note that `upgrade` takes the marketplace name `cboone-cc-plugins`, derived from the repository name, not the `owner/repo` identifier used by `add`). For a local-path marketplace, restart Codex after changing plugin files so it can rebuild cached plugin copies from the local source.
 
 Enable plugin-bundled hooks once per host so the `Stop` hook fires:
 

--- a/plugins/notify/hooks/codex.hooks.json
+++ b/plugins/notify/hooks/codex.hooks.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/notify stop",
+            "type": "command"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/notify/scripts/notify
+++ b/plugins/notify/scripts/notify
@@ -80,13 +80,16 @@ function do_send() {
   local message="${3:-}"
   local sound="${4:-Glass}"
 
-  terminal-notifier \
+  if ! terminal-notifier \
     -title "${title}" \
     -subtitle "${subtitle}" \
     -message "${message}" \
     -sound "${sound}" \
     -group claude-code \
-    -activate com.apple.Terminal
+    -activate com.apple.Terminal \
+    > /dev/null; then
+    echo "Warning: terminal-notifier failed to send notification." >&2
+  fi
 }
 
 function do_stop() {

--- a/plugins/update-docs-reminder/.codex-plugin/plugin.json
+++ b/plugins/update-docs-reminder/.codex-plugin/plugin.json
@@ -4,6 +4,7 @@
   },
   "description": "Reminds you to update documentation when a commit includes significant code changes.",
   "homepage": "https://github.com/cboone/cboone-cc-plugins",
+  "hooks": "./hooks/hooks.json",
   "keywords": ["documentation", "git", "hooks", "reminders"],
   "license": "MIT",
   "name": "update-docs-reminder",

--- a/plugins/update-docs-reminder/README.md
+++ b/plugins/update-docs-reminder/README.md
@@ -29,6 +29,14 @@ codex plugin marketplace add cboone/cboone-cc-plugins
 
 Codex CLI manages this plugin through the marketplace. For a Git-backed marketplace, refresh it after repository updates with `codex plugin marketplace upgrade cboone-cc-plugins`. For a local-path marketplace, restart Codex after changing plugin files so it can rebuild cached plugin copies from the local source. The plugin includes a Codex manifest with `"hooks": "./hooks/hooks.json"`, so Codex registers the same `PostToolUse` hook definition used by Claude Code.
 
+Enable plugin-bundled hooks once per host so the `PostToolUse` hook fires:
+
+```bash
+codex features enable plugin_hooks
+```
+
+Without this flag the plugin installs successfully but the hook is ignored. See [Codex CLI known limitations](../../README.md#codex-cli-known-limitations) for context.
+
 ### Using with OpenCode
 
 OpenCode loads the plugin automatically when [`OPENCODE_CONFIG_DIR`](../../README.md#using-with-opencode) is set to this repository's `dist/opencode/` mirror. The TypeScript plugin lives at [`opencode/index.ts`](./opencode/index.ts) and uses the `tool.execute.after` hook with the same skip rules, file patterns, and per-project `.update-docs-reminder.json` schema as the Claude Code version.

--- a/plugins/update-docs-reminder/README.md
+++ b/plugins/update-docs-reminder/README.md
@@ -27,7 +27,7 @@ Then select **Update Docs Reminder** from the available plugins.
 codex plugin marketplace add cboone/cboone-cc-plugins
 ```
 
-Codex CLI manages this plugin through the marketplace. For a Git-backed marketplace, refresh it after repository updates with `codex plugin marketplace upgrade cboone-cc-plugins`. For a local-path marketplace, restart Codex after changing plugin files so it can rebuild cached plugin copies from the local source. The plugin includes a Codex manifest with `"hooks": "./hooks/hooks.json"`, so Codex registers the same `PostToolUse` hook definition used by Claude Code.
+Codex CLI manages this plugin through the marketplace. For a Git-backed marketplace, refresh it after repository updates with `codex plugin marketplace upgrade cboone-cc-plugins` (note that `upgrade` takes the marketplace name `cboone-cc-plugins`, derived from the repository name, not the `owner/repo` identifier used by `add`). For a local-path marketplace, restart Codex after changing plugin files so it can rebuild cached plugin copies from the local source. The plugin includes a Codex manifest with `"hooks": "./hooks/hooks.json"`, so Codex registers the same `PostToolUse` hook definition used by Claude Code.
 
 Enable plugin-bundled hooks once per host so the `PostToolUse` hook fires:
 

--- a/plugins/update-docs-reminder/README.md
+++ b/plugins/update-docs-reminder/README.md
@@ -11,6 +11,8 @@ Reminds you to update documentation when a commit includes significant code chan
 
 ## Installation
 
+### Claude Code
+
 Add the [`cboone/cboone-cc-plugins`](https://github.com/cboone/cboone-cc-plugins) marketplace in Claude Code:
 
 ```text
@@ -18,6 +20,14 @@ Add the [`cboone/cboone-cc-plugins`](https://github.com/cboone/cboone-cc-plugins
 ```
 
 Then select **Update Docs Reminder** from the available plugins.
+
+### Codex CLI
+
+```bash
+codex plugin marketplace add cboone/cboone-cc-plugins
+```
+
+Codex CLI manages this plugin through the marketplace. For a Git-backed marketplace, refresh it after repository updates with `codex plugin marketplace upgrade cboone-cc-plugins`. For a local-path marketplace, restart Codex after changing plugin files so it can rebuild cached plugin copies from the local source. The plugin includes a Codex manifest with `"hooks": "./hooks/hooks.json"`, so Codex registers the same `PostToolUse` hook definition used by Claude Code.
 
 ### Using with OpenCode
 
@@ -31,7 +41,7 @@ Analyzes each git commit for changes that typically require documentation update
 
 ## When It Fires
 
-This hook runs as a `PostToolUse` hook on the `Bash` tool. After every successful shell command, the hook checks whether a `git commit` just ran. If so, it analyzes the committed diff and reports which documentation files may need attention. Non-commit commands are ignored with minimal overhead.
+This hook runs as a `PostToolUse` hook on the `Bash` tool. After every successful shell command, the hook checks whether a `git commit` just ran. If so, it analyzes the committed diff and reports which documentation files may need attention. Non-commit commands are ignored with minimal overhead. Claude Code and Codex CLI use the same `hooks/hooks.json` definition.
 
 | Change detected                     | Documentation to check            |
 | ----------------------------------- | --------------------------------- |


### PR DESCRIPTION
## Summary

- Add `.codex-plugin/plugin.json` manifests for hook plugins (`notify`, `update-docs-reminder`) so Codex CLI registers hooks that ship inside this marketplace.
- Add a Codex-compatible `Stop`-only hooks variant for `notify`, since Codex's hook schema rejects `Notification`/`PreCompact` and would otherwise discard the entire hook block.
- Extend `bin/validate-plugins` to enforce that dual Claude/Codex manifests agree on identity and shared metadata (description and hooks may differ).
- Document Codex CLI install paths and the `plugin_hooks` feature flag requirement in the README and per-plugin docs, plus a plan doc for native Codex CLI plugin support.

## Test plan

- [ ] `bin/validate-plugins` passes.
- [ ] Install this marketplace in Codex CLI 0.128.0 with `features.codex_hooks = true` and `features.plugin_hooks = true`, and verify the `notify` Stop hook fires.
- [ ] Verify `update-docs-reminder` hooks fire under Codex.
- [ ] Verify Claude Code still loads the original `.claude-plugin` manifest and full `hooks/hooks.json` for `notify` (including `Notification`/`PreCompact`).

## Closes

Closes #272
