### PR TITLE
fix: require tmpfile cleanup as a separate Bash tool call

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "metadata": {
     "description": "Claude Code commands, hooks, and skills from Christopher Boone (cboone.github.io)",
-    "version": "catalog-M55-m102-p61-n49"
+    "version": "catalog-M55-m102-p66-n49"
   },
   "name": "cboone-cc-plugins",
   "owner": {
@@ -161,7 +161,7 @@
       "name": "create-issue",
       "repository": "https://github.com/cboone/cboone-cc-plugins",
       "source": "./plugins/create-issue",
-      "version": "1.0.2"
+      "version": "1.0.3"
     },
     {
       "author": {
@@ -301,7 +301,7 @@
       "name": "pr",
       "repository": "https://github.com/cboone/cboone-cc-plugins",
       "source": "./plugins/pr",
-      "version": "1.5.1"
+      "version": "1.5.2"
     },
     {
       "author": {
@@ -329,7 +329,7 @@
       "name": "release",
       "repository": "https://github.com/cboone/cboone-cc-plugins",
       "source": "./plugins/release",
-      "version": "1.4.0"
+      "version": "1.4.1"
     },
     {
       "author": {
@@ -343,7 +343,7 @@
       "name": "resolve-copilot-pr-feedback",
       "repository": "https://github.com/cboone/cboone-cc-plugins",
       "source": "./plugins/resolve-copilot-pr-feedback",
-      "version": "1.3.2"
+      "version": "1.3.3"
     },
     {
       "author": {
@@ -539,7 +539,7 @@
       "name": "use-git",
       "repository": "https://github.com/cboone/cboone-cc-plugins",
       "source": "./plugins/use-git",
-      "version": "1.1.1"
+      "version": "1.1.2"
     },
     {
       "author": {

--- a/plugins/create-issue/.claude-plugin/plugin.json
+++ b/plugins/create-issue/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "name": "create-issue",
   "repository": "https://github.com/cboone/cboone-cc-plugins",
   "skills": "./skills",
-  "version": "1.0.2"
+  "version": "1.0.3"
 }

--- a/plugins/create-issue/skills/create-issue/SKILL.md
+++ b/plugins/create-issue/skills/create-issue/SKILL.md
@@ -72,11 +72,13 @@ gh issue create --repo owner/repo --title "Issue title here" --body-file TMPFILE
 
 ### 5. Clean Up
 
-Always remove the tmpfile after the issue creation attempt, regardless of whether it succeeded or failed:
+Always remove the tmpfile after the issue creation attempt, regardless of whether it succeeded or failed. Issue the cleanup as a **separate Bash tool call**, not chained onto `gh issue create`:
 
 ```bash
 rm -f TMPFILE
 ```
+
+Each Bash tool call runs unconditionally and the prior call's exit code is preserved by the harness, so a separate call cleans up after both successful and failed issue creations without any shell-level wrapping. Never combine the two with `;` followed by an exit-code preservation idiom such as `gh issue create ...; status=$?; rm -f TMPFILE; exit $status`. In zsh (the macOS default shell), `status` is a read-only built-in alias for `$?`, so the assignment fails with `read-only variable: status` and falsely reports a successful issue creation as failed. See `plugins/use-git/skills/use-git/references/tmpfile-pattern.md` for the full rationale.
 
 ### 6. Report the Result
 

--- a/plugins/pr/.claude-plugin/plugin.json
+++ b/plugins/pr/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "name": "pr",
   "repository": "https://github.com/cboone/cboone-cc-plugins",
   "skills": "./skills",
-  "version": "1.5.1"
+  "version": "1.5.2"
 }

--- a/plugins/pr/skills/pr/SKILL.md
+++ b/plugins/pr/skills/pr/SKILL.md
@@ -278,11 +278,13 @@ gh pr create --title "the pr title" --body-file TMPFILE
 
 Pass `--base <base-branch>` if `<base-branch>` differs from `<default-branch>`. Do not pass `--draft`. Do not add labels or reviewers.
 
-Always remove the tmpfile after the PR creation attempt, regardless of whether it succeeded or failed:
+Always remove the tmpfile after the PR creation attempt, regardless of whether it succeeded or failed. Issue the cleanup as a **separate Bash tool call**, not chained onto `gh pr create`:
 
 ```bash
 rm -f TMPFILE
 ```
+
+Each Bash tool call runs unconditionally and the prior call's exit code is preserved by the harness, so a separate call cleans up after both successful and failed PR creations without any shell-level wrapping. Never combine the two with `;` followed by an exit-code preservation idiom such as `gh pr create ...; status=$?; rm -f TMPFILE; exit $status`. In zsh (the macOS default shell), `status` is a read-only built-in alias for `$?`, so the assignment fails with `read-only variable: status` and falsely reports a successful PR creation as failed. See `plugins/use-git/skills/use-git/references/tmpfile-pattern.md` for the full rationale.
 
 ### 8. Report Results
 

--- a/plugins/release/.claude-plugin/plugin.json
+++ b/plugins/release/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "name": "release",
   "repository": "https://github.com/cboone/cboone-cc-plugins",
   "skills": "./skills",
-  "version": "1.4.0"
+  "version": "1.4.1"
 }

--- a/plugins/release/skills/release/SKILL.md
+++ b/plugins/release/skills/release/SKILL.md
@@ -285,7 +285,7 @@ If `gh` is available, write the notes to a tmpfile and create the GitHub Release
 gh release create CATALOG-STATE --title "Marketplace CATALOG-STATE" --notes-file TMPFILE --verify-tag
 ```
 
-Always remove the tmpfile after the command completes, regardless of success or failure.
+Always remove the tmpfile after the command completes, regardless of success or failure. Issue the cleanup (`rm -f TMPFILE`) as a **separate Bash tool call**, not chained onto `gh release create`. The harness preserves the prior call's exit code, and a chained `; status=$?; rm -f ...; exit $status` wrapper breaks under zsh because `status` is a read-only built-in alias for `$?`. See `plugins/use-git/skills/use-git/references/tmpfile-pattern.md` for the full rationale.
 
 Report:
 
@@ -578,11 +578,13 @@ gh release create vVERSION --title "vVERSION" --notes-file TMPFILE --verify-tag
 
 The `--verify-tag` flag ensures the command fails if the tag was not pushed successfully (safety net for step 11b).
 
-Always remove the tmpfile after the command completes, regardless of success or failure:
+Always remove the tmpfile after the command completes, regardless of success or failure. Issue the cleanup as a **separate Bash tool call**, not chained onto `gh release create`:
 
 ```bash
 rm -f TMPFILE
 ```
+
+Each Bash tool call runs unconditionally and the prior call's exit code is preserved by the harness, so a separate call cleans up after both successful and failed releases without any shell-level wrapping. Never combine the two with a `; status=$?; rm -f TMPFILE; exit $status` wrapper: in zsh (the macOS default shell), `status` is a read-only built-in alias for `$?`, so the assignment fails with `read-only variable: status`. See `plugins/use-git/skills/use-git/references/tmpfile-pattern.md` for the full rationale.
 
 ##### 11f. Report results
 

--- a/plugins/resolve-copilot-pr-feedback/.claude-plugin/plugin.json
+++ b/plugins/resolve-copilot-pr-feedback/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "name": "resolve-copilot-pr-feedback",
   "repository": "https://github.com/cboone/cboone-cc-plugins",
   "skills": "./skills",
-  "version": "1.3.2"
+  "version": "1.3.3"
 }

--- a/plugins/resolve-copilot-pr-feedback/skills/resolve-copilot-pr-feedback/SKILL.md
+++ b/plugins/resolve-copilot-pr-feedback/skills/resolve-copilot-pr-feedback/SKILL.md
@@ -201,12 +201,14 @@ bash resolve-copilot-threads reply THREAD_ID --body-file TMPFILE
 
 # Or reply and resolve in one step:
 bash resolve-copilot-threads reply-and-resolve THREAD_ID --body-file TMPFILE
+```
 
-# Step 4: Clean up:
+```bash
+# Step 4: Clean up — issue this as a SEPARATE Bash tool call, not chained onto step 3:
 rm -f TMPFILE
 ```
 
-Replace `TMPFILE` with the actual path returned by `mktemp`.
+Replace `TMPFILE` with the actual path returned by `mktemp`. The cleanup must be a separate Bash tool call: each tool invocation runs unconditionally, so the tmpfile is removed whether step 3 succeeded or failed, and the harness preserves step 3's exit code without any shell wrapping. Never combine the two with `; status=$?; rm -f TMPFILE; exit $status` — in zsh (the macOS default shell), `status` is a read-only built-in alias for `$?`, so the assignment fails with `read-only variable: status`. See `plugins/use-git/skills/use-git/references/tmpfile-pattern.md` for the full rationale.
 
 **NEVER pass the reply body inline** (e.g., via `echo "..." |` or heredocs). Always use the Write tool + `--body-file` pattern.
 
@@ -310,18 +312,20 @@ mktemp /tmp/copilot-summary-XXXXXX
 
 # Step 3: Post the comment:
 gh pr comment PR_NUMBER --body-file TMPFILE
+```
 
-# Step 4: Clean up:
+```bash
+# Step 4: Clean up — issue this as a SEPARATE Bash tool call, not chained onto step 3:
 rm -f TMPFILE
 ```
 
-Replace `PR_NUMBER` and `TMPFILE` with actual values.
+Replace `PR_NUMBER` and `TMPFILE` with actual values. The cleanup must be a separate Bash tool call (see [Outdated/Incorrect Copilot Comments](#outdatedincorrect-copilot-comments) above for the rationale): chaining with `; status=$?; rm -f TMPFILE; exit $status` breaks under zsh because `status` is a read-only built-in alias for `$?`.
 
 If the comment fails, log the error but do not fail the workflow. Thread resolution and code changes are the primary deliverables; the summary comment is best-effort.
 
 ## Reply Templates
 
-First, generate a unique tmpfile path with `mktemp /tmp/copilot-reply-XXXXXX`. Write these to the returned path using the Write tool, then pass via `--body-file`. Clean up the tmpfile after each reply operation.
+First, generate a unique tmpfile path with `mktemp /tmp/copilot-reply-XXXXXX`. Write these to the returned path using the Write tool, then pass via `--body-file`. Clean up the tmpfile (`rm -f TMPFILE`) after each reply operation as a **separate Bash tool call**, not chained onto the reply command.
 
 **For outdated comments:**
 

--- a/plugins/use-git/.claude-plugin/plugin.json
+++ b/plugins/use-git/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "name": "use-git",
   "repository": "https://github.com/cboone/cboone-cc-plugins",
   "skills": "./skills",
-  "version": "1.1.1"
+  "version": "1.1.2"
 }

--- a/plugins/use-git/skills/use-git/references/tmpfile-pattern.md
+++ b/plugins/use-git/skills/use-git/references/tmpfile-pattern.md
@@ -36,11 +36,22 @@ gh pr create --title "Add user authentication" --body-file TMPFILE
 
 ## Cleanup
 
-Always remove the tmpfile after the command completes, regardless of success or failure:
+Issue cleanup as a **separate Bash tool call** after the `gh` command:
 
 ```bash
 rm -f TMPFILE
 ```
+
+Each Bash tool invocation runs unconditionally, so the cleanup runs whether the `gh` command succeeded or failed, and the `gh` command's exit code is preserved by the harness without any shell-level wrapping.
+
+Do not chain the cleanup onto the `gh` command, and do not wrap it to preserve the exit code. In particular, never write:
+
+```bash
+# BAD - breaks in zsh
+gh pr create --title "..." --body-file TMPFILE; status=$?; rm -f TMPFILE; exit $status
+```
+
+In zsh (the macOS default shell), `status` and `pipestatus` are read-only built-in aliases for `$?` and `${pipestatus[@]}`. Assigning to either fails with `read-only variable: status`, so this wrapper exits non-zero and mis-reports a successful `gh` call as failed. Keep cleanup in its own Bash tool call instead.
 
 ## Examples
 


### PR DESCRIPTION
## Summary

- Pin the tmpfile cleanup pattern in the canonical `use-git` reference: cleanup must be issued as a **separate Bash tool call**, not chained onto the preceding `gh` command. Each Bash tool invocation runs unconditionally and the harness preserves the prior call's exit code, which sidesteps the entire `$status` problem without any shell-level wrapping.
- Update the four consuming skills (`pr`, `create-issue`, `release`, `resolve-copilot-pr-feedback`) to reflect the same pattern and link back to the canonical reference. Each cleanup site now includes a short warning about the zsh `$status`/`pipestatus` read-only built-in alias for `$?` so future agents do not reinvent the broken `gh ...; status=$?; rm -f TMPFILE; exit $status` wrapper.
- Patch-bump the five affected plugins and recompute marketplace catalog state to `catalog-M55-m101-p65-n49`.
- Bundles in a previously committed unrelated chore on this branch: `15ae56f chore: bump create-plugin to 1.2.3 and resync catalog state` (pre-existing, not part of #274).

## Test plan

- [ ] Read the updated `use-git` tmpfile-pattern reference and confirm the cleanup section explicitly says "separate Bash tool call", with the `BAD` example showing the broken `status=$?` wrapper and a clear explanation of the zsh failure mode.
- [ ] Spot-check each consuming skill (`pr`, `create-issue`, `release`, `resolve-copilot-pr-feedback`) and confirm the cleanup step now mentions "separate Bash tool call" and links back to the canonical reference.
- [ ] Run `yarn lint`, `bin/validate-json`, and `bin/validate-plugins` — all pass.
- [ ] Confirm catalog state matches the sum of plugin versions: `jq -r '.metadata.version, ([.plugins[].version | split(".") | map(tonumber)] | transpose | map(add)) | tostring' .claude-plugin/marketplace.json` shows `catalog-M55-m101-p65-n49` and `[55,101,65]` plus `n=49`.
- [ ] On a real PR creation in a zsh shell, observe that the cleanup runs in its own Bash tool call and no `read-only variable: status` error appears.

## Fixes

Fixes #274
