### PR TITLE
ci: automate catalog-state tagging and GitHub Releases on push to main

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -2,7 +2,7 @@
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "metadata": {
     "description": "Claude Code commands, hooks, and skills from Christopher Boone (cboone.github.io)",
-    "version": "catalog-M55-m102-p112-n48"
+    "version": "catalog-M55-m102-p113-n48"
   },
   "name": "cboone-cc-plugins",
   "owner": {
@@ -329,7 +329,7 @@
       "name": "release",
       "repository": "https://github.com/cboone/cboone-cc-plugins",
       "source": "./dist/codex/plugins/release",
-      "version": "1.5.7"
+      "version": "1.5.8"
     },
     {
       "author": {

--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -2,7 +2,7 @@
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "metadata": {
     "description": "Claude Code commands, hooks, and skills from Christopher Boone (cboone.github.io)",
-    "version": "catalog-M55-m100-p111-n48"
+    "version": "catalog-M55-m101-p115-n48"
   },
   "name": "cboone-cc-plugins",
   "owner": {
@@ -329,7 +329,7 @@
       "name": "release",
       "repository": "https://github.com/cboone/cboone-cc-plugins",
       "source": "./dist/codex/plugins/release",
-      "version": "1.4.2"
+      "version": "1.5.6"
     },
     {
       "author": {

--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -2,7 +2,7 @@
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "metadata": {
     "description": "Claude Code commands, hooks, and skills from Christopher Boone (cboone.github.io)",
-    "version": "catalog-M55-m103-p111-n48"
+    "version": "catalog-M55-m103-p112-n48"
   },
   "name": "cboone-cc-plugins",
   "owner": {
@@ -329,7 +329,7 @@
       "name": "release",
       "repository": "https://github.com/cboone/cboone-cc-plugins",
       "source": "./dist/codex/plugins/release",
-      "version": "1.5.8"
+      "version": "1.5.9"
     },
     {
       "author": {

--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -2,7 +2,7 @@
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "metadata": {
     "description": "Claude Code commands, hooks, and skills from Christopher Boone (cboone.github.io)",
-    "version": "catalog-M55-m101-p115-n48"
+    "version": "catalog-M55-m101-p116-n48"
   },
   "name": "cboone-cc-plugins",
   "owner": {
@@ -329,7 +329,7 @@
       "name": "release",
       "repository": "https://github.com/cboone/cboone-cc-plugins",
       "source": "./dist/codex/plugins/release",
-      "version": "1.5.6"
+      "version": "1.5.7"
     },
     {
       "author": {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "metadata": {
     "description": "Claude Code commands, hooks, and skills from Christopher Boone (cboone.github.io)",
-    "version": "catalog-M55-m101-p109-n48"
+    "version": "catalog-M55-m101-p110-n48"
   },
   "name": "cboone-cc-plugins",
   "owner": {
@@ -329,7 +329,7 @@
       "name": "release",
       "repository": "https://github.com/cboone/cboone-cc-plugins",
       "source": "./plugins/release",
-      "version": "1.5.0"
+      "version": "1.5.1"
     },
     {
       "author": {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "metadata": {
     "description": "Claude Code commands, hooks, and skills from Christopher Boone (cboone.github.io)",
-    "version": "catalog-M55-m101-p114-n48"
+    "version": "catalog-M55-m101-p115-n48"
   },
   "name": "cboone-cc-plugins",
   "owner": {
@@ -329,7 +329,7 @@
       "name": "release",
       "repository": "https://github.com/cboone/cboone-cc-plugins",
       "source": "./plugins/release",
-      "version": "1.5.5"
+      "version": "1.5.6"
     },
     {
       "author": {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "metadata": {
     "description": "Claude Code commands, hooks, and skills from Christopher Boone (cboone.github.io)",
-    "version": "catalog-M55-m101-p115-n48"
+    "version": "catalog-M55-m101-p116-n48"
   },
   "name": "cboone-cc-plugins",
   "owner": {
@@ -329,7 +329,7 @@
       "name": "release",
       "repository": "https://github.com/cboone/cboone-cc-plugins",
       "source": "./plugins/release",
-      "version": "1.5.6"
+      "version": "1.5.7"
     },
     {
       "author": {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "metadata": {
     "description": "Claude Code commands, hooks, and skills from Christopher Boone (cboone.github.io)",
-    "version": "catalog-M55-m103-p111-n48"
+    "version": "catalog-M55-m103-p112-n48"
   },
   "name": "cboone-cc-plugins",
   "owner": {
@@ -329,7 +329,7 @@
       "name": "release",
       "repository": "https://github.com/cboone/cboone-cc-plugins",
       "source": "./plugins/release",
-      "version": "1.5.8"
+      "version": "1.5.9"
     },
     {
       "author": {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "metadata": {
     "description": "Claude Code commands, hooks, and skills from Christopher Boone (cboone.github.io)",
-    "version": "catalog-M55-m100-p111-n48"
+    "version": "catalog-M55-m101-p109-n48"
   },
   "name": "cboone-cc-plugins",
   "owner": {
@@ -329,7 +329,7 @@
       "name": "release",
       "repository": "https://github.com/cboone/cboone-cc-plugins",
       "source": "./plugins/release",
-      "version": "1.4.2"
+      "version": "1.5.0"
     },
     {
       "author": {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "metadata": {
     "description": "Claude Code commands, hooks, and skills from Christopher Boone (cboone.github.io)",
-    "version": "catalog-M55-m101-p112-n48"
+    "version": "catalog-M55-m101-p113-n48"
   },
   "name": "cboone-cc-plugins",
   "owner": {
@@ -329,7 +329,7 @@
       "name": "release",
       "repository": "https://github.com/cboone/cboone-cc-plugins",
       "source": "./plugins/release",
-      "version": "1.5.3"
+      "version": "1.5.4"
     },
     {
       "author": {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "metadata": {
     "description": "Claude Code commands, hooks, and skills from Christopher Boone (cboone.github.io)",
-    "version": "catalog-M55-m101-p113-n48"
+    "version": "catalog-M55-m101-p114-n48"
   },
   "name": "cboone-cc-plugins",
   "owner": {
@@ -329,7 +329,7 @@
       "name": "release",
       "repository": "https://github.com/cboone/cboone-cc-plugins",
       "source": "./plugins/release",
-      "version": "1.5.4"
+      "version": "1.5.5"
     },
     {
       "author": {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "metadata": {
     "description": "Claude Code commands, hooks, and skills from Christopher Boone (cboone.github.io)",
-    "version": "catalog-M55-m102-p112-n48"
+    "version": "catalog-M55-m102-p113-n48"
   },
   "name": "cboone-cc-plugins",
   "owner": {
@@ -329,7 +329,7 @@
       "name": "release",
       "repository": "https://github.com/cboone/cboone-cc-plugins",
       "source": "./plugins/release",
-      "version": "1.5.7"
+      "version": "1.5.8"
     },
     {
       "author": {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "metadata": {
     "description": "Claude Code commands, hooks, and skills from Christopher Boone (cboone.github.io)",
-    "version": "catalog-M55-m101-p110-n48"
+    "version": "catalog-M55-m101-p111-n48"
   },
   "name": "cboone-cc-plugins",
   "owner": {
@@ -329,7 +329,7 @@
       "name": "release",
       "repository": "https://github.com/cboone/cboone-cc-plugins",
       "source": "./plugins/release",
-      "version": "1.5.1"
+      "version": "1.5.2"
     },
     {
       "author": {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "metadata": {
     "description": "Claude Code commands, hooks, and skills from Christopher Boone (cboone.github.io)",
-    "version": "catalog-M55-m101-p111-n48"
+    "version": "catalog-M55-m101-p112-n48"
   },
   "name": "cboone-cc-plugins",
   "owner": {
@@ -329,7 +329,7 @@
       "name": "release",
       "repository": "https://github.com/cboone/cboone-cc-plugins",
       "source": "./plugins/release",
-      "version": "1.5.2"
+      "version": "1.5.3"
     },
     {
       "author": {

--- a/.claude/skills/check-versions/SKILL.md
+++ b/.claude/skills/check-versions/SKILL.md
@@ -77,7 +77,7 @@ Read `.claude-plugin/marketplace.json` and verify:
 
 - **Version matching**: each marketplace entry's `version` matches its `plugin.json`
 - **Coverage**: every `plugins/*/` directory has a marketplace entry, and every marketplace entry points to an existing plugin directory
-- **Metadata version**: `metadata.version` is a catalog state tag in the form `catalog-M<major-sum>-m<minor-sum>-p<patch-sum>-n<plugin-count>`, derived from the marketplace plugin versions with no normalization or carry between components. Recompute it from `.plugins[].version` and verify the stored value matches the recomputed value. The `bin/validate-plugins` script uses the same computation and is the source of truth.
+- **Metadata version**: `metadata.version` is a catalog state tag in the form `catalog-M<major-sum>-m<minor-sum>-p<patch-sum>-n<plugin-count>`, derived from the marketplace plugin versions with no normalization or carry between components. Recompute it and verify the stored value matches. Prefer running `bin/compute-catalog-state` directly (the canonical implementation, also consumed by `bin/validate-plugins` and the `release` workflow); fall back to recomputing from `.plugins[].version` only if the script is missing.
 
 ### 5. Report
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,23 @@ jobs:
         env:
           TAG: ${{ steps.state.outputs.tag }}
         run: |
+          function release_exists() {
+            local tag="${1}"
+            local output
+
+            if output="$(gh api --method GET "repos/${GITHUB_REPOSITORY}/releases/tags/${tag}" --silent 2>&1)"; then
+              return 0
+            fi
+
+            if [[ "${output}" == *"HTTP 404"* ]]; then
+              return 1
+            fi
+
+            echo "::error::Failed to determine whether GitHub Release ${tag} exists." >&2
+            printf '%s\n' "${output}" >&2
+            return 2
+          }
+
           # Determines two independent booleans:
           #   tag_exists     - whether refs/tags/${TAG} is already on origin
           #   release_exists - whether the GitHub Release for ${TAG} exists
@@ -83,65 +100,73 @@ jobs:
           if [[ -z "${remote_commit}" ]]; then
             echo "Tag ${TAG} does not exist on origin; will create."
             echo "tag_exists=false" >> "${GITHUB_OUTPUT}"
-            echo "release_exists=false" >> "${GITHUB_OUTPUT}"
-            exit 0
-          fi
-
-          # Tag exists. There are three sub-cases to disambiguate:
-          #
-          # 1. Tag points at GITHUB_SHA - exact rerun of this commit. No-op.
-          # 2. Tag points at a different commit, but the marketplace plugin
-          #    versions at that commit are identical to HEAD's - the catalog
-          #    state has not actually changed (a docs/chore push reused the
-          #    same catalog state). No-op for the tag, but still confirm the
-          #    release exists.
-          # 3. Tag points at a different commit and the marketplace plugin
-          #    versions differ - true catalog-state collision. The format is
-          #    sum-based and not collision-free: two different plugin-version
-          #    mixes can yield the same component sums (e.g. +1 minor on
-          #    plugin A paired with -1 minor on plugin B). Treating any
-          #    same-named tag as "already released" would silently drop the
-          #    new state, so we abort loudly here.
-          if [[ "${remote_commit}" == "${GITHUB_SHA}" ]]; then
-            echo "Tag ${TAG} already points at ${GITHUB_SHA}; no new tag needed."
           else
-            tagged_versions="$(git show "${remote_commit}:.claude-plugin/marketplace.json" 2> /dev/null | jq -ec '[.plugins[] | {name, version}]' || echo '')"
-            head_versions="$(jq -ec '[.plugins[] | {name, version}]' .claude-plugin/marketplace.json)"
-
-            if [[ -n "${tagged_versions}" && "${tagged_versions}" == "${head_versions}" ]]; then
-              echo "Tag ${TAG} exists at ${remote_commit}; HEAD has the same plugin versions, so the catalog state is unchanged. No new tag needed."
+            # Tag exists. There are three sub-cases to disambiguate:
+            #
+            # 1. Tag points at GITHUB_SHA - exact rerun of this commit. No-op.
+            # 2. Tag points at a different commit, but the marketplace plugin
+            #    versions at that commit are identical to HEAD's - the catalog
+            #    state has not actually changed (a docs/chore push reused the
+            #    same catalog state). No-op for the tag, but still confirm the
+            #    release exists.
+            # 3. Tag points at a different commit and the marketplace plugin
+            #    versions differ - true catalog-state collision. The format is
+            #    sum-based and not collision-free: two different plugin-version
+            #    mixes can yield the same component sums (e.g. +1 minor on
+            #    plugin A paired with -1 minor on plugin B). Treating any
+            #    same-named tag as "already released" would silently drop the
+            #    new state, so we abort loudly here.
+            if [[ "${remote_commit}" == "${GITHUB_SHA}" ]]; then
+              echo "Tag ${TAG} already points at ${GITHUB_SHA}; no new tag needed."
             else
-              {
-                echo "::error::Catalog state tag ${TAG} already exists at a different commit with different plugin versions."
-                echo
-                echo "Existing tag points to: ${remote_commit}"
-                echo "Current commit:         ${GITHUB_SHA}"
-                echo
-                echo "This is a catalog-state collision: the marketplace plugin"
-                echo "versions changed in a way that produces the same per-component"
-                echo "sums as a previously-released catalog state. The format is"
-                echo "sum-based and not collision-free."
-                echo
-                echo "To resolve, bump one plugin's version on a follow-up commit so"
-                echo "the marketplace produces a unique catalog state, then re-push"
-                echo "or re-merge."
-              } >&2
-              exit 1
+              tagged_versions="$(git show "${remote_commit}:.claude-plugin/marketplace.json" 2> /dev/null | jq -ec '[.plugins[] | {name, version}]' || echo '')"
+              head_versions="$(jq -ec '[.plugins[] | {name, version}]' .claude-plugin/marketplace.json)"
+
+              if [[ -n "${tagged_versions}" && "${tagged_versions}" == "${head_versions}" ]]; then
+                echo "Tag ${TAG} exists at ${remote_commit}; HEAD has the same plugin versions, so the catalog state is unchanged. No new tag needed."
+              else
+                {
+                  echo "::error::Catalog state tag ${TAG} already exists at a different commit with different plugin versions."
+                  echo
+                  echo "Existing tag points to: ${remote_commit}"
+                  echo "Current commit:         ${GITHUB_SHA}"
+                  echo
+                  echo "This is a catalog-state collision: the marketplace plugin"
+                  echo "versions changed in a way that produces the same per-component"
+                  echo "sums as a previously-released catalog state. The format is"
+                  echo "sum-based and not collision-free."
+                  echo
+                  echo "To resolve, bump one plugin's version on a follow-up commit so"
+                  echo "the marketplace produces a unique catalog state, then re-push"
+                  echo "or re-merge."
+                } >&2
+                exit 1
+              fi
             fi
+
+            echo "tag_exists=true" >> "${GITHUB_OUTPUT}"
           fi
 
-          echo "tag_exists=true" >> "${GITHUB_OUTPUT}"
-
-          # Verify the GitHub Release exists. If `git push` succeeded on a
-          # prior run but `gh release create` failed, the tag will be present
-          # without a release; rerunning must recreate the release rather than
-          # silently skip it.
-          if gh release view "${TAG}" --json tagName > /dev/null 2>&1; then
+          # Verify the GitHub Release independently from the Git tag. If `git
+          # push` succeeded on a prior run but `gh release create` failed, the
+          # tag will be present without a release; rerunning must recreate the
+          # release rather than silently skip it. Conversely, a release can
+          # outlive a deleted tag; rerunning should recreate the tag without
+          # calling `gh release create` for an already-existing release.
+          if release_exists "${TAG}"; then
             echo "Release ${TAG} already exists; nothing to do."
             echo "release_exists=true" >> "${GITHUB_OUTPUT}"
           else
-            echo "Release ${TAG} does not exist yet; will create."
-            echo "release_exists=false" >> "${GITHUB_OUTPUT}"
+            release_status="${?}"
+            case "${release_status}" in
+              1)
+                echo "Release ${TAG} does not exist yet; will create."
+                echo "release_exists=false" >> "${GITHUB_OUTPUT}"
+                ;;
+              *)
+                exit "${release_status}"
+                ;;
+            esac
           fi
 
       - name: Create and push annotated tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,11 +5,11 @@ on:
     branches: [main]
   workflow_dispatch:
 
-# Serialize releases on main so two rapid merges cannot race to create the same
-# tag. cancel-in-progress is false because each push may correspond to a
-# distinct catalog state we still want to publish.
+# Serialize releases so two rapid merges cannot race to create the same tag.
+# cancel-in-progress is false because each push may correspond to a distinct
+# catalog state we still want to publish.
 concurrency:
-  group: release-main
+  group: ${{ github.repository }}-${{ github.workflow }}
   cancel-in-progress: false
 
 permissions:
@@ -45,10 +45,12 @@ jobs:
           # produce a tag and Release for a marketplace state that
           # bin/validate-plugins rejects in CI. Running the full validator
           # keeps automation in lockstep with the validator and ci.yml.
-          # Rule 10 of bin/validate-plugins covers the metadata.version
-          # check via bin/compute-catalog-state, so this also subsumes the
-          # previous standalone metadata-version verification.
+          # Rule 10 of bin/validate-plugins covers the metadata.version check
+          # via bin/compute-catalog-state, so this also subsumes the previous
+          # standalone metadata-version verification.
           bin/validate-plugins
+          bin/build-opencode-mirror
+          git diff --exit-code dist/
 
       - name: Compute catalog state
         id: state

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,82 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# Serialize releases on main so two rapid merges cannot race to create the same
+# tag. cancel-in-progress is false because each push may correspond to a
+# distinct catalog state we still want to publish.
+concurrency:
+  group: release-main
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Tag and publish catalog state
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Full history lets gh release --generate-notes diff against the
+          # previous tag, and lets git rev-parse resolve refs/tags/* via fetch.
+          fetch-depth: 0
+
+      - name: Compute catalog state
+        id: state
+        run: |
+          tag="$(bin/compute-catalog-state)"
+          echo "tag=${tag}" >> "${GITHUB_OUTPUT}"
+          echo "Catalog state: ${tag}"
+
+      - name: Check whether tag already exists
+        id: check
+        env:
+          TAG: ${{ steps.state.outputs.tag }}
+        run: |
+          # Idempotency guard: re-runs of the same main SHA, no-op merges, and
+          # reverts that land on an already-released catalog state must not
+          # republish. Consult the remote so a tag created by an earlier run of
+          # this workflow is honored even if it is not in the local fetch.
+          if git ls-remote --tags --exit-code origin "refs/tags/${TAG}" > /dev/null 2>&1; then
+            echo "Tag ${TAG} already exists on origin; nothing to do."
+            echo "exists=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "Tag ${TAG} does not exist; will create."
+            echo "exists=false" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Create and push annotated tag
+        if: steps.check.outputs.exists == 'false'
+        env:
+          TAG: ${{ steps.state.outputs.tag }}
+        run: |
+          # Annotated (not signed) tag: Actions does not have access to a GPG
+          # key, and the tag's authenticity is established by the workflow
+          # being the only writer of catalog-* tags on the repository.
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "${TAG}" -m "${TAG}"
+          git push origin "refs/tags/${TAG}"
+
+      - name: Create GitHub Release
+        if: steps.check.outputs.exists == 'false'
+        env:
+          TAG: ${{ steps.state.outputs.tag }}
+        run: |
+          # --generate-notes uses GitHub's auto-generated notes (commits and
+          # merged PRs since the previous release). The release skill produces
+          # commit-derived notes for local releases; CI uses --generate-notes
+          # to keep the workflow self-contained and avoid duplicating that
+          # logic here.
+          gh release create "${TAG}" \
+            --title "Marketplace ${TAG}" \
+            --generate-notes \
+            --verify-tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,12 +45,47 @@ jobs:
           # reverts that land on an already-released catalog state must not
           # republish. Consult the remote so a tag created by an earlier run of
           # this workflow is honored even if it is not in the local fetch.
-          if git ls-remote --tags --exit-code origin "refs/tags/${TAG}" > /dev/null 2>&1; then
-            echo "Tag ${TAG} already exists on origin; nothing to do."
+          #
+          # Compare commit SHAs, not just the tag name. Catalog-state tags are
+          # sum-based and not collision-free: two different plugin-version
+          # mixes can yield the same component sums (e.g. +1 minor on plugin A
+          # paired with -1 minor on plugin B). Treating any same-named tag as
+          # "already released" would silently drop the new state. Comparing
+          # SHAs lets us idempotently skip true repeats while loudly aborting
+          # on collisions.
+          #
+          # `ls-remote` for an annotated tag prints the tag object SHA; the
+          # peeled refspec (^{}) gives the commit the tag points at, which is
+          # what we want to compare. Lightweight tags expose the commit
+          # directly; we fall back to that case in case a tag was pushed by
+          # something other than this workflow.
+          remote_commit="$(git ls-remote origin "refs/tags/${TAG}^{}" | cut -f1)"
+          if [[ -z "${remote_commit}" ]]; then
+            remote_commit="$(git ls-remote origin "refs/tags/${TAG}" | cut -f1)"
+          fi
+
+          if [[ -z "${remote_commit}" ]]; then
+            echo "Tag ${TAG} does not exist on origin; will create."
+            echo "exists=false" >> "${GITHUB_OUTPUT}"
+          elif [[ "${remote_commit}" == "${GITHUB_SHA}" ]]; then
+            echo "Tag ${TAG} already points at ${GITHUB_SHA}; nothing to do."
             echo "exists=true" >> "${GITHUB_OUTPUT}"
           else
-            echo "Tag ${TAG} does not exist; will create."
-            echo "exists=false" >> "${GITHUB_OUTPUT}"
+            {
+              echo "::error::Catalog state tag ${TAG} already exists at a different commit."
+              echo
+              echo "Existing tag points to: ${remote_commit}"
+              echo "Current commit:         ${GITHUB_SHA}"
+              echo
+              echo "This usually indicates a catalog-state collision: the marketplace"
+              echo "plugin versions changed in a way that produces the same per-component"
+              echo "sums as a previously-released catalog state. The format is sum-based"
+              echo "and not collision-free."
+              echo
+              echo "To resolve, bump one plugin's version on a follow-up commit so the"
+              echo "marketplace produces a unique catalog state, then re-push or re-merge."
+            } >&2
+            exit 1
           fi
 
       - name: Create and push annotated tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,9 +151,21 @@ jobs:
           # push` succeeded on a prior run but `gh release create` failed, the
           # tag will be present without a release; rerunning must recreate the
           # release rather than silently skip it. Conversely, a release can
-          # outlive a deleted tag; rerunning should recreate the tag without
-          # calling `gh release create` for an already-existing release.
+          # outlive a deleted tag; rerunning must not recreate that tag at the
+          # current commit and silently retarget an already-published release.
           if release_exists "${TAG}"; then
+            if [[ -z "${remote_commit}" ]]; then
+              {
+                echo "::error::GitHub Release ${TAG} exists, but refs/tags/${TAG} is missing on origin."
+                echo
+                echo "Recreating the missing tag at ${GITHUB_SHA} would retarget an"
+                echo "already-published release to the current commit. Restore the"
+                echo "original tag manually, or delete and recreate the GitHub Release"
+                echo "intentionally before rerunning this workflow."
+              } >&2
+              exit 1
+            fi
+
             echo "Release ${TAG} already exists; nothing to do."
             echo "release_exists=true" >> "${GITHUB_OUTPUT}"
           else

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,41 +35,27 @@ jobs:
           # previous tag, and lets git rev-parse resolve refs/tags/* via fetch.
           fetch-depth: 0
 
+      - name: Validate plugins and marketplace
+        run: |
+          # Run the full plugin/marketplace validator before publishing.
+          # Gating only on the metadata.version <-> catalog-state invariant
+          # would let other inconsistencies (plugin.json <-> marketplace.json
+          # version drift, missing marketplace entries, alphabetical-ordering
+          # violations, Codex hook manifest issues, etc.) slip through and
+          # produce a tag and Release for a marketplace state that
+          # bin/validate-plugins rejects in CI. Running the full validator
+          # keeps automation in lockstep with the validator and ci.yml.
+          # Rule 10 of bin/validate-plugins covers the metadata.version
+          # check via bin/compute-catalog-state, so this also subsumes the
+          # previous standalone metadata-version verification.
+          bin/validate-plugins
+
       - name: Compute catalog state
         id: state
         run: |
           tag="$(bin/compute-catalog-state)"
           echo "tag=${tag}" >> "${GITHUB_OUTPUT}"
           echo "Catalog state: ${tag}"
-
-      - name: Verify committed metadata.version matches computed catalog state
-        env:
-          TAG: ${{ steps.state.outputs.tag }}
-        run: |
-          # Refuse to publish if .claude-plugin/marketplace.json's
-          # metadata.version disagrees with what bin/compute-catalog-state
-          # derives from .plugins[].version. A bad merge could otherwise land
-          # on main with stale metadata, and this workflow would happily mint
-          # a tag and Release for the computed state even though the
-          # repository advertises a different one (and bin/validate-plugins
-          # rejects it). Gating here keeps automation in lockstep with the
-          # validator.
-          metadata_version="$(jq -er '.metadata.version // empty' .claude-plugin/marketplace.json)"
-          if [[ "${metadata_version}" != "${TAG}" ]]; then
-            {
-              echo "::error::Marketplace metadata.version '${metadata_version}' does not match computed catalog state '${TAG}'."
-              echo
-              echo "The committed .claude-plugin/marketplace.json is out of sync with"
-              echo "its own .plugins[].version entries. Refusing to publish a tag and"
-              echo "Release derived from the computed state while the repository"
-              echo "advertises a different one."
-              echo
-              echo "To resolve, run bin/compute-catalog-state and update"
-              echo ".claude-plugin/marketplace.json's metadata.version to match,"
-              echo "then push or merge again."
-            } >&2
-            exit 1
-          fi
 
       - name: Check whether tag and release already exist
         id: check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,12 @@ permissions:
 jobs:
   release:
     name: Tag and publish catalog state
+    # Defense in depth: the push trigger is already restricted to main via
+    # branches:[main], but workflow_dispatch can be initiated from any ref.
+    # Without this guard, manually dispatching from a feature branch would
+    # mint a catalog-* tag and GitHub Release for code that never landed on
+    # main, contradicting the push-to-main release model.
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
@@ -36,23 +42,18 @@ jobs:
           echo "tag=${tag}" >> "${GITHUB_OUTPUT}"
           echo "Catalog state: ${tag}"
 
-      - name: Check whether tag already exists
+      - name: Check whether tag and release already exist
         id: check
         env:
           TAG: ${{ steps.state.outputs.tag }}
         run: |
-          # Idempotency guard: re-runs of the same main SHA, no-op merges, and
-          # reverts that land on an already-released catalog state must not
-          # republish. Consult the remote so a tag created by an earlier run of
-          # this workflow is honored even if it is not in the local fetch.
+          # Determines two independent booleans:
+          #   tag_exists     - whether refs/tags/${TAG} is already on origin
+          #   release_exists - whether the GitHub Release for ${TAG} exists
           #
-          # Compare commit SHAs, not just the tag name. Catalog-state tags are
-          # sum-based and not collision-free: two different plugin-version
-          # mixes can yield the same component sums (e.g. +1 minor on plugin A
-          # paired with -1 minor on plugin B). Treating any same-named tag as
-          # "already released" would silently drop the new state. Comparing
-          # SHAs lets us idempotently skip true repeats while loudly aborting
-          # on collisions.
+          # The two are decoupled so a partial prior run (tag pushed, release
+          # creation failed) can self-heal: a rerun will skip tagging but still
+          # create the missing release.
           #
           # `ls-remote` for an annotated tag prints the tag object SHA; the
           # peeled refspec (^{}) gives the commit the tag points at, which is
@@ -66,30 +67,70 @@ jobs:
 
           if [[ -z "${remote_commit}" ]]; then
             echo "Tag ${TAG} does not exist on origin; will create."
-            echo "exists=false" >> "${GITHUB_OUTPUT}"
-          elif [[ "${remote_commit}" == "${GITHUB_SHA}" ]]; then
-            echo "Tag ${TAG} already points at ${GITHUB_SHA}; nothing to do."
-            echo "exists=true" >> "${GITHUB_OUTPUT}"
+            echo "tag_exists=false" >> "${GITHUB_OUTPUT}"
+            echo "release_exists=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          # Tag exists. There are three sub-cases to disambiguate:
+          #
+          # 1. Tag points at GITHUB_SHA - exact rerun of this commit. No-op.
+          # 2. Tag points at a different commit, but the marketplace plugin
+          #    versions at that commit are identical to HEAD's - the catalog
+          #    state has not actually changed (a docs/chore push reused the
+          #    same catalog state). No-op for the tag, but still confirm the
+          #    release exists.
+          # 3. Tag points at a different commit and the marketplace plugin
+          #    versions differ - true catalog-state collision. The format is
+          #    sum-based and not collision-free: two different plugin-version
+          #    mixes can yield the same component sums (e.g. +1 minor on
+          #    plugin A paired with -1 minor on plugin B). Treating any
+          #    same-named tag as "already released" would silently drop the
+          #    new state, so we abort loudly here.
+          if [[ "${remote_commit}" == "${GITHUB_SHA}" ]]; then
+            echo "Tag ${TAG} already points at ${GITHUB_SHA}; no new tag needed."
           else
-            {
-              echo "::error::Catalog state tag ${TAG} already exists at a different commit."
-              echo
-              echo "Existing tag points to: ${remote_commit}"
-              echo "Current commit:         ${GITHUB_SHA}"
-              echo
-              echo "This usually indicates a catalog-state collision: the marketplace"
-              echo "plugin versions changed in a way that produces the same per-component"
-              echo "sums as a previously-released catalog state. The format is sum-based"
-              echo "and not collision-free."
-              echo
-              echo "To resolve, bump one plugin's version on a follow-up commit so the"
-              echo "marketplace produces a unique catalog state, then re-push or re-merge."
-            } >&2
-            exit 1
+            tagged_versions="$(git show "${remote_commit}:.claude-plugin/marketplace.json" 2> /dev/null | jq -ec '[.plugins[] | {name, version}]' || echo '')"
+            head_versions="$(jq -ec '[.plugins[] | {name, version}]' .claude-plugin/marketplace.json)"
+
+            if [[ -n "${tagged_versions}" && "${tagged_versions}" == "${head_versions}" ]]; then
+              echo "Tag ${TAG} exists at ${remote_commit}; HEAD has the same plugin versions, so the catalog state is unchanged. No new tag needed."
+            else
+              {
+                echo "::error::Catalog state tag ${TAG} already exists at a different commit with different plugin versions."
+                echo
+                echo "Existing tag points to: ${remote_commit}"
+                echo "Current commit:         ${GITHUB_SHA}"
+                echo
+                echo "This is a catalog-state collision: the marketplace plugin"
+                echo "versions changed in a way that produces the same per-component"
+                echo "sums as a previously-released catalog state. The format is"
+                echo "sum-based and not collision-free."
+                echo
+                echo "To resolve, bump one plugin's version on a follow-up commit so"
+                echo "the marketplace produces a unique catalog state, then re-push"
+                echo "or re-merge."
+              } >&2
+              exit 1
+            fi
+          fi
+
+          echo "tag_exists=true" >> "${GITHUB_OUTPUT}"
+
+          # Verify the GitHub Release exists. If `git push` succeeded on a
+          # prior run but `gh release create` failed, the tag will be present
+          # without a release; rerunning must recreate the release rather than
+          # silently skip it.
+          if gh release view "${TAG}" --json tagName > /dev/null 2>&1; then
+            echo "Release ${TAG} already exists; nothing to do."
+            echo "release_exists=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "Release ${TAG} does not exist yet; will create."
+            echo "release_exists=false" >> "${GITHUB_OUTPUT}"
           fi
 
       - name: Create and push annotated tag
-        if: steps.check.outputs.exists == 'false'
+        if: steps.check.outputs.tag_exists == 'false'
         env:
           TAG: ${{ steps.state.outputs.tag }}
         run: |
@@ -102,7 +143,7 @@ jobs:
           git push origin "refs/tags/${TAG}"
 
       - name: Create GitHub Release
-        if: steps.check.outputs.exists == 'false'
+        if: steps.check.outputs.release_exists == 'false'
         env:
           TAG: ${{ steps.state.outputs.tag }}
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,35 @@ jobs:
           echo "tag=${tag}" >> "${GITHUB_OUTPUT}"
           echo "Catalog state: ${tag}"
 
+      - name: Verify committed metadata.version matches computed catalog state
+        env:
+          TAG: ${{ steps.state.outputs.tag }}
+        run: |
+          # Refuse to publish if .claude-plugin/marketplace.json's
+          # metadata.version disagrees with what bin/compute-catalog-state
+          # derives from .plugins[].version. A bad merge could otherwise land
+          # on main with stale metadata, and this workflow would happily mint
+          # a tag and Release for the computed state even though the
+          # repository advertises a different one (and bin/validate-plugins
+          # rejects it). Gating here keeps automation in lockstep with the
+          # validator.
+          metadata_version="$(jq -er '.metadata.version // empty' .claude-plugin/marketplace.json)"
+          if [[ "${metadata_version}" != "${TAG}" ]]; then
+            {
+              echo "::error::Marketplace metadata.version '${metadata_version}' does not match computed catalog state '${TAG}'."
+              echo
+              echo "The committed .claude-plugin/marketplace.json is out of sync with"
+              echo "its own .plugins[].version entries. Refusing to publish a tag and"
+              echo "Release derived from the computed state while the repository"
+              echo "advertises a different one."
+              echo
+              echo "To resolve, run bin/compute-catalog-state and update"
+              echo ".claude-plugin/marketplace.json's metadata.version to match,"
+              echo "then push or merge again."
+            } >&2
+            exit 1
+          fi
+
       - name: Check whether tag and release already exist
         id: check
         env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -627,7 +627,7 @@ This repository uses two levels of versioning:
 - `p`: sum of all plugin patch versions
 - `n`: number of marketplace plugins
 - Do not normalize or carry between components.
-- Recompute it from `.plugins[].version` whenever any marketplace plugin version changes.
+- Recompute it from `.plugins[].version` whenever any marketplace plugin version changes. Use `bin/compute-catalog-state` (the canonical implementation, also consumed by `bin/validate-plugins` and `.github/workflows/release.yml`).
 
 **Individual plugin `version`** (in `plugin.json` and mirrored in `marketplace.json`):
 

--- a/bin/compute-catalog-state
+++ b/bin/compute-catalog-state
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Computes the canonical catalog state tag for the marketplace.
+#
+# Reads .claude-plugin/marketplace.json and prints a tag of the form
+#   catalog-M<major-sum>-m<minor-sum>-p<patch-sum>-n<plugin-count>
+# where each component is the sum of the matching SemVer field across every
+# plugin in .plugins[]. No normalization or carry between components.
+#
+# Exits non-zero if any plugin version is not strict MAJOR.MINOR.PATCH.
+
+set -euo pipefail
+
+MARKETPLACE="${MARKETPLACE:-.claude-plugin/marketplace.json}"
+
+if [[ ! -f "${MARKETPLACE}" ]]; then
+  echo "compute-catalog-state: ${MARKETPLACE} not found" >&2
+  exit 2
+fi
+
+jq -er '
+  def parse_version:
+    capture("^(?<major>[0-9]+)\\.(?<minor>[0-9]+)\\.(?<patch>[0-9]+)$")
+    | {
+        major: (.major | tonumber),
+        minor: (.minor | tonumber),
+        patch: (.patch | tonumber)
+      };
+
+  [.plugins[].version | parse_version] as $versions
+  | "catalog-M\($versions | map(.major) | add)-m\($versions | map(.minor) | add)-p\($versions | map(.patch) | add)-n\($versions | length)"
+' "${MARKETPLACE}"

--- a/bin/validate-plugins
+++ b/bin/validate-plugins
@@ -149,23 +149,10 @@ if [[ "${sorted}" != "${actual}" ]]; then
 fi
 
 # ─── 10. Marketplace catalog state matches plugin versions ──────────────────
+# bin/compute-catalog-state is the single source of truth for the canonical
+# catalog state tag and is also consumed by .github/workflows/release.yml.
 
-function compute_catalog_state() {
-  jq -r '
-    def parse_version:
-      capture("^(?<major>[0-9]+)\\.(?<minor>[0-9]+)\\.(?<patch>[0-9]+)$")
-      | {
-          major: (.major | tonumber),
-          minor: (.minor | tonumber),
-          patch: (.patch | tonumber)
-        };
-
-    [.plugins[].version | parse_version] as $versions
-    | "catalog-M\($versions | map(.major) | add)-m\($versions | map(.minor) | add)-p\($versions | map(.patch) | add)-n\($versions | length)"
-  ' "${MARKETPLACE}"
-}
-
-if ! computed_catalog_state="$(compute_catalog_state 2> /dev/null)"; then
+if ! computed_catalog_state="$(bin/compute-catalog-state 2> /dev/null)"; then
   error "Marketplace metadata.version could not be computed because one or more plugin versions are not SemVer"
 else
   metadata_version="$(jq -r '.metadata.version // empty' "${MARKETPLACE}")"

--- a/dist/codex/plugins/release/.claude-plugin/plugin.json
+++ b/dist/codex/plugins/release/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "name": "release",
   "repository": "https://github.com/cboone/cboone-cc-plugins",
   "skills": "./skills",
-  "version": "1.5.7"
+  "version": "1.5.8"
 }

--- a/dist/codex/plugins/release/.claude-plugin/plugin.json
+++ b/dist/codex/plugins/release/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "name": "release",
   "repository": "https://github.com/cboone/cboone-cc-plugins",
   "skills": "./skills",
-  "version": "1.5.8"
+  "version": "1.5.9"
 }

--- a/dist/codex/plugins/release/.claude-plugin/plugin.json
+++ b/dist/codex/plugins/release/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "name": "release",
   "repository": "https://github.com/cboone/cboone-cc-plugins",
   "skills": "./skills",
-  "version": "1.5.6"
+  "version": "1.5.7"
 }

--- a/dist/codex/plugins/release/.claude-plugin/plugin.json
+++ b/dist/codex/plugins/release/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "name": "release",
   "repository": "https://github.com/cboone/cboone-cc-plugins",
   "skills": "./skills",
-  "version": "1.4.2"
+  "version": "1.5.6"
 }

--- a/dist/codex/plugins/release/skills/release/SKILL.md
+++ b/dist/codex/plugins/release/skills/release/SKILL.md
@@ -47,9 +47,9 @@ if [ -d .github/workflows ]; then
     [ -f "$f" ] || continue
     # Tag-triggered workflows: a `tags:` trigger plus a list entry like
     # `- "v*"` or `- catalog-*`.
+    has_tag_trigger=0
     if grep -q 'tags:' "$f" && grep -qE "^[[:space:]]*-[[:space:]]+['\"]?(v[*[0-9]|catalog-)" "$f"; then
-      echo "$f"
-      continue
+      has_tag_trigger=1
     fi
     # Marketplace push-to-main automation: workflow invokes the canonical
     # catalog state computation, publishes a GitHub Release, AND triggers
@@ -67,6 +67,7 @@ if [ -d .github/workflows ]; then
     # script tracks indentation to scope branches: matches to the push:
     # block, and handles both inline (`branches: [main]`) and YAML-list
     # (`branches:` followed by `- main`) forms.
+    has_marketplace_push_to_main=0
     if grep -q 'compute-catalog-state' "$f" && grep -q 'gh release create' "$f" && awk '
         function leading_ws(s) {
           match(s, /^[[:space:]]*/)
@@ -121,13 +122,22 @@ if [ -d .github/workflows ]; then
         in_list && !/^[[:space:]]+-/ && !/^[[:space:]]*$/ { in_list = 0 }
         END { exit !found }
       ' "$f"; then
-      echo "$f"
+      has_marketplace_push_to_main=1
+    fi
+
+    # Push-to-main automation is more specific than a generic tag trigger.
+    # If a workflow matches both, classify it as push-to-main so marketplace
+    # catalog tags remain workflow-owned.
+    if [ "${has_marketplace_push_to_main}" -eq 1 ]; then
+      printf '%s\t%s\n' "$f" "marketplace-push-to-main"
+    elif [ "${has_tag_trigger}" -eq 1 ]; then
+      printf '%s\t%s\n' "$f" "tag-triggered"
     fi
   done
 fi
 ```
 
-If the loop prints any files, note that a **release workflow likely exists** that will automatically create a GitHub Release. Preserve which workflow kind was detected, because marketplace catalog releases handle the two kinds differently:
+If the loop prints any tab-delimited lines, note that a **release workflow likely exists** that will automatically create a GitHub Release. Each line has the form `<workflow-path>\t<workflow-kind>`. Preserve the workflow kind, because marketplace catalog releases handle the two kinds differently. If a workflow matches both kinds, the loop reports `marketplace-push-to-main`, which is the more specific automation and the only writer of marketplace catalog tags:
 
 - **Tag-triggered workflows**: a `tags:` trigger plus a YAML list entry whose value starts with `v` followed by `*`, `[`, or a digit (e.g., `- "v*"`, `- "v[0-9]+.[0-9]+.[0-9]+"`), or starts with `catalog-`. Anchoring to list-item form avoids false positives from action refs like `actions/checkout@v4`.
 - **Marketplace push-to-main workflows**: a workflow that invokes `bin/compute-catalog-state`, runs `gh release create`, and triggers on push to the default branch (`main` or `master`). All three signals together mark end-to-end automation that tags and publishes on push to the default branch. A workflow that only computes the catalog state (e.g., for validation) does not qualify, and neither does a workflow_dispatch-only or PR-triggered workflow that happens to invoke both, since neither will run when a commit lands on main.
@@ -348,6 +358,8 @@ Do not create another tag or choose a different state tag automatically. The use
 
 Build a final review and wait for explicit user approval. The wording depends on which release workflow kind was detected in step 1.
 
+If M4 found an **existing remote tag at a different commit with identical plugin versions** and M3 produced no release-file changes, skip the pre-tag review. The release-recovery path has no new commit or tag to approve; M8c handles the user approval before creating any missing GitHub Release.
+
 If **no marketplace push-to-main workflow** was detected:
 
 ```text
@@ -385,7 +397,22 @@ If `--dry-run` was specified, present this as a proposed review and stop. Do not
 
 #### M6. Create Marketplace Commit
 
-Stage only the files changed by the release and create a GPG-signed commit. Choose the commit message based on whether marketplace push-to-main automation was detected:
+If M4 found an **existing remote tag at a different commit with identical plugin versions**, first check whether M3 produced any release-file changes:
+
+```bash
+if git diff --quiet -- .claude-plugin/marketplace.json plugins/*/.claude-plugin/plugin.json; then
+  release_commit_created=0
+else
+  release_commit_created=1
+fi
+```
+
+When no release-file changes exist, skip commit creation. This is the release-recovery path: do not create an empty commit, and do not stage or commit unrelated local changes. Continue based on the workflow kind:
+
+- **Release workflow detected**: report that the existing remote catalog tag is present and the workflow owns GitHub Release publication. Stop without creating a local commit or tag.
+- **No release workflow detected**: continue to M8c with `release_commit_created=0` so the skill can verify or create the missing GitHub Release for the existing remote tag.
+
+For all other M4 cases, or when release files changed, stage only the files changed by the release and create a GPG-signed commit. Choose the commit message based on whether marketplace push-to-main automation was detected:
 
 - **No marketplace push-to-main workflow**: use `release: CATALOG-STATE` so the message marks the local tag. This includes tag-triggered release workflows, because this skill still creates and pushes the exact catalog tag that fires the workflow.
 - **Marketplace push-to-main workflow detected**: use a conventional commit that describes the underlying plugin change (e.g., `chore: bump <plugin> to <version> and resync catalog state`, or `feat(<plugin>): <summary>` if the bump is a feature). The workflow will produce its own release-named tag from the resulting `metadata.version`; the commit subject should describe the work, not the catalog state.
@@ -891,7 +918,7 @@ Release vVERSION published.
 - **Tag already exists:** Abort with a message that the tag `vVERSION` already exists. Suggest choosing a different version.
 - **Marketplace catalog remote tag already exists at HEAD:** Do not retag. In the no-workflow path, continue to M8c to verify or create the GitHub Release for the existing remote tag. With release workflow automation, report that the remote tag exists and the workflow owns release publication.
 - **Marketplace catalog local-only tag already exists at HEAD:** The catalog state is tagged locally but is not known to be published. Continue through M5-M8, skip replacement tag creation in M7, and publish the existing local tag if the user chooses to publish.
-- **Marketplace catalog tag already exists at a different commit, same plugin versions:** The catalog state is genuinely unchanged (e.g., a docs-only follow-up reused the previous catalog state). Do not retag. In the no-workflow path, continue to M8c to verify or create the GitHub Release for the existing remote tag; with release workflow automation, report that the workflow owns release publication.
+- **Marketplace catalog tag already exists at a different commit, same plugin versions:** The catalog state is genuinely unchanged (e.g., a docs-only follow-up reused the previous catalog state). Do not retag and do not create an empty release commit when M3 produced no release-file changes. In the no-workflow path, continue to M8c to verify or create the GitHub Release for the existing remote tag; with release workflow automation, report that the workflow owns release publication.
 - **Marketplace catalog tag already exists at a different commit, different plugin versions:** Treat as a catalog-state collision (the sum-based tag format is not collision-free). Abort with the collision-aware message in M4 and ask the user to bump one plugin so the marketplace produces a unique catalog state. Do not retag or rename.
 - **Not a git repository:** Abort immediately.
 - **No remote configured:** Skip comparison links in CHANGELOG, skip push and GitHub Release in step 11, warn the user.

--- a/dist/codex/plugins/release/skills/release/SKILL.md
+++ b/dist/codex/plugins/release/skills/release/SKILL.md
@@ -41,18 +41,98 @@ git tag --list 'catalog-M*-m*-p*-n*' --sort=-creatordate
 # Get today's date
 date +%Y-%m-%d
 
-# Check for a release workflow triggered by release tags
+# Check for a release workflow that publishes GitHub Releases automatically
 if [ -d .github/workflows ]; then
   for f in .github/workflows/*.yml .github/workflows/*.yaml; do
     [ -f "$f" ] || continue
+    # Tag-triggered workflows: a `tags:` trigger plus a list entry like
+    # `- "v*"` or `- catalog-*`.
     if grep -q 'tags:' "$f" && grep -qE "^[[:space:]]*-[[:space:]]+['\"]?(v[*[0-9]|catalog-)" "$f"; then
+      echo "$f"
+      continue
+    fi
+    # Marketplace push-to-main automation: workflow invokes the canonical
+    # catalog state computation, publishes a GitHub Release, AND triggers
+    # on push to the default branch (main or master). All three are
+    # required. The compute-catalog-state and gh release create checks
+    # rule out partial automation (e.g., a validation workflow that
+    # computes the catalog state without tagging or releasing). The push
+    # trigger check rules out workflow_dispatch-only or PR-only workflows
+    # that happen to mention both strings: those will not run when a
+    # commit lands on main, so deferring to them would silently skip
+    # local catalog tagging and leave nothing tagged or released. The
+    # branches:/main match must occur *under* push: rather than under a
+    # sibling key like pull_request: -- otherwise a workflow with
+    # `pull_request: branches: [main]` would falsely match. The awk
+    # script tracks indentation to scope branches: matches to the push:
+    # block, and handles both inline (`branches: [main]`) and YAML-list
+    # (`branches:` followed by `- main`) forms.
+    if grep -q 'compute-catalog-state' "$f" && grep -q 'gh release create' "$f" && awk '
+        function leading_ws(s) {
+          match(s, /^[[:space:]]*/)
+          return RLENGTH
+        }
+        {
+          # When indentation falls back to the push: level (or shallower),
+          # we have left the push: block. Reset state before running other
+          # rules on this line so a sibling key (e.g. pull_request:) does
+          # not pick up branches: matches inside push:.
+          if (in_push && $0 !~ /^[[:space:]]*$/ && leading_ws($0) <= push_indent) {
+            in_push = 0
+            in_list = 0
+          }
+        }
+        /^[[:space:]]*push:[[:space:]]*$/ {
+          push_indent = leading_ws($0)
+          in_push = 1
+          in_list = 0
+          next
+        }
+        # Inline form: branches: [main], branches: ["main", "master"],
+        # branches: [dev, main]. Strip brackets and quotes, split on
+        # commas/whitespace, then compare each token. This avoids needing
+        # word-boundary support, which BSD awk lacks ([maintenance] and
+        # [main_v2] do not produce a "main" or "master" token).
+        in_push && match($0, /branches:[[:space:]]*\[[^]]*\]/) {
+          s = substr($0, RSTART, RLENGTH)
+          gsub(/\[/, "", s)
+          gsub(/\]/, "", s)
+          gsub(/"/, "", s)
+          gsub(/\047/, "", s)
+          n = split(s, a, /[, ]+/)
+          for (i = 1; i <= n; i++) {
+            if (a[i] == "main" || a[i] == "master") {
+              found = 1
+              break
+            }
+          }
+        }
+        # YAML-list form: a `branches:` line followed by indented
+        # `- main` / `- master` entries. Exact line anchors avoid needing
+        # word-boundary support.
+        in_push && /^[[:space:]]+branches:[[:space:]]*$/ {
+          in_list = 1
+          next
+        }
+        in_list && /^[[:space:]]+-[[:space:]]+["'\''"]?(main|master)["'\''"]?[[:space:]]*$/ {
+          found = 1
+          in_list = 0
+        }
+        in_list && !/^[[:space:]]+-/ && !/^[[:space:]]*$/ { in_list = 0 }
+        END { exit !found }
+      ' "$f"; then
       echo "$f"
     fi
   done
 fi
 ```
 
-If the loop prints any files, note that a **release workflow likely exists** that will automatically create a GitHub Release when a release tag is pushed. The detection looks for workflow files that contain both a `tags:` trigger and a YAML list entry whose value starts with `v` followed by `*`, `[`, or a digit (e.g., `- "v*"`, `- 'v*'`, `- "v[0-9]*.[0-9]*.[0-9]*"`, `- "v[0-9]+.[0-9]+.[0-9]+"`, or unquoted `- v*`), or starts with `catalog-` for Claude Code marketplace releases. Anchoring to list-item form avoids false positives from action refs like `actions/checkout@v4`. It is best-effort and may miss inline list forms (e.g., `tags: ['v*']`) or other exotic patterns. If the detection seems wrong, ask the user to confirm. This flag affects step 11.
+If the loop prints any files, note that a **release workflow likely exists** that will automatically create a GitHub Release. Preserve which workflow kind was detected, because marketplace catalog releases handle the two kinds differently:
+
+- **Tag-triggered workflows**: a `tags:` trigger plus a YAML list entry whose value starts with `v` followed by `*`, `[`, or a digit (e.g., `- "v*"`, `- "v[0-9]+.[0-9]+.[0-9]+"`), or starts with `catalog-`. Anchoring to list-item form avoids false positives from action refs like `actions/checkout@v4`.
+- **Marketplace push-to-main workflows**: a workflow that invokes `bin/compute-catalog-state`, runs `gh release create`, and triggers on push to the default branch (`main` or `master`). All three signals together mark end-to-end automation that tags and publishes on push to the default branch. A workflow that only computes the catalog state (e.g., for validation) does not qualify, and neither does a workflow_dispatch-only or PR-triggered workflow that happens to invoke both, since neither will run when a commit lands on main.
+
+Detection is best-effort and may miss inline list forms (e.g., `tags: ['v*']`) or other exotic patterns. If the detection seems wrong, ask the user to confirm. This workflow kind affects M4-M8 for marketplace releases and step 11 for SemVer releases. For marketplace releases, only a **marketplace push-to-main workflow** skips local catalog tagging; a **tag-triggered workflow** still needs M7 to create the exact `catalog-*` tag so pushing that tag can fire the workflow.
 
 **Abort conditions:**
 
@@ -123,38 +203,150 @@ Confirm the individual plugin version changes with the user before modifying fil
 
 #### M3. Compute Catalog State
 
-After plugin versions are final, compute the catalog state from marketplace plugin versions. Use strict `MAJOR.MINOR.PATCH` parsing (matching `bin/validate-plugins`) so malformed versions fail loudly instead of silently producing an incorrect tag:
+After plugin versions are final, compute the catalog state from marketplace plugin versions. Prefer the project's helper script when present so the skill stays in sync with whatever the repository considers canonical:
 
 ```bash
-jq -r '
-  def parse_version:
-    capture("^(?<major>[0-9]+)\\.(?<minor>[0-9]+)\\.(?<patch>[0-9]+)$")
-    | {
-        major: (.major | tonumber),
-        minor: (.minor | tonumber),
-        patch: (.patch | tonumber)
-      };
+if [ -f bin/compute-catalog-state ]; then
+  if [ -x bin/compute-catalog-state ]; then
+    bin/compute-catalog-state
+  else
+    # Helper exists but lost its executable bit. Fail loudly rather than
+    # falling back to the inline jq: the helper is the single source of
+    # truth that bin/validate-plugins and the release workflow consume,
+    # and silently bypassing it would let /release publish a tag the
+    # validator and CI then reject.
+    echo "bin/compute-catalog-state exists but is not executable. Run 'chmod +x bin/compute-catalog-state' (and commit the mode bit) before re-running /release." >&2
+    exit 1
+  fi
+else
+  jq -r '
+    def parse_version:
+      capture("^(?<major>[0-9]+)\\.(?<minor>[0-9]+)\\.(?<patch>[0-9]+)$")
+      | {
+          major: (.major | tonumber),
+          minor: (.minor | tonumber),
+          patch: (.patch | tonumber)
+        };
 
-  [.plugins[].version | parse_version] as $versions
-  | "catalog-M\($versions | map(.major) | add)-m\($versions | map(.minor) | add)-p\($versions | map(.patch) | add)-n\($versions | length)"
-' .claude-plugin/marketplace.json
+    [.plugins[].version | parse_version] as $versions
+    | "catalog-M\($versions | map(.major) | add)-m\($versions | map(.minor) | add)-p\($versions | map(.patch) | add)-n\($versions | length)"
+  ' .claude-plugin/marketplace.json
+fi
 ```
+
+The inline fallback applies only when the helper is absent (e.g., older repos that have not adopted `bin/compute-catalog-state`). It uses strict `MAJOR.MINOR.PATCH` parsing (matching `bin/validate-plugins`) so malformed versions fail loudly instead of silently producing an incorrect tag.
 
 Update `.claude-plugin/marketplace.json` `metadata.version` to exactly the computed catalog state.
 
-#### M4. Abort if Tag Exists
+#### M4. Reconcile Existing Catalog State Tag
 
-Before any commit or tag operation, check whether the exact catalog state tag already exists:
+Before any commit or tag operation, check whether the exact catalog state tag already exists, locally and (if a remote is configured) on the remote, and reconcile against `HEAD`.
+
+Compare commit SHAs, not just the tag name. The catalog-state format is sum-based and not collision-free: two different plugin-version mixes can produce the same component sums (for example, `+1` minor on plugin A paired with `-1` minor on plugin B). Treating any same-named tag as "already released" would silently drop a real catalog change. Comparing SHAs lets the skill idempotently skip true repeats while loudly aborting on real collisions.
+
+A same-named tag at a different commit does not always mean a collision, though. The release workflow legitimately reuses an existing catalog tag when later commits leave every plugin's `version` unchanged (for example, a docs-only follow-up after a marketplace bump). M4 must mirror that logic so `/release` does not falsely report a collision and tell the user to bump versions when there is genuinely nothing to release.
 
 ```bash
-git rev-parse -q --verify "refs/tags/CATALOG-STATE"
+head_commit="$(git rev-parse HEAD)"
+
+# Annotated tags expose the commit they point to via the peeled refspec
+# (^{}). Lightweight tags expose the commit directly. Try both locally.
+local_commit="$(git rev-parse -q --verify "refs/tags/CATALOG-STATE^{commit}" 2> /dev/null || true)"
+
+# Only consult the remote when one is configured. Repos without an
+# `origin` remote (preparing a release locally and publishing later) must
+# not fail here just because `git ls-remote origin` would error out.
+remote_commit=""
+if git remote get-url origin > /dev/null 2>&1; then
+  # Capture ls-remote's output and exit status separately. Piping straight
+  # into `cut` would mask auth/network failures: cut succeeds on empty
+  # input, so an authentication error or a transient network failure
+  # would leave remote_commit empty and silently fall back to the local
+  # tag. That can mask an already-published remote CATALOG-STATE tag and
+  # surface the conflict only when the eventual `git push` fails.
+  if ! ls_remote_output="$(git ls-remote origin "refs/tags/CATALOG-STATE^{}" "refs/tags/CATALOG-STATE" 2>&1)"; then
+    {
+      echo "git ls-remote origin failed:"
+      printf '%s\n' "${ls_remote_output}"
+      echo
+      echo "Cannot verify whether catalog state CATALOG-STATE is already published on origin."
+      echo "Resolve the network or authentication issue and re-run /release rather than"
+      echo "proceeding with a possibly-stale local view of remote tags."
+    } >&2
+    exit 1
+  fi
+  # Prefer the peeled refspec (annotated tags); fall back to the unpeeled
+  # refspec (lightweight tags). Both are queried in one ls-remote call.
+  remote_commit="$(printf '%s\n' "${ls_remote_output}" | awk '$2 == "refs/tags/CATALOG-STATE^{}" {print $1; exit}')"
+  if [[ -z "${remote_commit}" ]]; then
+    remote_commit="$(printf '%s\n' "${ls_remote_output}" | awk '$2 == "refs/tags/CATALOG-STATE" {print $1; exit}')"
+  fi
+fi
+
+# Prefer the remote tag whenever it exists. Published tags are
+# authoritative; a stale or recreated local tag pointing at HEAD must
+# not mask a remote ref pointing at a different commit. Track whether
+# the matching tag came from the remote or only from the local clone:
+# a local-only tag is not proof that the catalog state was published.
+existing_commit=""
+existing_tag_source=""
+if [[ -n "${remote_commit}" ]]; then
+  existing_commit="${remote_commit}"
+  existing_tag_source="remote"
+elif [[ -n "${local_commit}" ]]; then
+  existing_commit="${local_commit}"
+  existing_tag_source="local"
+fi
 ```
 
-If the tag already exists, abort with a message that the tag `CATALOG-STATE` already exists. Do not create another tag or choose a different state tag unless the user explicitly changes plugin versions.
+Cases:
+
+- **No existing tag** (`existing_commit` empty): proceed.
+- **Remote tag exists at `HEAD`** (`existing_tag_source=remote`): a release for this catalog state is already published at this commit. Report that there is nothing to release and stop. Do not retag or republish.
+- **Only a local tag exists at `HEAD`** (`existing_tag_source=local`): the catalog state is already tagged locally, but it is not known to be published. Do not report that there is nothing to release. Continue to M5-M8, skip creating a replacement tag in M7, and publish the existing local tag if the user chooses to publish. If no remote is configured, M8 will stop with the normal "configure a Git remote" guidance.
+- **Tag exists at a different commit**: distinguish "catalog state genuinely unchanged" from "real collision" by comparing the marketplace plugin versions at the tagged commit against `HEAD`'s. This is the same comparison `.github/workflows/release.yml` performs:
+
+  ```bash
+  tagged_versions="$(git show "${existing_commit}:.claude-plugin/marketplace.json" 2> /dev/null | jq -ec '[.plugins[] | {name, version}]' || echo '')"
+  head_versions="$(jq -ec '[.plugins[] | {name, version}]' .claude-plugin/marketplace.json)"
+
+  if [[ -n "${tagged_versions}" && "${tagged_versions}" == "${head_versions}" ]]; then
+    # Plugin versions are identical, so the catalog state is unchanged.
+    # Report that there is nothing to release and stop. Do not retag.
+    :
+  else
+    # Real catalog-state collision; abort with the message below.
+    :
+  fi
+  ```
+
+  If `tagged_versions` is empty (the tagged commit is not reachable locally, common when the branch lacks remote history), treat the situation as a collision rather than silently proceeding. The user can fetch the tag and re-run, or bump a plugin to break the apparent collision.
+
+For the collision case, present this to the user:
+
+```text
+Catalog state tag CATALOG-STATE already exists at a different commit
+with different plugin versions.
+
+Existing tag points to: <existing_commit>
+Current commit:         <head_commit>
+
+This is a catalog-state collision: the marketplace plugin versions
+changed in a way that produces the same per-component sums as a
+previously-released catalog state. The format is sum-based and not
+collision-free.
+
+To resolve, bump one plugin's version by an additional patch so the
+marketplace produces a unique catalog state, then re-run /release.
+```
+
+Do not create another tag or choose a different state tag automatically. The user must change plugin versions to break the collision.
 
 #### M5. Pre-Tag Review
 
-Build a final review and wait for explicit user approval:
+Build a final review and wait for explicit user approval. The wording depends on which release workflow kind was detected in step 1.
+
+If **no marketplace push-to-main workflow** was detected:
 
 ```text
 Pre-tag review for CATALOG-STATE:
@@ -165,30 +357,54 @@ Files modified:
 
 Catalog state:
   - Tag: CATALOG-STATE
-  - GitHub Release title: Marketplace CATALOG-STATE
+  - GitHub Release: created by tag-triggered workflow after the tag is pushed
+    (or created directly by this skill if no release workflow was detected)
 
 Tags are immutable. Proceed with commit and tag?
 ```
 
+If a **marketplace push-to-main workflow** was detected:
+
+```text
+Pre-release review for CATALOG-STATE:
+
+Files modified:
+  - .claude-plugin/marketplace.json (metadata.version updated, plugin versions mirrored)
+  - plugins/<name>/.claude-plugin/plugin.json (plugin version bumped)
+
+Catalog state CATALOG-STATE will be tagged and released automatically by the
+detected marketplace push-to-main workflow when this change reaches the default
+branch. No local tag will be created.
+
+Proceed with commit?
+```
+
 If `--dry-run` was specified, present this as a proposed review and stop. Do not stage changes, commit, tag, push, or create a GitHub Release.
 
-#### M6. Create Marketplace Release Commit
+#### M6. Create Marketplace Commit
 
-Stage only the files changed by the release and create a GPG-signed commit:
+Stage only the files changed by the release and create a GPG-signed commit. Choose the commit message based on whether marketplace push-to-main automation was detected:
+
+- **No marketplace push-to-main workflow**: use `release: CATALOG-STATE` so the message marks the local tag. This includes tag-triggered release workflows, because this skill still creates and pushes the exact catalog tag that fires the workflow.
+- **Marketplace push-to-main workflow detected**: use a conventional commit that describes the underlying plugin change (e.g., `chore: bump <plugin> to <version> and resync catalog state`, or `feat(<plugin>): <summary>` if the bump is a feature). The workflow will produce its own release-named tag from the resulting `metadata.version`; the commit subject should describe the work, not the catalog state.
 
 ```bash
 git add <FILES>
 git commit -S -m "$(cat <<'EOF'
-release: CATALOG-STATE
+<commit subject per the rule above>
 EOF
 )"
 ```
 
 CRITICAL: Never use `git commit --amend`. Always create a new commit. If a pre-commit hook fails, fix the issue, re-stage, and create a new commit.
 
-#### M7. Create Marketplace Tag
+#### M7. Tag the Catalog State
 
-Create a GPG-signed annotated tag using the exact catalog state:
+Skip this step entirely if a **marketplace push-to-main workflow** was detected in step 1. The workflow is the only writer of `catalog-*` tags in that case; creating one locally would break workflow idempotency by registering a tag the workflow then sees as already existing.
+
+If M4 found an **only-local tag at `HEAD`** (`existing_tag_source=local`), do not create a replacement tag. Reuse that existing local tag in M8 so the user can finish publishing it.
+
+Otherwise, create a GPG-signed annotated tag using the exact catalog state:
 
 ```bash
 git tag -s CATALOG-STATE -m "CATALOG-STATE"
@@ -202,24 +418,92 @@ After tagging, confirm:
 Marketplace release CATALOG-STATE tagged locally.
 ```
 
-#### M8. Publish Marketplace Release
+#### M8. Publish
 
-Ask the user if they want to push the commit and tag.
+The publish step depends on which release workflow kind was detected in step 1.
 
-If no release workflow was detected in step 1:
+##### M8a. Marketplace push-to-main workflow detected
+
+The workflow will create the tag and GitHub Release automatically once the commit lands on the default branch (usually `main`). The skill should not push tags or create releases directly.
+
+Ask the user how they want to land the commit:
+
+```text
+Commit for CATALOG-STATE is ready.
+The marketplace push-to-main workflow will tag and release it once it merges into the default branch.
+
+How would you like to publish?
+  - Open a pull request (recommended)
+  - Push directly to the default branch (only if your workflow allows)
+  - Stop here and publish manually
+```
+
+If the user opens a PR, recommend the `/pr` skill. If the user pushes directly to the default branch, the commit must reach that branch on the remote. From the default branch itself, recommend the `/commit` skill's push step (or `git push origin HEAD`). From a feature branch, `git push origin HEAD` only updates the feature branch on the remote, leaving the default branch untouched and the release workflow inert; in that case the user must fast-forward or merge the commit onto the default branch first (`/pr` is the safest path), or push the commit explicitly with a refspec like `git push origin HEAD:main` if their branch protection rules allow it. In either case, do not run the push from this skill: leave that decision to the dedicated skill so its safety checks apply.
+
+After the user confirms how they intend to publish, report:
+
+```text
+Catalog state CATALOG-STATE is committed locally.
+
+After this commit reaches the default branch, the release workflow will:
+  - Create annotated tag CATALOG-STATE
+  - Publish "Marketplace CATALOG-STATE" with auto-generated release notes
+```
+
+##### M8b. Tag-triggered release workflow detected
+
+Ask the user if they want to push the commit and tag:
+
+```text
+Push commit and tag for CATALOG-STATE?
+(Tag-triggered release workflow detected; it will create the GitHub Release when the tag is pushed.)
+```
+
+If the user declines, show the manual commands and stop:
+
+```text
+Marketplace release CATALOG-STATE is ready locally.
+
+To publish manually:
+  git push origin HEAD
+  git push origin CATALOG-STATE
+
+The tag-triggered release workflow will create the GitHub Release automatically when the tag is pushed.
+```
+
+If the user accepts, push the commit and tag.
+
+First, check for a remote:
+
+```bash
+git remote get-url origin
+```
+
+If no remote is configured, report the error and tell the user to configure a Git remote before rerunning this step. Do not show any `git push origin ...` commands in this case. Stop.
+
+```bash
+git push origin HEAD
+git push origin CATALOG-STATE
+```
+
+If the push is rejected, report the error and stop. Never force push.
+
+Report:
+
+```text
+Marketplace release CATALOG-STATE tag pushed.
+The tag-triggered release workflow will create the GitHub Release.
+```
+
+##### M8c. No release workflow detected
+
+Ask the user if they want to push the commit and tag:
 
 ```text
 Push and create a GitHub Release for CATALOG-STATE?
 ```
 
-If a release workflow was detected in step 1:
-
-```text
-Push commit and tag for CATALOG-STATE?
-(Release workflow detected; it will create the GitHub Release automatically.)
-```
-
-If the user declines and no release workflow was detected, show:
+If the user declines, show the manual commands and stop:
 
 ```text
 Marketplace release CATALOG-STATE is ready locally.
@@ -230,19 +514,7 @@ To publish manually:
   gh release create CATALOG-STATE --title "Marketplace CATALOG-STATE" --notes-file <release-notes-file> --verify-tag
 ```
 
-If the user declines and a release workflow was detected, show:
-
-```text
-Marketplace release CATALOG-STATE is ready locally.
-
-To publish manually:
-  git push origin HEAD
-  git push origin CATALOG-STATE
-
-The release workflow will create the GitHub Release automatically when the tag is pushed.
-```
-
-If the user accepts, push the commit and tag:
+If the user accepts, push the commit and tag.
 
 First, check for a remote:
 
@@ -259,16 +531,7 @@ git push origin CATALOG-STATE
 
 If the push is rejected, report the error and stop. Never force push. Show the remaining manual commands so the user can complete the process after resolving the push issue.
 
-If a release workflow was detected, skip manual GitHub Release creation and report:
-
-```text
-Tagged CATALOG-STATE and pushed to origin.
-
-  Tag: CATALOG-STATE
-  GitHub Release: the release workflow is expected to create it automatically.
-```
-
-If no release workflow was detected, create release notes from the commit summary or changed plugin list. First, check that `gh` is available:
+Create release notes from the commit summary or changed plugin list. First, check that `gh` is available:
 
 ```bash
 command -v gh
@@ -608,11 +871,15 @@ Release vVERSION published.
 - **Version file not found:** Skip source file updates, rely on git tag, inform the user.
 - **CHANGELOG parse error:** If the existing file has an unrecognized format, warn the user and offer to create a new one or append a version section at the top.
 - **Tag already exists:** Abort with a message that the tag `vVERSION` already exists. Suggest choosing a different version.
-- **Marketplace catalog tag already exists:** Abort with a message that the tag `CATALOG-STATE` already exists. Recompute the catalog state only after the user changes individual plugin versions.
+- **Marketplace catalog remote tag already exists at HEAD:** A release for this catalog state is already published at this commit. Report that there is nothing to release and stop; do not retag.
+- **Marketplace catalog local-only tag already exists at HEAD:** The catalog state is tagged locally but is not known to be published. Continue through M5-M8, skip replacement tag creation in M7, and publish the existing local tag if the user chooses to publish.
+- **Marketplace catalog tag already exists at a different commit, same plugin versions:** The catalog state is genuinely unchanged (e.g., a docs-only follow-up reused the previous catalog state). Report that there is nothing to release and stop; do not retag.
+- **Marketplace catalog tag already exists at a different commit, different plugin versions:** Treat as a catalog-state collision (the sum-based tag format is not collision-free). Abort with the collision-aware message in M4 and ask the user to bump one plugin so the marketplace produces a unique catalog state. Do not retag or rename.
 - **Not a git repository:** Abort immediately.
 - **No remote configured:** Skip comparison links in CHANGELOG, skip push and GitHub Release in step 11, warn the user.
 - **First release:** Use `v0.0.0` as the base for bump calculation, create the CHANGELOG from scratch, skip doc version updates (no old version to replace).
 - **Push rejected:** Report the error and show remaining manual commands. Never force push.
-- **Release workflow detected:** Skip manual GitHub Release creation; the workflow will create it when the tag is pushed. Push the commit and tag only.
+- **Release workflow detected (tag-triggered):** Skip manual GitHub Release creation; the workflow will create it when the tag is pushed. Push the commit and tag only.
+- **Release workflow detected (marketplace push-to-main):** Skip the local catalog tag entirely (M7) and skip both push and GitHub Release creation in M8. The workflow tags and releases when the commit reaches the default branch; the skill's job ends at the local commit. Recommend `/pr` or the user's chosen merge path.
 - **`gh` not available:** Push the commit and tag, skip GitHub Release creation, note that `gh` is required for GitHub Releases and show the manual `gh release create` command.
 - **GitHub Release creation fails:** The push already succeeded, so the tag is on the remote. Report the `gh` error and show the manual `gh release create` command for the user to retry.

--- a/dist/codex/plugins/release/skills/release/SKILL.md
+++ b/dist/codex/plugins/release/skills/release/SKILL.md
@@ -302,7 +302,7 @@ fi
 Cases:
 
 - **No existing tag** (`existing_commit` empty): proceed.
-- **Remote tag exists at `HEAD`** (`existing_tag_source=remote`): a release for this catalog state is already published at this commit. Report that there is nothing to release and stop. Do not retag or republish.
+- **Remote tag exists at `HEAD`** (`existing_tag_source=remote`): do not retag. If no release workflow was detected, continue to M8c so the skill can verify or create the GitHub Release for the existing remote tag; a previous manual release may have pushed the tag and failed before `gh release create`. If a release workflow was detected, report that the catalog tag is already on the remote and the workflow owns GitHub Release publication; do not push the tag again.
 - **Only a local tag exists at `HEAD`** (`existing_tag_source=local`): the catalog state is already tagged locally, but it is not known to be published. Do not report that there is nothing to release. Continue to M5-M8, skip creating a replacement tag in M7, and publish the existing local tag if the user chooses to publish. If no remote is configured, M8 will stop with the normal "configure a Git remote" guidance.
 - **Tag exists at a different commit**: distinguish "catalog state genuinely unchanged" from "real collision" by comparing the marketplace plugin versions at the tagged commit against `HEAD`'s. This is the same comparison `.github/workflows/release.yml` performs:
 
@@ -312,7 +312,9 @@ Cases:
 
   if [[ -n "${tagged_versions}" && "${tagged_versions}" == "${head_versions}" ]]; then
     # Plugin versions are identical, so the catalog state is unchanged.
-    # Report that there is nothing to release and stop. Do not retag.
+    # Do not retag. If no release workflow was detected, continue to M8c
+    # so the skill can create a missing GitHub Release for the existing
+    # remote tag. Otherwise report that the release workflow owns publication.
     :
   else
     # Real catalog-state collision; abort with the message below.
@@ -403,6 +405,8 @@ CRITICAL: Never use `git commit --amend`. Always create a new commit. If a pre-c
 Skip this step entirely if a **marketplace push-to-main workflow** was detected in step 1. The workflow is the only writer of `catalog-*` tags in that case; creating one locally would break workflow idempotency by registering a tag the workflow then sees as already existing.
 
 If M4 found an **only-local tag at `HEAD`** (`existing_tag_source=local`), do not create a replacement tag. Reuse that existing local tag in M8 so the user can finish publishing it.
+
+If M4 found an **existing remote tag** to reuse (either at `HEAD` or at a different commit with identical plugin versions), do not create a replacement tag. The remote tag is authoritative for this catalog state. In the no-workflow path, M8c can still create the missing GitHub Release for that existing tag.
 
 Otherwise, create a GPG-signed annotated tag using the exact catalog state:
 
@@ -497,6 +501,16 @@ The tag-triggered release workflow will create the GitHub Release.
 
 ##### M8c. No release workflow detected
 
+If M4 found an **existing remote tag** to reuse, this is a release-recovery path rather than a tag-publishing path. Do not push `CATALOG-STATE` again and do not create a replacement local tag. If a release commit was created locally, ask whether to push the commit before creating the GitHub Release; if there are no local commits to publish, skip the commit push as well.
+
+Before creating a GitHub Release for an existing remote tag, check whether it already exists:
+
+```bash
+gh release view CATALOG-STATE --json tagName
+```
+
+If the release exists, report that the catalog tag and GitHub Release already exist and stop. If `gh release view` reports the release is missing, continue with release-note creation and `gh release create` below. If it fails for another reason (auth, API, or network), report the error and stop rather than treating it as missing.
+
 Ask the user if they want to push the commit and tag:
 
 ```text
@@ -509,10 +523,12 @@ If the user declines, show the manual commands and stop:
 Marketplace release CATALOG-STATE is ready locally.
 
 To publish manually:
-  git push origin HEAD
-  git push origin CATALOG-STATE
-  gh release create CATALOG-STATE --title "Marketplace CATALOG-STATE" --notes-file <release-notes-file> --verify-tag
+git push origin HEAD
+git push origin CATALOG-STATE
+gh release create CATALOG-STATE --title "Marketplace CATALOG-STATE" --notes-file <release-notes-file> --verify-tag
 ```
+
+If M4 found an existing remote tag to reuse, omit `git push origin CATALOG-STATE` from the manual commands. Keep `gh release create ... --verify-tag`, since the tag is already on the remote.
 
 If the user accepts, push the commit and tag.
 
@@ -528,6 +544,8 @@ If no remote is configured, report the error and tell the user to configure a Gi
 git push origin HEAD
 git push origin CATALOG-STATE
 ```
+
+If M4 found an existing remote tag to reuse, skip `git push origin CATALOG-STATE`. The tag is already on the remote, and pushing it again can fail or be a no-op depending on local tag state.
 
 If the push is rejected, report the error and stop. Never force push. Show the remaining manual commands so the user can complete the process after resolving the push issue.
 
@@ -871,9 +889,9 @@ Release vVERSION published.
 - **Version file not found:** Skip source file updates, rely on git tag, inform the user.
 - **CHANGELOG parse error:** If the existing file has an unrecognized format, warn the user and offer to create a new one or append a version section at the top.
 - **Tag already exists:** Abort with a message that the tag `vVERSION` already exists. Suggest choosing a different version.
-- **Marketplace catalog remote tag already exists at HEAD:** A release for this catalog state is already published at this commit. Report that there is nothing to release and stop; do not retag.
+- **Marketplace catalog remote tag already exists at HEAD:** Do not retag. In the no-workflow path, continue to M8c to verify or create the GitHub Release for the existing remote tag. With release workflow automation, report that the remote tag exists and the workflow owns release publication.
 - **Marketplace catalog local-only tag already exists at HEAD:** The catalog state is tagged locally but is not known to be published. Continue through M5-M8, skip replacement tag creation in M7, and publish the existing local tag if the user chooses to publish.
-- **Marketplace catalog tag already exists at a different commit, same plugin versions:** The catalog state is genuinely unchanged (e.g., a docs-only follow-up reused the previous catalog state). Report that there is nothing to release and stop; do not retag.
+- **Marketplace catalog tag already exists at a different commit, same plugin versions:** The catalog state is genuinely unchanged (e.g., a docs-only follow-up reused the previous catalog state). Do not retag. In the no-workflow path, continue to M8c to verify or create the GitHub Release for the existing remote tag; with release workflow automation, report that the workflow owns release publication.
 - **Marketplace catalog tag already exists at a different commit, different plugin versions:** Treat as a catalog-state collision (the sum-based tag format is not collision-free). Abort with the collision-aware message in M4 and ask the user to bump one plugin so the marketplace produces a unique catalog state. Do not retag or rename.
 - **Not a git repository:** Abort immediately.
 - **No remote configured:** Skip comparison links in CHANGELOG, skip push and GitHub Release in step 11, warn the user.

--- a/dist/codex/plugins/release/skills/release/SKILL.md
+++ b/dist/codex/plugins/release/skills/release/SKILL.md
@@ -358,7 +358,7 @@ Do not create another tag or choose a different state tag automatically. The use
 
 Build a final review and wait for explicit user approval. The wording depends on which release workflow kind was detected in step 1.
 
-If M4 found an **existing remote tag at a different commit with identical plugin versions** and M3 produced no release-file changes, skip the pre-tag review. The release-recovery path has no new commit or tag to approve; M8c handles the user approval before creating any missing GitHub Release.
+If M4 found an **existing catalog state tag to reuse** and M3 produced no release-file changes, skip the pre-tag review. The release-recovery path has no new commit or tag to approve; M8 handles the user approval before publishing any existing local tag or creating any missing GitHub Release.
 
 If **no marketplace push-to-main workflow** was detected:
 
@@ -397,7 +397,7 @@ If `--dry-run` was specified, present this as a proposed review and stop. Do not
 
 #### M6. Create Marketplace Commit
 
-If M4 found an **existing remote tag at a different commit with identical plugin versions**, first check whether M3 produced any release-file changes:
+If M4 found an **existing catalog state tag to reuse** (`existing_commit` is non-empty and the case was not a collision), first check whether M3 produced any release-file changes:
 
 ```bash
 if git diff --quiet -- .claude-plugin/marketplace.json plugins/*/.claude-plugin/plugin.json; then
@@ -407,10 +407,11 @@ else
 fi
 ```
 
-When no release-file changes exist, skip commit creation. This is the release-recovery path: do not create an empty commit, and do not stage or commit unrelated local changes. Continue based on the workflow kind:
+When no release-file changes exist, skip commit creation. This is the release-recovery path: do not create an empty commit, and do not stage or commit unrelated local changes. Continue based on the tag source and workflow kind:
 
-- **Release workflow detected**: report that the existing remote catalog tag is present and the workflow owns GitHub Release publication. Stop without creating a local commit or tag.
-- **No release workflow detected**: continue to M8c with `release_commit_created=0` so the skill can verify or create the missing GitHub Release for the existing remote tag.
+- **Existing remote tag and release workflow detected**: report that the existing remote catalog tag is present and the workflow owns GitHub Release publication. Stop without creating a local commit or tag.
+- **Existing local-only tag and tag-triggered release workflow detected**: continue to M8b with `release_commit_created=0` so the skill can publish the existing local tag without pushing an unrelated branch tip.
+- **No release workflow detected**: continue to M8c with `release_commit_created=0` so the skill can publish an existing local tag if needed, or verify or create the missing GitHub Release for an existing remote tag.
 
 For all other M4 cases, or when release files changed, stage only the files changed by the release and create a GPG-signed commit. Choose the commit message based on whether marketplace push-to-main automation was detected:
 
@@ -483,7 +484,7 @@ After this commit reaches the default branch, the release workflow will:
 
 ##### M8b. Tag-triggered release workflow detected
 
-Ask the user if they want to push the commit and tag:
+Ask the user if they want to push the commit and tag. If `release_commit_created=0`, ask whether to push the existing local tag instead:
 
 ```text
 Push commit and tag for CATALOG-STATE?
@@ -502,7 +503,9 @@ To publish manually:
 The tag-triggered release workflow will create the GitHub Release automatically when the tag is pushed.
 ```
 
-If the user accepts, push the commit and tag.
+If `release_commit_created=0`, omit `git push origin HEAD` from the manual commands. There is no new release commit to publish, and pushing `HEAD` could publish an unrelated branch tip. Keep `git push origin CATALOG-STATE` so the existing local tag can fire the tag-triggered workflow.
+
+If the user accepts, push the commit and tag. Skip the commit push when `release_commit_created=0`:
 
 First, check for a remote:
 
@@ -513,7 +516,10 @@ git remote get-url origin
 If no remote is configured, report the error and tell the user to configure a Git remote before rerunning this step. Do not show any `git push origin ...` commands in this case. Stop.
 
 ```bash
-git push origin HEAD
+if [ "${release_commit_created:-1}" -eq 1 ]; then
+  git push origin HEAD
+fi
+
 git push origin CATALOG-STATE
 ```
 
@@ -528,9 +534,9 @@ The tag-triggered release workflow will create the GitHub Release.
 
 ##### M8c. No release workflow detected
 
-If M4 found an **existing remote tag** to reuse, this is a release-recovery path rather than a tag-publishing path. Do not push `CATALOG-STATE` again and do not create a replacement local tag. If a release commit was created locally, ask whether to push the commit before creating the GitHub Release; if there are no local commits to publish, skip the commit push as well.
+If M4 found an **existing tag** to reuse, this is a release-recovery path. For an existing remote tag, do not push `CATALOG-STATE` again and do not create a replacement local tag. For an existing local-only tag, publish that tag if the user accepts. If a release commit was created locally, ask whether to push the commit before creating the GitHub Release; if there are no local commits to publish, skip the commit push as well.
 
-Before creating a GitHub Release for an existing remote tag, check whether it already exists:
+Before creating a GitHub Release for an existing remote tag, check whether it already exists. If M4 found an existing local-only tag, skip this pre-check until after the tag is pushed:
 
 ```bash
 gh release view CATALOG-STATE --json tagName
@@ -555,7 +561,7 @@ git push origin CATALOG-STATE
 gh release create CATALOG-STATE --title "Marketplace CATALOG-STATE" --notes-file <release-notes-file> --verify-tag
 ```
 
-If M4 found an existing remote tag to reuse, omit `git push origin CATALOG-STATE` from the manual commands. Keep `gh release create ... --verify-tag`, since the tag is already on the remote.
+If `release_commit_created=0`, omit `git push origin HEAD` from the manual commands. There is no new release commit to publish, and pushing `HEAD` could publish an unrelated branch tip. If M4 found an existing remote tag to reuse, also omit `git push origin CATALOG-STATE`. Keep `gh release create ... --verify-tag`, since the tag is already on the remote. If M4 found an existing local-only tag to reuse, keep `git push origin CATALOG-STATE` so the existing local tag is published before `gh release create`.
 
 If the user accepts, push the commit and tag.
 
@@ -568,11 +574,16 @@ git remote get-url origin
 If no remote is configured, report the error and tell the user to configure a Git remote before rerunning this step. Do not show any `git push origin ...` commands in this case. Stop.
 
 ```bash
-git push origin HEAD
-git push origin CATALOG-STATE
+if [ "${release_commit_created:-1}" -eq 1 ]; then
+  git push origin HEAD
+fi
+
+if [ "${existing_tag_source:-}" != "remote" ]; then
+  git push origin CATALOG-STATE
+fi
 ```
 
-If M4 found an existing remote tag to reuse, skip `git push origin CATALOG-STATE`. The tag is already on the remote, and pushing it again can fail or be a no-op depending on local tag state.
+If M4 found an existing remote tag to reuse, the tag push is skipped. The tag is already on the remote, and pushing it again can fail or be a no-op depending on local tag state.
 
 If the push is rejected, report the error and stop. Never force push. Show the remaining manual commands so the user can complete the process after resolving the push issue.
 

--- a/plugins/release/.claude-plugin/plugin.json
+++ b/plugins/release/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "name": "release",
   "repository": "https://github.com/cboone/cboone-cc-plugins",
   "skills": "./skills",
-  "version": "1.5.3"
+  "version": "1.5.4"
 }

--- a/plugins/release/.claude-plugin/plugin.json
+++ b/plugins/release/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "name": "release",
   "repository": "https://github.com/cboone/cboone-cc-plugins",
   "skills": "./skills",
-  "version": "1.5.2"
+  "version": "1.5.3"
 }

--- a/plugins/release/.claude-plugin/plugin.json
+++ b/plugins/release/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "name": "release",
   "repository": "https://github.com/cboone/cboone-cc-plugins",
   "skills": "./skills",
-  "version": "1.5.4"
+  "version": "1.5.5"
 }

--- a/plugins/release/.claude-plugin/plugin.json
+++ b/plugins/release/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "name": "release",
   "repository": "https://github.com/cboone/cboone-cc-plugins",
   "skills": "./skills",
-  "version": "1.5.7"
+  "version": "1.5.8"
 }

--- a/plugins/release/.claude-plugin/plugin.json
+++ b/plugins/release/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "name": "release",
   "repository": "https://github.com/cboone/cboone-cc-plugins",
   "skills": "./skills",
-  "version": "1.5.8"
+  "version": "1.5.9"
 }

--- a/plugins/release/.claude-plugin/plugin.json
+++ b/plugins/release/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "name": "release",
   "repository": "https://github.com/cboone/cboone-cc-plugins",
   "skills": "./skills",
-  "version": "1.4.2"
+  "version": "1.5.0"
 }

--- a/plugins/release/.claude-plugin/plugin.json
+++ b/plugins/release/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "name": "release",
   "repository": "https://github.com/cboone/cboone-cc-plugins",
   "skills": "./skills",
-  "version": "1.5.0"
+  "version": "1.5.1"
 }

--- a/plugins/release/.claude-plugin/plugin.json
+++ b/plugins/release/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "name": "release",
   "repository": "https://github.com/cboone/cboone-cc-plugins",
   "skills": "./skills",
-  "version": "1.5.6"
+  "version": "1.5.7"
 }

--- a/plugins/release/.claude-plugin/plugin.json
+++ b/plugins/release/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "name": "release",
   "repository": "https://github.com/cboone/cboone-cc-plugins",
   "skills": "./skills",
-  "version": "1.5.5"
+  "version": "1.5.6"
 }

--- a/plugins/release/.claude-plugin/plugin.json
+++ b/plugins/release/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "name": "release",
   "repository": "https://github.com/cboone/cboone-cc-plugins",
   "skills": "./skills",
-  "version": "1.5.1"
+  "version": "1.5.2"
 }

--- a/plugins/release/skills/release/SKILL.md
+++ b/plugins/release/skills/release/SKILL.md
@@ -144,8 +144,18 @@ Confirm the individual plugin version changes with the user before modifying fil
 After plugin versions are final, compute the catalog state from marketplace plugin versions. Prefer the project's helper script when present so the skill stays in sync with whatever the repository considers canonical:
 
 ```bash
-if [ -x bin/compute-catalog-state ]; then
-  bin/compute-catalog-state
+if [ -f bin/compute-catalog-state ]; then
+  if [ -x bin/compute-catalog-state ]; then
+    bin/compute-catalog-state
+  else
+    # Helper exists but lost its executable bit. Fail loudly rather than
+    # falling back to the inline jq: the helper is the single source of
+    # truth that bin/validate-plugins and the release workflow consume,
+    # and silently bypassing it would let /release publish a tag the
+    # validator and CI then reject.
+    echo "bin/compute-catalog-state exists but is not executable. Run 'chmod +x bin/compute-catalog-state' (and commit the mode bit) before re-running /release." >&2
+    exit 1
+  fi
 else
   jq -r '
     def parse_version:
@@ -162,26 +172,34 @@ else
 fi
 ```
 
-The fallback uses strict `MAJOR.MINOR.PATCH` parsing (matching `bin/validate-plugins`) so malformed versions fail loudly instead of silently producing an incorrect tag.
+The inline fallback applies only when the helper is absent (e.g., older repos that have not adopted `bin/compute-catalog-state`). It uses strict `MAJOR.MINOR.PATCH` parsing (matching `bin/validate-plugins`) so malformed versions fail loudly instead of silently producing an incorrect tag.
 
 Update `.claude-plugin/marketplace.json` `metadata.version` to exactly the computed catalog state.
 
-#### M4. Abort if Tag Exists at a Different Commit
+#### M4. Reconcile Existing Catalog State Tag
 
-Before any commit or tag operation, check whether the exact catalog state tag already exists, both locally and on the remote, and compare the commit it points to against `HEAD`.
+Before any commit or tag operation, check whether the exact catalog state tag already exists, locally and (if a remote is configured) on the remote, and reconcile against `HEAD`.
 
-Compare commit SHAs, not just the tag name. The catalog-state format is sum-based and not collision-free: two different plugin-version mixes can produce the same component sums (for example, `+1` minor on plugin A paired with `-1` minor on plugin B). Treating any same-named tag as "already released" would silently drop a real catalog change. Comparing SHAs lets the skill idempotently skip true repeats while loudly aborting on collisions.
+Compare commit SHAs, not just the tag name. The catalog-state format is sum-based and not collision-free: two different plugin-version mixes can produce the same component sums (for example, `+1` minor on plugin A paired with `-1` minor on plugin B). Treating any same-named tag as "already released" would silently drop a real catalog change. Comparing SHAs lets the skill idempotently skip true repeats while loudly aborting on real collisions.
+
+A same-named tag at a different commit does not always mean a collision, though. The release workflow legitimately reuses an existing catalog tag when later commits leave every plugin's `version` unchanged (for example, a docs-only follow-up after a marketplace bump). M4 must mirror that logic so `/release` does not falsely report a collision and tell the user to bump versions when there is genuinely nothing to release.
 
 ```bash
 head_commit="$(git rev-parse HEAD)"
 
 # Annotated tags expose the commit they point to via the peeled refspec
-# (^{}). Lightweight tags expose the commit directly. Try both, locally
-# and on the remote.
+# (^{}). Lightweight tags expose the commit directly. Try both locally.
 local_commit="$(git rev-parse -q --verify "refs/tags/CATALOG-STATE^{commit}" 2> /dev/null || true)"
-remote_commit="$(git ls-remote origin "refs/tags/CATALOG-STATE^{}" | cut -f1)"
-if [[ -z "${remote_commit}" ]]; then
-  remote_commit="$(git ls-remote origin "refs/tags/CATALOG-STATE" | cut -f1)"
+
+# Only consult the remote when one is configured. Repos without an
+# `origin` remote (preparing a release locally and publishing later) must
+# not fail here just because `git ls-remote origin` would error out.
+remote_commit=""
+if git remote get-url origin > /dev/null 2>&1; then
+  remote_commit="$(git ls-remote origin "refs/tags/CATALOG-STATE^{}" | cut -f1)"
+  if [[ -z "${remote_commit}" ]]; then
+    remote_commit="$(git ls-remote origin "refs/tags/CATALOG-STATE" | cut -f1)"
+  fi
 fi
 
 # Prefer the remote tag whenever it exists. Published tags are
@@ -190,22 +208,39 @@ fi
 existing_commit="${remote_commit:-${local_commit}}"
 ```
 
-Three cases:
+Cases:
 
 - **No existing tag** (`existing_commit` empty): proceed.
 - **Tag exists at `HEAD`**: a release for this catalog state is already published at this commit. Report that there is nothing to release and stop. Do not retag or republish.
-- **Tag exists at a different commit**: abort with a collision-aware error.
+- **Tag exists at a different commit**: distinguish "catalog state genuinely unchanged" from "real collision" by comparing the marketplace plugin versions at the tagged commit against `HEAD`'s. This is the same comparison `.github/workflows/release.yml` performs:
+
+  ```bash
+  tagged_versions="$(git show "${existing_commit}:.claude-plugin/marketplace.json" 2> /dev/null | jq -ec '[.plugins[] | {name, version}]' || echo '')"
+  head_versions="$(jq -ec '[.plugins[] | {name, version}]' .claude-plugin/marketplace.json)"
+
+  if [[ -n "${tagged_versions}" && "${tagged_versions}" == "${head_versions}" ]]; then
+    # Plugin versions are identical, so the catalog state is unchanged.
+    # Report that there is nothing to release and stop. Do not retag.
+    :
+  else
+    # Real catalog-state collision; abort with the message below.
+    :
+  fi
+  ```
+
+  If `tagged_versions` is empty (the tagged commit is not reachable locally, common when the branch lacks remote history), treat the situation as a collision rather than silently proceeding. The user can fetch the tag and re-run, or bump a plugin to break the apparent collision.
 
 For the collision case, present this to the user:
 
 ```text
-Catalog state tag CATALOG-STATE already exists at a different commit.
+Catalog state tag CATALOG-STATE already exists at a different commit
+with different plugin versions.
 
 Existing tag points to: <existing_commit>
 Current commit:         <head_commit>
 
-This usually indicates a catalog-state collision: the marketplace plugin
-versions changed in a way that produces the same per-component sums as a
+This is a catalog-state collision: the marketplace plugin versions
+changed in a way that produces the same per-component sums as a
 previously-released catalog state. The format is sum-based and not
 collision-free.
 
@@ -697,7 +732,8 @@ Release vVERSION published.
 - **CHANGELOG parse error:** If the existing file has an unrecognized format, warn the user and offer to create a new one or append a version section at the top.
 - **Tag already exists:** Abort with a message that the tag `vVERSION` already exists. Suggest choosing a different version.
 - **Marketplace catalog tag already exists at HEAD:** A release for this catalog state is already published at this commit. Report that there is nothing to release and stop; do not retag.
-- **Marketplace catalog tag already exists at a different commit:** Treat as a catalog-state collision (the sum-based tag format is not collision-free). Abort with the collision-aware message in M4 and ask the user to bump one plugin so the marketplace produces a unique catalog state. Do not retag or rename.
+- **Marketplace catalog tag already exists at a different commit, same plugin versions:** The catalog state is genuinely unchanged (e.g., a docs-only follow-up reused the previous catalog state). Report that there is nothing to release and stop; do not retag.
+- **Marketplace catalog tag already exists at a different commit, different plugin versions:** Treat as a catalog-state collision (the sum-based tag format is not collision-free). Abort with the collision-aware message in M4 and ask the user to bump one plugin so the marketplace produces a unique catalog state. Do not retag or rename.
 - **Not a git repository:** Abort immediately.
 - **No remote configured:** Skip comparison links in CHANGELOG, skip push and GitHub Release in step 11, warn the user.
 - **First release:** Use `v0.0.0` as the base for bump calculation, create the CHANGELOG from scratch, skip doc version updates (no old version to replace).

--- a/plugins/release/skills/release/SKILL.md
+++ b/plugins/release/skills/release/SKILL.md
@@ -305,7 +305,7 @@ fi
 Cases:
 
 - **No existing tag** (`existing_commit` empty): proceed.
-- **Remote tag exists at `HEAD`** (`existing_tag_source=remote`): a release for this catalog state is already published at this commit. Report that there is nothing to release and stop. Do not retag or republish.
+- **Remote tag exists at `HEAD`** (`existing_tag_source=remote`): do not retag. If no release workflow was detected, continue to M8c so the skill can verify or create the GitHub Release for the existing remote tag; a previous manual release may have pushed the tag and failed before `gh release create`. If a release workflow was detected, report that the catalog tag is already on the remote and the workflow owns GitHub Release publication; do not push the tag again.
 - **Only a local tag exists at `HEAD`** (`existing_tag_source=local`): the catalog state is already tagged locally, but it is not known to be published. Do not report that there is nothing to release. Continue to M5-M8, skip creating a replacement tag in M7, and publish the existing local tag if the user chooses to publish. If no remote is configured, M8 will stop with the normal "configure a Git remote" guidance.
 - **Tag exists at a different commit**: distinguish "catalog state genuinely unchanged" from "real collision" by comparing the marketplace plugin versions at the tagged commit against `HEAD`'s. This is the same comparison `.github/workflows/release.yml` performs:
 
@@ -315,7 +315,9 @@ Cases:
 
   if [[ -n "${tagged_versions}" && "${tagged_versions}" == "${head_versions}" ]]; then
     # Plugin versions are identical, so the catalog state is unchanged.
-    # Report that there is nothing to release and stop. Do not retag.
+    # Do not retag. If no release workflow was detected, continue to M8c
+    # so the skill can create a missing GitHub Release for the existing
+    # remote tag. Otherwise report that the release workflow owns publication.
     :
   else
     # Real catalog-state collision; abort with the message below.
@@ -406,6 +408,8 @@ CRITICAL: Never use `git commit --amend`. Always create a new commit. If a pre-c
 Skip this step entirely if a **marketplace push-to-main workflow** was detected in step 1. The workflow is the only writer of `catalog-*` tags in that case; creating one locally would break workflow idempotency by registering a tag the workflow then sees as already existing.
 
 If M4 found an **only-local tag at `HEAD`** (`existing_tag_source=local`), do not create a replacement tag. Reuse that existing local tag in M8 so the user can finish publishing it.
+
+If M4 found an **existing remote tag** to reuse (either at `HEAD` or at a different commit with identical plugin versions), do not create a replacement tag. The remote tag is authoritative for this catalog state. In the no-workflow path, M8c can still create the missing GitHub Release for that existing tag.
 
 Otherwise, create a GPG-signed annotated tag using the exact catalog state:
 
@@ -500,6 +504,16 @@ The tag-triggered release workflow will create the GitHub Release.
 
 ##### M8c. No release workflow detected
 
+If M4 found an **existing remote tag** to reuse, this is a release-recovery path rather than a tag-publishing path. Do not push `CATALOG-STATE` again and do not create a replacement local tag. If a release commit was created locally, ask whether to push the commit before creating the GitHub Release; if there are no local commits to publish, skip the commit push as well.
+
+Before creating a GitHub Release for an existing remote tag, check whether it already exists:
+
+```bash
+gh release view CATALOG-STATE --json tagName
+```
+
+If the release exists, report that the catalog tag and GitHub Release already exist and stop. If `gh release view` reports the release is missing, continue with release-note creation and `gh release create` below. If it fails for another reason (auth, API, or network), report the error and stop rather than treating it as missing.
+
 Ask the user if they want to push the commit and tag:
 
 ```text
@@ -512,10 +526,12 @@ If the user declines, show the manual commands and stop:
 Marketplace release CATALOG-STATE is ready locally.
 
 To publish manually:
-  git push origin HEAD
-  git push origin CATALOG-STATE
-  gh release create CATALOG-STATE --title "Marketplace CATALOG-STATE" --notes-file <release-notes-file> --verify-tag
+git push origin HEAD
+git push origin CATALOG-STATE
+gh release create CATALOG-STATE --title "Marketplace CATALOG-STATE" --notes-file <release-notes-file> --verify-tag
 ```
+
+If M4 found an existing remote tag to reuse, omit `git push origin CATALOG-STATE` from the manual commands. Keep `gh release create ... --verify-tag`, since the tag is already on the remote.
 
 If the user accepts, push the commit and tag.
 
@@ -531,6 +547,8 @@ If no remote is configured, report the error and tell the user to configure a Gi
 git push origin HEAD
 git push origin CATALOG-STATE
 ```
+
+If M4 found an existing remote tag to reuse, skip `git push origin CATALOG-STATE`. The tag is already on the remote, and pushing it again can fail or be a no-op depending on local tag state.
 
 If the push is rejected, report the error and stop. Never force push. Show the remaining manual commands so the user can complete the process after resolving the push issue.
 
@@ -874,9 +892,9 @@ Release vVERSION published.
 - **Version file not found:** Skip source file updates, rely on git tag, inform the user.
 - **CHANGELOG parse error:** If the existing file has an unrecognized format, warn the user and offer to create a new one or append a version section at the top.
 - **Tag already exists:** Abort with a message that the tag `vVERSION` already exists. Suggest choosing a different version.
-- **Marketplace catalog remote tag already exists at HEAD:** A release for this catalog state is already published at this commit. Report that there is nothing to release and stop; do not retag.
+- **Marketplace catalog remote tag already exists at HEAD:** Do not retag. In the no-workflow path, continue to M8c to verify or create the GitHub Release for the existing remote tag. With release workflow automation, report that the remote tag exists and the workflow owns release publication.
 - **Marketplace catalog local-only tag already exists at HEAD:** The catalog state is tagged locally but is not known to be published. Continue through M5-M8, skip replacement tag creation in M7, and publish the existing local tag if the user chooses to publish.
-- **Marketplace catalog tag already exists at a different commit, same plugin versions:** The catalog state is genuinely unchanged (e.g., a docs-only follow-up reused the previous catalog state). Report that there is nothing to release and stop; do not retag.
+- **Marketplace catalog tag already exists at a different commit, same plugin versions:** The catalog state is genuinely unchanged (e.g., a docs-only follow-up reused the previous catalog state). Do not retag. In the no-workflow path, continue to M8c to verify or create the GitHub Release for the existing remote tag; with release workflow automation, report that the workflow owns release publication.
 - **Marketplace catalog tag already exists at a different commit, different plugin versions:** Treat as a catalog-state collision (the sum-based tag format is not collision-free). Abort with the collision-aware message in M4 and ask the user to bump one plugin so the marketplace produces a unique catalog state. Do not retag or rename.
 - **Not a git repository:** Abort immediately.
 - **No remote configured:** Skip comparison links in CHANGELOG, skip push and GitHub Release in step 11, warn the user.

--- a/plugins/release/skills/release/SKILL.md
+++ b/plugins/release/skills/release/SKILL.md
@@ -130,12 +130,12 @@ if [ -d .github/workflows ]; then
 fi
 ```
 
-If the loop prints any files, note that a **release workflow likely exists** that will automatically create a GitHub Release. Two patterns are detected:
+If the loop prints any files, note that a **release workflow likely exists** that will automatically create a GitHub Release. Preserve which workflow kind was detected, because marketplace catalog releases handle the two kinds differently:
 
 - **Tag-triggered workflows**: a `tags:` trigger plus a YAML list entry whose value starts with `v` followed by `*`, `[`, or a digit (e.g., `- "v*"`, `- "v[0-9]+.[0-9]+.[0-9]+"`), or starts with `catalog-`. Anchoring to list-item form avoids false positives from action refs like `actions/checkout@v4`.
 - **Marketplace push-to-main workflows**: a workflow that invokes `bin/compute-catalog-state`, runs `gh release create`, and triggers on push to the default branch (`main` or `master`). All three signals together mark end-to-end automation that tags and publishes on push to the default branch. A workflow that only computes the catalog state (e.g., for validation) does not qualify, and neither does a workflow_dispatch-only or PR-triggered workflow that happens to invoke both, since neither will run when a commit lands on main.
 
-Detection is best-effort and may miss inline list forms (e.g., `tags: ['v*']`) or other exotic patterns. If the detection seems wrong, ask the user to confirm. This flag affects M4-M8 for marketplace releases and step 11 for SemVer releases.
+Detection is best-effort and may miss inline list forms (e.g., `tags: ['v*']`) or other exotic patterns. If the detection seems wrong, ask the user to confirm. This workflow kind affects M4-M8 for marketplace releases and step 11 for SemVer releases. For marketplace releases, only a **marketplace push-to-main workflow** skips local catalog tagging; a **tag-triggered workflow** still needs M7 to create the exact `catalog-*` tag so pushing that tag can fire the workflow.
 
 **Abort conditions:**
 
@@ -288,14 +288,25 @@ fi
 
 # Prefer the remote tag whenever it exists. Published tags are
 # authoritative; a stale or recreated local tag pointing at HEAD must
-# not mask a remote ref pointing at a different commit.
-existing_commit="${remote_commit:-${local_commit}}"
+# not mask a remote ref pointing at a different commit. Track whether
+# the matching tag came from the remote or only from the local clone:
+# a local-only tag is not proof that the catalog state was published.
+existing_commit=""
+existing_tag_source=""
+if [[ -n "${remote_commit}" ]]; then
+  existing_commit="${remote_commit}"
+  existing_tag_source="remote"
+elif [[ -n "${local_commit}" ]]; then
+  existing_commit="${local_commit}"
+  existing_tag_source="local"
+fi
 ```
 
 Cases:
 
 - **No existing tag** (`existing_commit` empty): proceed.
-- **Tag exists at `HEAD`**: a release for this catalog state is already published at this commit. Report that there is nothing to release and stop. Do not retag or republish.
+- **Remote tag exists at `HEAD`** (`existing_tag_source=remote`): a release for this catalog state is already published at this commit. Report that there is nothing to release and stop. Do not retag or republish.
+- **Only a local tag exists at `HEAD`** (`existing_tag_source=local`): the catalog state is already tagged locally, but it is not known to be published. Do not report that there is nothing to release. Continue to M5-M8, skip creating a replacement tag in M7, and publish the existing local tag if the user chooses to publish. If no remote is configured, M8 will stop with the normal "configure a Git remote" guidance.
 - **Tag exists at a different commit**: distinguish "catalog state genuinely unchanged" from "real collision" by comparing the marketplace plugin versions at the tagged commit against `HEAD`'s. This is the same comparison `.github/workflows/release.yml` performs:
 
   ```bash
@@ -336,9 +347,9 @@ Do not create another tag or choose a different state tag automatically. The use
 
 #### M5. Pre-Tag Review
 
-Build a final review and wait for explicit user approval. The wording depends on whether a release workflow was detected in step 1.
+Build a final review and wait for explicit user approval. The wording depends on which release workflow kind was detected in step 1.
 
-If **no release workflow** was detected:
+If **no marketplace push-to-main workflow** was detected:
 
 ```text
 Pre-tag review for CATALOG-STATE:
@@ -349,12 +360,13 @@ Files modified:
 
 Catalog state:
   - Tag: CATALOG-STATE
-  - GitHub Release title: Marketplace CATALOG-STATE
+  - GitHub Release: created by tag-triggered workflow after the tag is pushed
+    (or created directly by this skill if no release workflow was detected)
 
 Tags are immutable. Proceed with commit and tag?
 ```
 
-If a **release workflow was detected**:
+If a **marketplace push-to-main workflow** was detected:
 
 ```text
 Pre-release review for CATALOG-STATE:
@@ -364,8 +376,8 @@ Files modified:
   - plugins/<name>/.claude-plugin/plugin.json (plugin version bumped)
 
 Catalog state CATALOG-STATE will be tagged and released automatically by the
-detected release workflow when this change reaches the default branch. No
-local tag will be created.
+detected marketplace push-to-main workflow when this change reaches the default
+branch. No local tag will be created.
 
 Proceed with commit?
 ```
@@ -374,10 +386,10 @@ If `--dry-run` was specified, present this as a proposed review and stop. Do not
 
 #### M6. Create Marketplace Commit
 
-Stage only the files changed by the release and create a GPG-signed commit. Choose the commit message based on whether a release workflow was detected:
+Stage only the files changed by the release and create a GPG-signed commit. Choose the commit message based on whether marketplace push-to-main automation was detected:
 
-- **No release workflow**: use `release: CATALOG-STATE` so the message marks the local tag.
-- **Release workflow detected**: use a conventional commit that describes the underlying plugin change (e.g., `chore: bump <plugin> to <version> and resync catalog state`, or `feat(<plugin>): <summary>` if the bump is a feature). The workflow will produce its own release-named tag from the resulting `metadata.version`; the commit subject should describe the work, not the catalog state.
+- **No marketplace push-to-main workflow**: use `release: CATALOG-STATE` so the message marks the local tag. This includes tag-triggered release workflows, because this skill still creates and pushes the exact catalog tag that fires the workflow.
+- **Marketplace push-to-main workflow detected**: use a conventional commit that describes the underlying plugin change (e.g., `chore: bump <plugin> to <version> and resync catalog state`, or `feat(<plugin>): <summary>` if the bump is a feature). The workflow will produce its own release-named tag from the resulting `metadata.version`; the commit subject should describe the work, not the catalog state.
 
 ```bash
 git add <FILES>
@@ -391,9 +403,11 @@ CRITICAL: Never use `git commit --amend`. Always create a new commit. If a pre-c
 
 #### M7. Tag the Catalog State
 
-Skip this step entirely if a **release workflow was detected** in step 1. The workflow is the only writer of `catalog-*` tags in that case; creating one locally would break workflow idempotency by registering a tag the workflow then sees as already existing.
+Skip this step entirely if a **marketplace push-to-main workflow** was detected in step 1. The workflow is the only writer of `catalog-*` tags in that case; creating one locally would break workflow idempotency by registering a tag the workflow then sees as already existing.
 
-If **no release workflow** was detected, create a GPG-signed annotated tag using the exact catalog state:
+If M4 found an **only-local tag at `HEAD`** (`existing_tag_source=local`), do not create a replacement tag. Reuse that existing local tag in M8 so the user can finish publishing it.
+
+Otherwise, create a GPG-signed annotated tag using the exact catalog state:
 
 ```bash
 git tag -s CATALOG-STATE -m "CATALOG-STATE"
@@ -409,9 +423,9 @@ Marketplace release CATALOG-STATE tagged locally.
 
 #### M8. Publish
 
-The publish step depends on whether a release workflow was detected in step 1.
+The publish step depends on which release workflow kind was detected in step 1.
 
-##### M8a. Release workflow detected
+##### M8a. Marketplace push-to-main workflow detected
 
 The workflow will create the tag and GitHub Release automatically once the commit lands on the default branch (usually `main`). The skill should not push tags or create releases directly.
 
@@ -419,7 +433,7 @@ Ask the user how they want to land the commit:
 
 ```text
 Commit for CATALOG-STATE is ready.
-The release workflow will tag and release it once it merges into the default branch.
+The marketplace push-to-main workflow will tag and release it once it merges into the default branch.
 
 How would you like to publish?
   - Open a pull request (recommended)
@@ -439,7 +453,52 @@ After this commit reaches the default branch, the release workflow will:
   - Publish "Marketplace CATALOG-STATE" with auto-generated release notes
 ```
 
-##### M8b. No release workflow detected
+##### M8b. Tag-triggered release workflow detected
+
+Ask the user if they want to push the commit and tag:
+
+```text
+Push commit and tag for CATALOG-STATE?
+(Tag-triggered release workflow detected; it will create the GitHub Release when the tag is pushed.)
+```
+
+If the user declines, show the manual commands and stop:
+
+```text
+Marketplace release CATALOG-STATE is ready locally.
+
+To publish manually:
+  git push origin HEAD
+  git push origin CATALOG-STATE
+
+The tag-triggered release workflow will create the GitHub Release automatically when the tag is pushed.
+```
+
+If the user accepts, push the commit and tag.
+
+First, check for a remote:
+
+```bash
+git remote get-url origin
+```
+
+If no remote is configured, report the error and tell the user to configure a Git remote before rerunning this step. Do not show any `git push origin ...` commands in this case. Stop.
+
+```bash
+git push origin HEAD
+git push origin CATALOG-STATE
+```
+
+If the push is rejected, report the error and stop. Never force push.
+
+Report:
+
+```text
+Marketplace release CATALOG-STATE tag pushed.
+The tag-triggered release workflow will create the GitHub Release.
+```
+
+##### M8c. No release workflow detected
 
 Ask the user if they want to push the commit and tag:
 
@@ -815,7 +874,8 @@ Release vVERSION published.
 - **Version file not found:** Skip source file updates, rely on git tag, inform the user.
 - **CHANGELOG parse error:** If the existing file has an unrecognized format, warn the user and offer to create a new one or append a version section at the top.
 - **Tag already exists:** Abort with a message that the tag `vVERSION` already exists. Suggest choosing a different version.
-- **Marketplace catalog tag already exists at HEAD:** A release for this catalog state is already published at this commit. Report that there is nothing to release and stop; do not retag.
+- **Marketplace catalog remote tag already exists at HEAD:** A release for this catalog state is already published at this commit. Report that there is nothing to release and stop; do not retag.
+- **Marketplace catalog local-only tag already exists at HEAD:** The catalog state is tagged locally but is not known to be published. Continue through M5-M8, skip replacement tag creation in M7, and publish the existing local tag if the user chooses to publish.
 - **Marketplace catalog tag already exists at a different commit, same plugin versions:** The catalog state is genuinely unchanged (e.g., a docs-only follow-up reused the previous catalog state). Report that there is nothing to release and stop; do not retag.
 - **Marketplace catalog tag already exists at a different commit, different plugin versions:** Treat as a catalog-state collision (the sum-based tag format is not collision-free). Abort with the collision-aware message in M4 and ask the user to bump one plugin so the marketplace produces a unique catalog state. Do not retag or rename.
 - **Not a git repository:** Abort immediately.

--- a/plugins/release/skills/release/SKILL.md
+++ b/plugins/release/skills/release/SKILL.md
@@ -164,16 +164,51 @@ The fallback uses strict `MAJOR.MINOR.PATCH` parsing (matching `bin/validate-plu
 
 Update `.claude-plugin/marketplace.json` `metadata.version` to exactly the computed catalog state.
 
-#### M4. Abort if Tag Exists
+#### M4. Abort if Tag Exists at a Different Commit
 
-Before any commit or tag operation, check whether the exact catalog state tag already exists, both locally and on the remote:
+Before any commit or tag operation, check whether the exact catalog state tag already exists, both locally and on the remote, and compare the commit it points to against `HEAD`.
+
+Compare commit SHAs, not just the tag name. The catalog-state format is sum-based and not collision-free: two different plugin-version mixes can produce the same component sums (for example, `+1` minor on plugin A paired with `-1` minor on plugin B). Treating any same-named tag as "already released" would silently drop a real catalog change. Comparing SHAs lets the skill idempotently skip true repeats while loudly aborting on collisions.
 
 ```bash
-git rev-parse -q --verify "refs/tags/CATALOG-STATE" \
-  || git ls-remote --tags --exit-code origin "refs/tags/CATALOG-STATE"
+head_commit="$(git rev-parse HEAD)"
+
+# Annotated tags expose the commit they point to via the peeled refspec
+# (^{}). Lightweight tags expose the commit directly. Try both, locally
+# and on the remote.
+local_commit="$(git rev-parse -q --verify "refs/tags/CATALOG-STATE^{commit}" 2> /dev/null || true)"
+remote_commit="$(git ls-remote origin "refs/tags/CATALOG-STATE^{}" | cut -f1)"
+if [[ -z "${remote_commit}" ]]; then
+  remote_commit="$(git ls-remote origin "refs/tags/CATALOG-STATE" | cut -f1)"
+fi
+
+existing_commit="${local_commit:-${remote_commit}}"
 ```
 
-If either check finds the tag, abort with a message that the tag `CATALOG-STATE` already exists. Do not create another tag or choose a different state tag unless the user explicitly changes plugin versions.
+Three cases:
+
+- **No existing tag** (`existing_commit` empty): proceed.
+- **Tag exists at `HEAD`**: a release for this catalog state is already published at this commit. Report that there is nothing to release and stop. Do not retag or republish.
+- **Tag exists at a different commit**: abort with a collision-aware error.
+
+For the collision case, present this to the user:
+
+```text
+Catalog state tag CATALOG-STATE already exists at a different commit.
+
+Existing tag points to: <existing_commit>
+Current commit:         <head_commit>
+
+This usually indicates a catalog-state collision: the marketplace plugin
+versions changed in a way that produces the same per-component sums as a
+previously-released catalog state. The format is sum-based and not
+collision-free.
+
+To resolve, bump one plugin's version by an additional patch so the
+marketplace produces a unique catalog state, then re-run /release.
+```
+
+Do not create another tag or choose a different state tag automatically. The user must change plugin versions to break the collision.
 
 #### M5. Pre-Tag Review
 
@@ -656,7 +691,8 @@ Release vVERSION published.
 - **Version file not found:** Skip source file updates, rely on git tag, inform the user.
 - **CHANGELOG parse error:** If the existing file has an unrecognized format, warn the user and offer to create a new one or append a version section at the top.
 - **Tag already exists:** Abort with a message that the tag `vVERSION` already exists. Suggest choosing a different version.
-- **Marketplace catalog tag already exists:** Abort with a message that the tag `CATALOG-STATE` already exists. Recompute the catalog state only after the user changes individual plugin versions.
+- **Marketplace catalog tag already exists at HEAD:** A release for this catalog state is already published at this commit. Report that there is nothing to release and stop; do not retag.
+- **Marketplace catalog tag already exists at a different commit:** Treat as a catalog-state collision (the sum-based tag format is not collision-free). Abort with the collision-aware message in M4 and ask the user to bump one plugin so the marketplace produces a unique catalog state. Do not retag or rename.
 - **Not a git repository:** Abort immediately.
 - **No remote configured:** Skip comparison links in CHANGELOG, skip push and GitHub Release in step 11, warn the user.
 - **First release:** Use `v0.0.0` as the base for bump calculation, create the CHANGELOG from scratch, skip doc version updates (no old version to replace).

--- a/plugins/release/skills/release/SKILL.md
+++ b/plugins/release/skills/release/SKILL.md
@@ -55,8 +55,10 @@ if [ -d .github/workflows ]; then
       continue
     fi
     # Marketplace push-to-main automation: workflow invokes the canonical
-    # catalog state computation.
-    if grep -q 'compute-catalog-state' "$f"; then
+    # catalog state computation AND publishes a GitHub Release. Both halves
+    # are required: a validation workflow may call compute-catalog-state
+    # without tagging or releasing anything, and we should not defer to it.
+    if grep -q 'compute-catalog-state' "$f" && grep -q 'gh release create' "$f"; then
       echo "$f"
     fi
   done
@@ -66,7 +68,7 @@ fi
 If the loop prints any files, note that a **release workflow likely exists** that will automatically create a GitHub Release. Two patterns are detected:
 
 - **Tag-triggered workflows**: a `tags:` trigger plus a YAML list entry whose value starts with `v` followed by `*`, `[`, or a digit (e.g., `- "v*"`, `- "v[0-9]+.[0-9]+.[0-9]+"`), or starts with `catalog-`. Anchoring to list-item form avoids false positives from action refs like `actions/checkout@v4`.
-- **Marketplace push-to-main workflows**: any workflow that invokes `bin/compute-catalog-state`, which signals end-to-end automation that tags and publishes on push to the default branch.
+- **Marketplace push-to-main workflows**: a workflow that invokes `bin/compute-catalog-state` _and_ runs `gh release create`. Both signals together mark end-to-end automation that tags and publishes on push to the default branch. A workflow that only computes the catalog state (e.g., for validation) does not qualify.
 
 Detection is best-effort and may miss inline list forms (e.g., `tags: ['v*']`) or other exotic patterns. If the detection seems wrong, ask the user to confirm. This flag affects M4-M8 for marketplace releases and step 11 for SemVer releases.
 
@@ -182,7 +184,10 @@ if [[ -z "${remote_commit}" ]]; then
   remote_commit="$(git ls-remote origin "refs/tags/CATALOG-STATE" | cut -f1)"
 fi
 
-existing_commit="${local_commit:-${remote_commit}}"
+# Prefer the remote tag whenever it exists. Published tags are
+# authoritative; a stale or recreated local tag pointing at HEAD must
+# not mask a remote ref pointing at a different commit.
+existing_commit="${remote_commit:-${local_commit}}"
 ```
 
 Three cases:

--- a/plugins/release/skills/release/SKILL.md
+++ b/plugins/release/skills/release/SKILL.md
@@ -63,23 +63,67 @@ if [ -d .github/workflows ]; then
     # trigger check rules out workflow_dispatch-only or PR-only workflows
     # that happen to mention both strings: those will not run when a
     # commit lands on main, so deferring to them would silently skip
-    # local catalog tagging and leave nothing tagged or released.
-    if grep -q 'compute-catalog-state' "$f" && grep -q 'gh release create' "$f" && (
-      # Inline-list form: branches: [main], branches: ["main", "master"],
-      # branches: [dev, main]. \b is a word boundary, so [maintenance]
-      # and [main_v2] do not falsely match.
-      grep -qE 'branches:[[:space:]]*\[[^]]*\b(main|master)\b' "$f" ||
+    # local catalog tagging and leave nothing tagged or released. The
+    # branches:/main match must occur *under* push: rather than under a
+    # sibling key like pull_request: -- otherwise a workflow with
+    # `pull_request: branches: [main]` would falsely match. The awk
+    # script tracks indentation to scope branches: matches to the push:
+    # block, and handles both inline (`branches: [main]`) and YAML-list
+    # (`branches:` followed by `- main`) forms.
+    if grep -q 'compute-catalog-state' "$f" && grep -q 'gh release create' "$f" && awk '
+        function leading_ws(s) {
+          match(s, /^[[:space:]]*/)
+          return RLENGTH
+        }
+        {
+          # When indentation falls back to the push: level (or shallower),
+          # we have left the push: block. Reset state before running other
+          # rules on this line so a sibling key (e.g. pull_request:) does
+          # not pick up branches: matches inside push:.
+          if (in_push && $0 !~ /^[[:space:]]*$/ && leading_ws($0) <= push_indent) {
+            in_push = 0
+            in_list = 0
+          }
+        }
+        /^[[:space:]]*push:[[:space:]]*$/ {
+          push_indent = leading_ws($0)
+          in_push = 1
+          in_list = 0
+          next
+        }
+        # Inline form: branches: [main], branches: ["main", "master"],
+        # branches: [dev, main]. Strip brackets and quotes, split on
+        # commas/whitespace, then compare each token. This avoids needing
+        # word-boundary support, which BSD awk lacks ([maintenance] and
+        # [main_v2] do not produce a "main" or "master" token).
+        in_push && match($0, /branches:[[:space:]]*\[[^]]*\]/) {
+          s = substr($0, RSTART, RLENGTH)
+          gsub(/\[/, "", s)
+          gsub(/\]/, "", s)
+          gsub(/"/, "", s)
+          gsub(/\047/, "", s)
+          n = split(s, a, /[, ]+/)
+          for (i = 1; i <= n; i++) {
+            if (a[i] == "main" || a[i] == "master") {
+              found = 1
+              break
+            }
+          }
+        }
         # YAML-list form: a `branches:` line followed by indented
         # `- main` / `- master` entries. Exact line anchors avoid needing
-        # word-boundary support inside awk (BSD awk lacks \< \> and
-        # [[:<:]]).
-        awk '
-          /^[[:space:]]+branches:[[:space:]]*$/ { in_list = 1; next }
-          in_list && /^[[:space:]]+-[[:space:]]+["'\''"]?(main|master)["'\''"]?[[:space:]]*$/ { found = 1; in_list = 0 }
-          in_list && !/^[[:space:]]+-/ && !/^[[:space:]]*$/ { in_list = 0 }
-          END { exit !found }
-        ' "$f"
-    ); then
+        # word-boundary support.
+        in_push && /^[[:space:]]+branches:[[:space:]]*$/ {
+          in_list = 1
+          next
+        }
+        in_list && /^[[:space:]]+-[[:space:]]+["'\''"]?(main|master)["'\''"]?[[:space:]]*$/ {
+          found = 1
+          in_list = 0
+        }
+        in_list && !/^[[:space:]]+-/ && !/^[[:space:]]*$/ { in_list = 0 }
+        END { exit !found }
+      ' "$f"; then
       echo "$f"
     fi
   done
@@ -383,7 +427,7 @@ How would you like to publish?
   - Stop here and publish manually
 ```
 
-If the user opens a PR, recommend the `/pr` skill. If the user pushes directly, recommend the `/commit` skill's push step (or `git push origin HEAD`). In either case, do not run the push from this skill: leave that decision to the dedicated skill so its safety checks apply.
+If the user opens a PR, recommend the `/pr` skill. If the user pushes directly to the default branch, the commit must reach that branch on the remote. From the default branch itself, recommend the `/commit` skill's push step (or `git push origin HEAD`). From a feature branch, `git push origin HEAD` only updates the feature branch on the remote, leaving the default branch untouched and the release workflow inert; in that case the user must fast-forward or merge the commit onto the default branch first (`/pr` is the safest path), or push the commit explicitly with a refspec like `git push origin HEAD:main` if their branch protection rules allow it. In either case, do not run the push from this skill: leave that decision to the dedicated skill so its safety checks apply.
 
 After the user confirms how they intend to publish, report:
 

--- a/plugins/release/skills/release/SKILL.md
+++ b/plugins/release/skills/release/SKILL.md
@@ -44,18 +44,31 @@ git tag --list 'catalog-M*-m*-p*-n*' --sort=-creatordate
 # Get today's date
 date +%Y-%m-%d
 
-# Check for a release workflow triggered by release tags
+# Check for a release workflow that publishes GitHub Releases automatically
 if [ -d .github/workflows ]; then
   for f in .github/workflows/*.yml .github/workflows/*.yaml; do
     [ -f "$f" ] || continue
+    # Tag-triggered workflows: a `tags:` trigger plus a list entry like
+    # `- "v*"` or `- catalog-*`.
     if grep -q 'tags:' "$f" && grep -qE "^[[:space:]]*-[[:space:]]+['\"]?(v[*[0-9]|catalog-)" "$f"; then
+      echo "$f"
+      continue
+    fi
+    # Marketplace push-to-main automation: workflow invokes the canonical
+    # catalog state computation.
+    if grep -q 'compute-catalog-state' "$f"; then
       echo "$f"
     fi
   done
 fi
 ```
 
-If the loop prints any files, note that a **release workflow likely exists** that will automatically create a GitHub Release when a release tag is pushed. The detection looks for workflow files that contain both a `tags:` trigger and a YAML list entry whose value starts with `v` followed by `*`, `[`, or a digit (e.g., `- "v*"`, `- 'v*'`, `- "v[0-9]*.[0-9]*.[0-9]*"`, `- "v[0-9]+.[0-9]+.[0-9]+"`, or unquoted `- v*`), or starts with `catalog-` for Claude Code marketplace releases. Anchoring to list-item form avoids false positives from action refs like `actions/checkout@v4`. It is best-effort and may miss inline list forms (e.g., `tags: ['v*']`) or other exotic patterns. If the detection seems wrong, ask the user to confirm. This flag affects step 11.
+If the loop prints any files, note that a **release workflow likely exists** that will automatically create a GitHub Release. Two patterns are detected:
+
+- **Tag-triggered workflows**: a `tags:` trigger plus a YAML list entry whose value starts with `v` followed by `*`, `[`, or a digit (e.g., `- "v*"`, `- "v[0-9]+.[0-9]+.[0-9]+"`), or starts with `catalog-`. Anchoring to list-item form avoids false positives from action refs like `actions/checkout@v4`.
+- **Marketplace push-to-main workflows**: any workflow that invokes `bin/compute-catalog-state`, which signals end-to-end automation that tags and publishes on push to the default branch.
+
+Detection is best-effort and may miss inline list forms (e.g., `tags: ['v*']`) or other exotic patterns. If the detection seems wrong, ask the user to confirm. This flag affects M4-M8 for marketplace releases and step 11 for SemVer releases.
 
 **Abort conditions:**
 
@@ -126,38 +139,47 @@ Confirm the individual plugin version changes with the user before modifying fil
 
 #### M3. Compute Catalog State
 
-After plugin versions are final, compute the catalog state from marketplace plugin versions. Use strict `MAJOR.MINOR.PATCH` parsing (matching `bin/validate-plugins`) so malformed versions fail loudly instead of silently producing an incorrect tag:
+After plugin versions are final, compute the catalog state from marketplace plugin versions. Prefer the project's helper script when present so the skill stays in sync with whatever the repository considers canonical:
 
 ```bash
-jq -r '
-  def parse_version:
-    capture("^(?<major>[0-9]+)\\.(?<minor>[0-9]+)\\.(?<patch>[0-9]+)$")
-    | {
-        major: (.major | tonumber),
-        minor: (.minor | tonumber),
-        patch: (.patch | tonumber)
-      };
+if [ -x bin/compute-catalog-state ]; then
+  bin/compute-catalog-state
+else
+  jq -r '
+    def parse_version:
+      capture("^(?<major>[0-9]+)\\.(?<minor>[0-9]+)\\.(?<patch>[0-9]+)$")
+      | {
+          major: (.major | tonumber),
+          minor: (.minor | tonumber),
+          patch: (.patch | tonumber)
+        };
 
-  [.plugins[].version | parse_version] as $versions
-  | "catalog-M\($versions | map(.major) | add)-m\($versions | map(.minor) | add)-p\($versions | map(.patch) | add)-n\($versions | length)"
-' .claude-plugin/marketplace.json
+    [.plugins[].version | parse_version] as $versions
+    | "catalog-M\($versions | map(.major) | add)-m\($versions | map(.minor) | add)-p\($versions | map(.patch) | add)-n\($versions | length)"
+  ' .claude-plugin/marketplace.json
+fi
 ```
+
+The fallback uses strict `MAJOR.MINOR.PATCH` parsing (matching `bin/validate-plugins`) so malformed versions fail loudly instead of silently producing an incorrect tag.
 
 Update `.claude-plugin/marketplace.json` `metadata.version` to exactly the computed catalog state.
 
 #### M4. Abort if Tag Exists
 
-Before any commit or tag operation, check whether the exact catalog state tag already exists:
+Before any commit or tag operation, check whether the exact catalog state tag already exists, both locally and on the remote:
 
 ```bash
-git rev-parse -q --verify "refs/tags/CATALOG-STATE"
+git rev-parse -q --verify "refs/tags/CATALOG-STATE" \
+  || git ls-remote --tags --exit-code origin "refs/tags/CATALOG-STATE"
 ```
 
-If the tag already exists, abort with a message that the tag `CATALOG-STATE` already exists. Do not create another tag or choose a different state tag unless the user explicitly changes plugin versions.
+If either check finds the tag, abort with a message that the tag `CATALOG-STATE` already exists. Do not create another tag or choose a different state tag unless the user explicitly changes plugin versions.
 
 #### M5. Pre-Tag Review
 
-Build a final review and wait for explicit user approval:
+Build a final review and wait for explicit user approval. The wording depends on whether a release workflow was detected in step 1.
+
+If **no release workflow** was detected:
 
 ```text
 Pre-tag review for CATALOG-STATE:
@@ -173,25 +195,46 @@ Catalog state:
 Tags are immutable. Proceed with commit and tag?
 ```
 
+If a **release workflow was detected**:
+
+```text
+Pre-release review for CATALOG-STATE:
+
+Files modified:
+  - .claude-plugin/marketplace.json (metadata.version updated, plugin versions mirrored)
+  - plugins/<name>/.claude-plugin/plugin.json (plugin version bumped)
+
+Catalog state CATALOG-STATE will be tagged and released automatically by the
+detected release workflow when this change reaches the default branch. No
+local tag will be created.
+
+Proceed with commit?
+```
+
 If `--dry-run` was specified, present this as a proposed review and stop. Do not stage changes, commit, tag, push, or create a GitHub Release.
 
-#### M6. Create Marketplace Release Commit
+#### M6. Create Marketplace Commit
 
-Stage only the files changed by the release and create a GPG-signed commit:
+Stage only the files changed by the release and create a GPG-signed commit. Choose the commit message based on whether a release workflow was detected:
+
+- **No release workflow**: use `release: CATALOG-STATE` so the message marks the local tag.
+- **Release workflow detected**: use a conventional commit that describes the underlying plugin change (e.g., `chore: bump <plugin> to <version> and resync catalog state`, or `feat(<plugin>): <summary>` if the bump is a feature). The workflow will produce its own release-named tag from the resulting `metadata.version`; the commit subject should describe the work, not the catalog state.
 
 ```bash
 git add <FILES>
 git commit -S -m "$(cat <<'EOF'
-release: CATALOG-STATE
+<commit subject per the rule above>
 EOF
 )"
 ```
 
 CRITICAL: Never use `git commit --amend`. Always create a new commit. If a pre-commit hook fails, fix the issue, re-stage, and create a new commit.
 
-#### M7. Create Marketplace Tag
+#### M7. Tag the Catalog State
 
-Create a GPG-signed annotated tag using the exact catalog state:
+Skip this step entirely if a **release workflow was detected** in step 1. The workflow is the only writer of `catalog-*` tags in that case; creating one locally would break workflow idempotency by registering a tag the workflow then sees as already existing.
+
+If **no release workflow** was detected, create a GPG-signed annotated tag using the exact catalog state:
 
 ```bash
 git tag -s CATALOG-STATE -m "CATALOG-STATE"
@@ -205,24 +248,47 @@ After tagging, confirm:
 Marketplace release CATALOG-STATE tagged locally.
 ```
 
-#### M8. Publish Marketplace Release
+#### M8. Publish
 
-Ask the user if they want to push the commit and tag.
+The publish step depends on whether a release workflow was detected in step 1.
 
-If no release workflow was detected in step 1:
+##### M8a. Release workflow detected
+
+The workflow will create the tag and GitHub Release automatically once the commit lands on the default branch (usually `main`). The skill should not push tags or create releases directly.
+
+Ask the user how they want to land the commit:
+
+```text
+Commit for CATALOG-STATE is ready.
+The release workflow will tag and release it once it merges into the default branch.
+
+How would you like to publish?
+  - Open a pull request (recommended)
+  - Push directly to the default branch (only if your workflow allows)
+  - Stop here and publish manually
+```
+
+If the user opens a PR, recommend the `/pr` skill. If the user pushes directly, recommend the `/commit` skill's push step (or `git push origin HEAD`). In either case, do not run the push from this skill: leave that decision to the dedicated skill so its safety checks apply.
+
+After the user confirms how they intend to publish, report:
+
+```text
+Catalog state CATALOG-STATE is committed locally.
+
+After this commit reaches the default branch, the release workflow will:
+  - Create annotated tag CATALOG-STATE
+  - Publish "Marketplace CATALOG-STATE" with auto-generated release notes
+```
+
+##### M8b. No release workflow detected
+
+Ask the user if they want to push the commit and tag:
 
 ```text
 Push and create a GitHub Release for CATALOG-STATE?
 ```
 
-If a release workflow was detected in step 1:
-
-```text
-Push commit and tag for CATALOG-STATE?
-(Release workflow detected; it will create the GitHub Release automatically.)
-```
-
-If the user declines and no release workflow was detected, show:
+If the user declines, show the manual commands and stop:
 
 ```text
 Marketplace release CATALOG-STATE is ready locally.
@@ -233,19 +299,7 @@ To publish manually:
   gh release create CATALOG-STATE --title "Marketplace CATALOG-STATE" --notes-file <release-notes-file> --verify-tag
 ```
 
-If the user declines and a release workflow was detected, show:
-
-```text
-Marketplace release CATALOG-STATE is ready locally.
-
-To publish manually:
-  git push origin HEAD
-  git push origin CATALOG-STATE
-
-The release workflow will create the GitHub Release automatically when the tag is pushed.
-```
-
-If the user accepts, push the commit and tag:
+If the user accepts, push the commit and tag.
 
 First, check for a remote:
 
@@ -262,16 +316,7 @@ git push origin CATALOG-STATE
 
 If the push is rejected, report the error and stop. Never force push. Show the remaining manual commands so the user can complete the process after resolving the push issue.
 
-If a release workflow was detected, skip manual GitHub Release creation and report:
-
-```text
-Tagged CATALOG-STATE and pushed to origin.
-
-  Tag: CATALOG-STATE
-  GitHub Release: the release workflow is expected to create it automatically.
-```
-
-If no release workflow was detected, create release notes from the commit summary or changed plugin list. First, check that `gh` is available:
+Create release notes from the commit summary or changed plugin list. First, check that `gh` is available:
 
 ```bash
 command -v gh
@@ -616,6 +661,7 @@ Release vVERSION published.
 - **No remote configured:** Skip comparison links in CHANGELOG, skip push and GitHub Release in step 11, warn the user.
 - **First release:** Use `v0.0.0` as the base for bump calculation, create the CHANGELOG from scratch, skip doc version updates (no old version to replace).
 - **Push rejected:** Report the error and show remaining manual commands. Never force push.
-- **Release workflow detected:** Skip manual GitHub Release creation; the workflow will create it when the tag is pushed. Push the commit and tag only.
+- **Release workflow detected (tag-triggered):** Skip manual GitHub Release creation; the workflow will create it when the tag is pushed. Push the commit and tag only.
+- **Release workflow detected (marketplace push-to-main):** Skip the local catalog tag entirely (M7) and skip both push and GitHub Release creation in M8. The workflow tags and releases when the commit reaches the default branch; the skill's job ends at the local commit. Recommend `/pr` or the user's chosen merge path.
 - **`gh` not available:** Push the commit and tag, skip GitHub Release creation, note that `gh` is required for GitHub Releases and show the manual `gh release create` command.
 - **GitHub Release creation fails:** The push already succeeded, so the tag is on the remote. Report the `gh` error and show the manual `gh release create` command for the user to retry.

--- a/plugins/release/skills/release/SKILL.md
+++ b/plugins/release/skills/release/SKILL.md
@@ -361,7 +361,7 @@ Do not create another tag or choose a different state tag automatically. The use
 
 Build a final review and wait for explicit user approval. The wording depends on which release workflow kind was detected in step 1.
 
-If M4 found an **existing remote tag at a different commit with identical plugin versions** and M3 produced no release-file changes, skip the pre-tag review. The release-recovery path has no new commit or tag to approve; M8c handles the user approval before creating any missing GitHub Release.
+If M4 found an **existing catalog state tag to reuse** and M3 produced no release-file changes, skip the pre-tag review. The release-recovery path has no new commit or tag to approve; M8 handles the user approval before publishing any existing local tag or creating any missing GitHub Release.
 
 If **no marketplace push-to-main workflow** was detected:
 
@@ -400,7 +400,7 @@ If `--dry-run` was specified, present this as a proposed review and stop. Do not
 
 #### M6. Create Marketplace Commit
 
-If M4 found an **existing remote tag at a different commit with identical plugin versions**, first check whether M3 produced any release-file changes:
+If M4 found an **existing catalog state tag to reuse** (`existing_commit` is non-empty and the case was not a collision), first check whether M3 produced any release-file changes:
 
 ```bash
 if git diff --quiet -- .claude-plugin/marketplace.json plugins/*/.claude-plugin/plugin.json; then
@@ -410,10 +410,11 @@ else
 fi
 ```
 
-When no release-file changes exist, skip commit creation. This is the release-recovery path: do not create an empty commit, and do not stage or commit unrelated local changes. Continue based on the workflow kind:
+When no release-file changes exist, skip commit creation. This is the release-recovery path: do not create an empty commit, and do not stage or commit unrelated local changes. Continue based on the tag source and workflow kind:
 
-- **Release workflow detected**: report that the existing remote catalog tag is present and the workflow owns GitHub Release publication. Stop without creating a local commit or tag.
-- **No release workflow detected**: continue to M8c with `release_commit_created=0` so the skill can verify or create the missing GitHub Release for the existing remote tag.
+- **Existing remote tag and release workflow detected**: report that the existing remote catalog tag is present and the workflow owns GitHub Release publication. Stop without creating a local commit or tag.
+- **Existing local-only tag and tag-triggered release workflow detected**: continue to M8b with `release_commit_created=0` so the skill can publish the existing local tag without pushing an unrelated branch tip.
+- **No release workflow detected**: continue to M8c with `release_commit_created=0` so the skill can publish an existing local tag if needed, or verify or create the missing GitHub Release for an existing remote tag.
 
 For all other M4 cases, or when release files changed, stage only the files changed by the release and create a GPG-signed commit. Choose the commit message based on whether marketplace push-to-main automation was detected:
 
@@ -486,7 +487,7 @@ After this commit reaches the default branch, the release workflow will:
 
 ##### M8b. Tag-triggered release workflow detected
 
-Ask the user if they want to push the commit and tag:
+Ask the user if they want to push the commit and tag. If `release_commit_created=0`, ask whether to push the existing local tag instead:
 
 ```text
 Push commit and tag for CATALOG-STATE?
@@ -505,7 +506,9 @@ To publish manually:
 The tag-triggered release workflow will create the GitHub Release automatically when the tag is pushed.
 ```
 
-If the user accepts, push the commit and tag.
+If `release_commit_created=0`, omit `git push origin HEAD` from the manual commands. There is no new release commit to publish, and pushing `HEAD` could publish an unrelated branch tip. Keep `git push origin CATALOG-STATE` so the existing local tag can fire the tag-triggered workflow.
+
+If the user accepts, push the commit and tag. Skip the commit push when `release_commit_created=0`:
 
 First, check for a remote:
 
@@ -516,7 +519,10 @@ git remote get-url origin
 If no remote is configured, report the error and tell the user to configure a Git remote before rerunning this step. Do not show any `git push origin ...` commands in this case. Stop.
 
 ```bash
-git push origin HEAD
+if [ "${release_commit_created:-1}" -eq 1 ]; then
+  git push origin HEAD
+fi
+
 git push origin CATALOG-STATE
 ```
 
@@ -531,9 +537,9 @@ The tag-triggered release workflow will create the GitHub Release.
 
 ##### M8c. No release workflow detected
 
-If M4 found an **existing remote tag** to reuse, this is a release-recovery path rather than a tag-publishing path. Do not push `CATALOG-STATE` again and do not create a replacement local tag. If a release commit was created locally, ask whether to push the commit before creating the GitHub Release; if there are no local commits to publish, skip the commit push as well.
+If M4 found an **existing tag** to reuse, this is a release-recovery path. For an existing remote tag, do not push `CATALOG-STATE` again and do not create a replacement local tag. For an existing local-only tag, publish that tag if the user accepts. If a release commit was created locally, ask whether to push the commit before creating the GitHub Release; if there are no local commits to publish, skip the commit push as well.
 
-Before creating a GitHub Release for an existing remote tag, check whether it already exists:
+Before creating a GitHub Release for an existing remote tag, check whether it already exists. If M4 found an existing local-only tag, skip this pre-check until after the tag is pushed:
 
 ```bash
 gh release view CATALOG-STATE --json tagName
@@ -558,7 +564,7 @@ git push origin CATALOG-STATE
 gh release create CATALOG-STATE --title "Marketplace CATALOG-STATE" --notes-file <release-notes-file> --verify-tag
 ```
 
-If M4 found an existing remote tag to reuse, omit `git push origin CATALOG-STATE` from the manual commands. Keep `gh release create ... --verify-tag`, since the tag is already on the remote.
+If `release_commit_created=0`, omit `git push origin HEAD` from the manual commands. There is no new release commit to publish, and pushing `HEAD` could publish an unrelated branch tip. If M4 found an existing remote tag to reuse, also omit `git push origin CATALOG-STATE`. Keep `gh release create ... --verify-tag`, since the tag is already on the remote. If M4 found an existing local-only tag to reuse, keep `git push origin CATALOG-STATE` so the existing local tag is published before `gh release create`.
 
 If the user accepts, push the commit and tag.
 
@@ -571,11 +577,16 @@ git remote get-url origin
 If no remote is configured, report the error and tell the user to configure a Git remote before rerunning this step. Do not show any `git push origin ...` commands in this case. Stop.
 
 ```bash
-git push origin HEAD
-git push origin CATALOG-STATE
+if [ "${release_commit_created:-1}" -eq 1 ]; then
+  git push origin HEAD
+fi
+
+if [ "${existing_tag_source:-}" != "remote" ]; then
+  git push origin CATALOG-STATE
+fi
 ```
 
-If M4 found an existing remote tag to reuse, skip `git push origin CATALOG-STATE`. The tag is already on the remote, and pushing it again can fail or be a no-op depending on local tag state.
+If M4 found an existing remote tag to reuse, the tag push is skipped. The tag is already on the remote, and pushing it again can fail or be a no-op depending on local tag state.
 
 If the push is rejected, report the error and stop. Never force push. Show the remaining manual commands so the user can complete the process after resolving the push issue.
 

--- a/plugins/release/skills/release/SKILL.md
+++ b/plugins/release/skills/release/SKILL.md
@@ -55,10 +55,31 @@ if [ -d .github/workflows ]; then
       continue
     fi
     # Marketplace push-to-main automation: workflow invokes the canonical
-    # catalog state computation AND publishes a GitHub Release. Both halves
-    # are required: a validation workflow may call compute-catalog-state
-    # without tagging or releasing anything, and we should not defer to it.
-    if grep -q 'compute-catalog-state' "$f" && grep -q 'gh release create' "$f"; then
+    # catalog state computation, publishes a GitHub Release, AND triggers
+    # on push to the default branch (main or master). All three are
+    # required. The compute-catalog-state and gh release create checks
+    # rule out partial automation (e.g., a validation workflow that
+    # computes the catalog state without tagging or releasing). The push
+    # trigger check rules out workflow_dispatch-only or PR-only workflows
+    # that happen to mention both strings: those will not run when a
+    # commit lands on main, so deferring to them would silently skip
+    # local catalog tagging and leave nothing tagged or released.
+    if grep -q 'compute-catalog-state' "$f" && grep -q 'gh release create' "$f" && (
+      # Inline-list form: branches: [main], branches: ["main", "master"],
+      # branches: [dev, main]. \b is a word boundary, so [maintenance]
+      # and [main_v2] do not falsely match.
+      grep -qE 'branches:[[:space:]]*\[[^]]*\b(main|master)\b' "$f" ||
+        # YAML-list form: a `branches:` line followed by indented
+        # `- main` / `- master` entries. Exact line anchors avoid needing
+        # word-boundary support inside awk (BSD awk lacks \< \> and
+        # [[:<:]]).
+        awk '
+          /^[[:space:]]+branches:[[:space:]]*$/ { in_list = 1; next }
+          in_list && /^[[:space:]]+-[[:space:]]+["'\''"]?(main|master)["'\''"]?[[:space:]]*$/ { found = 1; in_list = 0 }
+          in_list && !/^[[:space:]]+-/ && !/^[[:space:]]*$/ { in_list = 0 }
+          END { exit !found }
+        ' "$f"
+    ); then
       echo "$f"
     fi
   done
@@ -68,7 +89,7 @@ fi
 If the loop prints any files, note that a **release workflow likely exists** that will automatically create a GitHub Release. Two patterns are detected:
 
 - **Tag-triggered workflows**: a `tags:` trigger plus a YAML list entry whose value starts with `v` followed by `*`, `[`, or a digit (e.g., `- "v*"`, `- "v[0-9]+.[0-9]+.[0-9]+"`), or starts with `catalog-`. Anchoring to list-item form avoids false positives from action refs like `actions/checkout@v4`.
-- **Marketplace push-to-main workflows**: a workflow that invokes `bin/compute-catalog-state` _and_ runs `gh release create`. Both signals together mark end-to-end automation that tags and publishes on push to the default branch. A workflow that only computes the catalog state (e.g., for validation) does not qualify.
+- **Marketplace push-to-main workflows**: a workflow that invokes `bin/compute-catalog-state`, runs `gh release create`, and triggers on push to the default branch (`main` or `master`). All three signals together mark end-to-end automation that tags and publishes on push to the default branch. A workflow that only computes the catalog state (e.g., for validation) does not qualify, and neither does a workflow_dispatch-only or PR-triggered workflow that happens to invoke both, since neither will run when a commit lands on main.
 
 Detection is best-effort and may miss inline list forms (e.g., `tags: ['v*']`) or other exotic patterns. If the detection seems wrong, ask the user to confirm. This flag affects M4-M8 for marketplace releases and step 11 for SemVer releases.
 
@@ -196,9 +217,28 @@ local_commit="$(git rev-parse -q --verify "refs/tags/CATALOG-STATE^{commit}" 2> 
 # not fail here just because `git ls-remote origin` would error out.
 remote_commit=""
 if git remote get-url origin > /dev/null 2>&1; then
-  remote_commit="$(git ls-remote origin "refs/tags/CATALOG-STATE^{}" | cut -f1)"
+  # Capture ls-remote's output and exit status separately. Piping straight
+  # into `cut` would mask auth/network failures: cut succeeds on empty
+  # input, so an authentication error or a transient network failure
+  # would leave remote_commit empty and silently fall back to the local
+  # tag. That can mask an already-published remote CATALOG-STATE tag and
+  # surface the conflict only when the eventual `git push` fails.
+  if ! ls_remote_output="$(git ls-remote origin "refs/tags/CATALOG-STATE^{}" "refs/tags/CATALOG-STATE" 2>&1)"; then
+    {
+      echo "git ls-remote origin failed:"
+      printf '%s\n' "${ls_remote_output}"
+      echo
+      echo "Cannot verify whether catalog state CATALOG-STATE is already published on origin."
+      echo "Resolve the network or authentication issue and re-run /release rather than"
+      echo "proceeding with a possibly-stale local view of remote tags."
+    } >&2
+    exit 1
+  fi
+  # Prefer the peeled refspec (annotated tags); fall back to the unpeeled
+  # refspec (lightweight tags). Both are queried in one ls-remote call.
+  remote_commit="$(printf '%s\n' "${ls_remote_output}" | awk '$2 == "refs/tags/CATALOG-STATE^{}" {print $1; exit}')"
   if [[ -z "${remote_commit}" ]]; then
-    remote_commit="$(git ls-remote origin "refs/tags/CATALOG-STATE" | cut -f1)"
+    remote_commit="$(printf '%s\n' "${ls_remote_output}" | awk '$2 == "refs/tags/CATALOG-STATE" {print $1; exit}')"
   fi
 fi
 

--- a/plugins/release/skills/release/SKILL.md
+++ b/plugins/release/skills/release/SKILL.md
@@ -50,9 +50,9 @@ if [ -d .github/workflows ]; then
     [ -f "$f" ] || continue
     # Tag-triggered workflows: a `tags:` trigger plus a list entry like
     # `- "v*"` or `- catalog-*`.
+    has_tag_trigger=0
     if grep -q 'tags:' "$f" && grep -qE "^[[:space:]]*-[[:space:]]+['\"]?(v[*[0-9]|catalog-)" "$f"; then
-      echo "$f"
-      continue
+      has_tag_trigger=1
     fi
     # Marketplace push-to-main automation: workflow invokes the canonical
     # catalog state computation, publishes a GitHub Release, AND triggers
@@ -70,6 +70,7 @@ if [ -d .github/workflows ]; then
     # script tracks indentation to scope branches: matches to the push:
     # block, and handles both inline (`branches: [main]`) and YAML-list
     # (`branches:` followed by `- main`) forms.
+    has_marketplace_push_to_main=0
     if grep -q 'compute-catalog-state' "$f" && grep -q 'gh release create' "$f" && awk '
         function leading_ws(s) {
           match(s, /^[[:space:]]*/)
@@ -124,13 +125,22 @@ if [ -d .github/workflows ]; then
         in_list && !/^[[:space:]]+-/ && !/^[[:space:]]*$/ { in_list = 0 }
         END { exit !found }
       ' "$f"; then
-      echo "$f"
+      has_marketplace_push_to_main=1
+    fi
+
+    # Push-to-main automation is more specific than a generic tag trigger.
+    # If a workflow matches both, classify it as push-to-main so marketplace
+    # catalog tags remain workflow-owned.
+    if [ "${has_marketplace_push_to_main}" -eq 1 ]; then
+      printf '%s\t%s\n' "$f" "marketplace-push-to-main"
+    elif [ "${has_tag_trigger}" -eq 1 ]; then
+      printf '%s\t%s\n' "$f" "tag-triggered"
     fi
   done
 fi
 ```
 
-If the loop prints any files, note that a **release workflow likely exists** that will automatically create a GitHub Release. Preserve which workflow kind was detected, because marketplace catalog releases handle the two kinds differently:
+If the loop prints any tab-delimited lines, note that a **release workflow likely exists** that will automatically create a GitHub Release. Each line has the form `<workflow-path>\t<workflow-kind>`. Preserve the workflow kind, because marketplace catalog releases handle the two kinds differently. If a workflow matches both kinds, the loop reports `marketplace-push-to-main`, which is the more specific automation and the only writer of marketplace catalog tags:
 
 - **Tag-triggered workflows**: a `tags:` trigger plus a YAML list entry whose value starts with `v` followed by `*`, `[`, or a digit (e.g., `- "v*"`, `- "v[0-9]+.[0-9]+.[0-9]+"`), or starts with `catalog-`. Anchoring to list-item form avoids false positives from action refs like `actions/checkout@v4`.
 - **Marketplace push-to-main workflows**: a workflow that invokes `bin/compute-catalog-state`, runs `gh release create`, and triggers on push to the default branch (`main` or `master`). All three signals together mark end-to-end automation that tags and publishes on push to the default branch. A workflow that only computes the catalog state (e.g., for validation) does not qualify, and neither does a workflow_dispatch-only or PR-triggered workflow that happens to invoke both, since neither will run when a commit lands on main.
@@ -351,6 +361,8 @@ Do not create another tag or choose a different state tag automatically. The use
 
 Build a final review and wait for explicit user approval. The wording depends on which release workflow kind was detected in step 1.
 
+If M4 found an **existing remote tag at a different commit with identical plugin versions** and M3 produced no release-file changes, skip the pre-tag review. The release-recovery path has no new commit or tag to approve; M8c handles the user approval before creating any missing GitHub Release.
+
 If **no marketplace push-to-main workflow** was detected:
 
 ```text
@@ -388,7 +400,22 @@ If `--dry-run` was specified, present this as a proposed review and stop. Do not
 
 #### M6. Create Marketplace Commit
 
-Stage only the files changed by the release and create a GPG-signed commit. Choose the commit message based on whether marketplace push-to-main automation was detected:
+If M4 found an **existing remote tag at a different commit with identical plugin versions**, first check whether M3 produced any release-file changes:
+
+```bash
+if git diff --quiet -- .claude-plugin/marketplace.json plugins/*/.claude-plugin/plugin.json; then
+  release_commit_created=0
+else
+  release_commit_created=1
+fi
+```
+
+When no release-file changes exist, skip commit creation. This is the release-recovery path: do not create an empty commit, and do not stage or commit unrelated local changes. Continue based on the workflow kind:
+
+- **Release workflow detected**: report that the existing remote catalog tag is present and the workflow owns GitHub Release publication. Stop without creating a local commit or tag.
+- **No release workflow detected**: continue to M8c with `release_commit_created=0` so the skill can verify or create the missing GitHub Release for the existing remote tag.
+
+For all other M4 cases, or when release files changed, stage only the files changed by the release and create a GPG-signed commit. Choose the commit message based on whether marketplace push-to-main automation was detected:
 
 - **No marketplace push-to-main workflow**: use `release: CATALOG-STATE` so the message marks the local tag. This includes tag-triggered release workflows, because this skill still creates and pushes the exact catalog tag that fires the workflow.
 - **Marketplace push-to-main workflow detected**: use a conventional commit that describes the underlying plugin change (e.g., `chore: bump <plugin> to <version> and resync catalog state`, or `feat(<plugin>): <summary>` if the bump is a feature). The workflow will produce its own release-named tag from the resulting `metadata.version`; the commit subject should describe the work, not the catalog state.
@@ -894,7 +921,7 @@ Release vVERSION published.
 - **Tag already exists:** Abort with a message that the tag `vVERSION` already exists. Suggest choosing a different version.
 - **Marketplace catalog remote tag already exists at HEAD:** Do not retag. In the no-workflow path, continue to M8c to verify or create the GitHub Release for the existing remote tag. With release workflow automation, report that the remote tag exists and the workflow owns release publication.
 - **Marketplace catalog local-only tag already exists at HEAD:** The catalog state is tagged locally but is not known to be published. Continue through M5-M8, skip replacement tag creation in M7, and publish the existing local tag if the user chooses to publish.
-- **Marketplace catalog tag already exists at a different commit, same plugin versions:** The catalog state is genuinely unchanged (e.g., a docs-only follow-up reused the previous catalog state). Do not retag. In the no-workflow path, continue to M8c to verify or create the GitHub Release for the existing remote tag; with release workflow automation, report that the workflow owns release publication.
+- **Marketplace catalog tag already exists at a different commit, same plugin versions:** The catalog state is genuinely unchanged (e.g., a docs-only follow-up reused the previous catalog state). Do not retag and do not create an empty release commit when M3 produced no release-file changes. In the no-workflow path, continue to M8c to verify or create the GitHub Release for the existing remote tag; with release workflow automation, report that the workflow owns release publication.
 - **Marketplace catalog tag already exists at a different commit, different plugin versions:** Treat as a catalog-state collision (the sum-based tag format is not collision-free). Abort with the collision-aware message in M4 and ask the user to bump one plugin so the marketplace produces a unique catalog state. Do not retag or rename.
 - **Not a git repository:** Abort immediately.
 - **No remote configured:** Skip comparison links in CHANGELOG, skip push and GitHub Release in step 11, warn the user.


### PR DESCRIPTION
## Summary

- Add `.github/workflows/release.yml`, which on every push to `main` computes the canonical catalog state via `bin/compute-catalog-state` and idempotently creates an annotated tag plus a `Marketplace <catalog-state>` GitHub Release with `--generate-notes`. Concurrency-grouped on `release-main` with `contents: write` via `GITHUB_TOKEN`.
- Extract the catalog-state jq snippet from `bin/validate-plugins` into a new `bin/compute-catalog-state` so the workflow and the validator share one source of truth.
- Compare commit SHAs (not just tag names) before re-publishing. Catalog-state tags are sum-based and not collision-free, so the workflow now does an idempotent skip when the existing tag points at `HEAD` and aborts loudly with a collision-aware error when it points elsewhere. Same logic mirrored into the release skill's M4 step.
- Update the `release` skill's marketplace flow to detect any workflow that invokes `bin/compute-catalog-state` and, when found, skip local catalog tagging entirely (the workflow becomes the sole writer of `catalog-*` tags). Cross-reference `bin/compute-catalog-state` from the `check-versions` skill and the Versioning section of `AGENTS.md`. Bump `release` to 1.5.1; resync catalog state to `catalog-M55-m102-p61-n49`.

## Test plan

- [ ] Confirm the new workflow appears under Actions on this PR (no run on the PR itself; first run triggers on merge to `main`).
- [ ] After merge: confirm a `catalog-M55-m102-p61-n49` tag is created at the merge commit and a `Marketplace catalog-M55-m102-p61-n49` GitHub Release is published with auto-generated notes.
- [ ] Re-run the workflow on the same `main` SHA via `workflow_dispatch` and confirm it logs `Tag ... already points at <SHA>; nothing to do.` and exits clean (idempotency).
- [ ] Confirm `bin/validate-plugins` still passes locally and in CI; `bin/compute-catalog-state` returns the same value it computed inline before.

## Closes

Closes #277
