### PR TITLE
Add upgrade everything skill

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -2,7 +2,7 @@
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "metadata": {
     "description": "Claude Code commands, hooks, and skills from Christopher Boone (cboone.github.io)",
-    "version": "catalog-M56-m104-p109-n49"
+    "version": "catalog-M57-m104-p109-n50"
   },
   "name": "cboone-cc-plugins",
   "owner": {
@@ -526,6 +526,20 @@
       "repository": "https://github.com/cboone/cboone-cc-plugins",
       "source": "./dist/codex/plugins/update-review",
       "version": "1.0.1"
+    },
+    {
+      "author": {
+        "name": "Christopher Boone"
+      },
+      "category": "ci-and-release",
+      "description": "Assess every version reference in a repository, evaluate available upgrades with repo-specific risk and reward, and present selectable upgrade options.",
+      "homepage": "https://github.com/cboone/cboone-cc-plugins",
+      "keywords": ["dependencies", "maintenance", "risk", "upgrades", "versioning"],
+      "license": "MIT",
+      "name": "upgrade-everything",
+      "repository": "https://github.com/cboone/cboone-cc-plugins",
+      "source": "./dist/codex/plugins/upgrade-everything",
+      "version": "1.0.0"
     },
     {
       "author": {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "metadata": {
     "description": "Claude Code commands, hooks, and skills from Christopher Boone (cboone.github.io)",
-    "version": "catalog-M56-m104-p109-n49"
+    "version": "catalog-M57-m104-p109-n50"
   },
   "name": "cboone-cc-plugins",
   "owner": {
@@ -526,6 +526,20 @@
       "repository": "https://github.com/cboone/cboone-cc-plugins",
       "source": "./plugins/update-review",
       "version": "1.0.1"
+    },
+    {
+      "author": {
+        "name": "Christopher Boone"
+      },
+      "category": "ci-and-release",
+      "description": "Assess every version reference in a repository, evaluate available upgrades with repo-specific risk and reward, and present selectable upgrade options.",
+      "homepage": "https://github.com/cboone/cboone-cc-plugins",
+      "keywords": ["dependencies", "maintenance", "risk", "upgrades", "versioning"],
+      "license": "MIT",
+      "name": "upgrade-everything",
+      "repository": "https://github.com/cboone/cboone-cc-plugins",
+      "source": "./plugins/upgrade-everything",
+      "version": "1.0.0"
     },
     {
       "author": {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -427,6 +427,17 @@ cboone-cc-plugins/
     │   └── skills/
     │       └── update-review/
     │           └── SKILL.md
+    ├── upgrade-everything/          # Risk/reward upgrade audit skill
+    │   ├── .claude-plugin/
+    │   │   └── plugin.json
+    │   ├── README.md
+    │   └── skills/
+    │       └── upgrade-everything/
+    │           ├── SKILL.md
+    │           └── references/
+    │               ├── risk-reward.md
+    │               ├── upgrade-sources.md
+    │               └── version-surfaces.md
     ├── write-latex/                 # LaTeX typesetting style guide skill
     │   ├── .claude-plugin/
     │   │   └── plugin.json

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ A collection of plugins for [Claude Code](https://docs.anthropic.com/en/docs/cla
 ∙ [Setup CI](#setup-ci)
 ∙ [Setup Installers](#setup-installers)
 ∙ [Setup Secret Scanning](#setup-secret-scanning)
+∙ [Update Everything](#update-everything)
+∙ [Upgrade Everything](#upgrade-everything)
 <br>Agents:
 [Clean Up Agent Config](#clean-up-agent-config)
 ∙ [Create Plugin](#create-plugin)
@@ -451,6 +453,20 @@ Set up secret scanning with gitleaks and TruffleHog GitHub Actions workflows and
 
 > **Trigger:** `/setup-secret-scanning`
 > **Details:** [README](./plugins/setup-secret-scanning/README.md)
+
+#### Update Everything
+
+Audit a repository against the latest plugin templates and update anything out of date. The maintenance companion to Bootstrap Project: bootstrap sets things up, this keeps them current. Detects which tools have been used, compares files against current templates, presents a plan, and applies confirmed updates.
+
+> **Trigger:** `/update-everything`
+> **Details:** [README](./plugins/update-everything/README.md)
+
+#### Upgrade Everything
+
+Assess every version reference in a repository, resolve current upstream versions, and present a risk/reward upgrade plan that includes every discovered upgrade candidate. Applies only the upgrades the user explicitly selects, preserving each ecosystem's normal update mechanism.
+
+> **Trigger:** `/upgrade-everything` (also activates automatically)
+> **Details:** [README](./plugins/upgrade-everything/README.md)
 
 ### Agents
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ A collection of plugins for [Claude Code](https://docs.anthropic.com/en/docs/cla
 ∙ [Setup CI](#setup-ci)
 ∙ [Setup Installers](#setup-installers)
 ∙ [Setup Secret Scanning](#setup-secret-scanning)
-∙ [Update Everything](#update-everything)
 ∙ [Upgrade Everything](#upgrade-everything)
 <br>Agents:
 [Clean Up Agent Config](#clean-up-agent-config)
@@ -453,13 +452,6 @@ Set up secret scanning with gitleaks and TruffleHog GitHub Actions workflows and
 
 > **Trigger:** `/setup-secret-scanning`
 > **Details:** [README](./plugins/setup-secret-scanning/README.md)
-
-#### Update Everything
-
-Audit a repository against the latest plugin templates and update anything out of date. The maintenance companion to Bootstrap Project: bootstrap sets things up, this keeps them current. Detects which tools have been used, compares files against current templates, presents a plan, and applies confirmed updates.
-
-> **Trigger:** `/update-everything`
-> **Details:** [README](./plugins/update-everything/README.md)
 
 #### Upgrade Everything
 

--- a/dist/codex/plugins/upgrade-everything/.claude-plugin/plugin.json
+++ b/dist/codex/plugins/upgrade-everything/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "author": {
+    "name": "Christopher Boone"
+  },
+  "description": "Assess every version reference in a repository, evaluate available upgrades with repo-specific risk and reward, and present selectable upgrade options.",
+  "homepage": "https://github.com/cboone/cboone-cc-plugins",
+  "keywords": ["dependencies", "maintenance", "risk", "upgrades", "versioning"],
+  "license": "MIT",
+  "name": "upgrade-everything",
+  "repository": "https://github.com/cboone/cboone-cc-plugins",
+  "skills": "./skills",
+  "version": "1.0.0"
+}

--- a/dist/codex/plugins/upgrade-everything/README.md
+++ b/dist/codex/plugins/upgrade-everything/README.md
@@ -39,4 +39,4 @@ The skill applies only the upgrades the user explicitly selects. When applying u
 - [Pin Everything](../pin-everything/README.md): harden mutable version references before or after upgrade review
 - [Release](../release/README.md): update release metadata after selected upgrades land
 - [Lint and Fix](../lint-and-fix/README.md): format and verify files after upgrades
-- [All plugins](../../README.md)
+- [All plugins](../../../../README.md)

--- a/dist/codex/plugins/upgrade-everything/skills/upgrade-everything/SKILL.md
+++ b/dist/codex/plugins/upgrade-everything/skills/upgrade-everything/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: upgrade-everything
+description: >-
+  Assess every version reference in a repository, evaluate available upgrades
+  with repo-specific risk and reward, and present selectable upgrade options.
+---
+
+# Upgrade Everything
+
+Audit every version reference in a repository, resolve current upstream versions, evaluate each available upgrade with repo-specific reward and risk, then apply only the upgrades the user explicitly selects.
+
+## Workflow
+
+### 1. Record the Audit Date
+
+Run `date` before searching for upstream versions. Upgrade data is date-sensitive, so include the exact date in the audit summary and in any later note about unresolved or stale upstream information.
+
+### 2. Detect Repository Shape
+
+Detect the repository root, project languages, package managers, CI systems, release tooling, and whether the repo is an application, public library, template, plugin marketplace, or monorepo. Exclude generated, vendored, and cache directories from all version searches.
+
+Always exclude at least:
+
+- `.git/`
+- `node_modules/`
+- `.yarn/`
+- `.lake/`
+- `vendor/`
+- `dist/`
+- `target/`
+- `.venv/`
+- lockfile cache directories
+
+Use `./references/version-surfaces.md` to decide which files and literals to inspect.
+
+### 3. Discover Version Surfaces
+
+Use the `pin-everything` surface coverage as the baseline, then add upgrade-specific surfaces. Inventory package manifests and lockfiles, GitHub Actions refs, reusable workflows, language runtime files, Docker and devcontainer images, tool install commands, package manager pins, schema URLs, marketplace and plugin versions, release config versions, and unclassified version-like literals in scripts, docs, and config.
+
+For each discovered surface, record:
+
+- File path and owning ecosystem
+- Current value and surrounding context
+- Whether a package manager, lockfile, generator, or template owns the value
+- Whether the surface is user-facing documentation, executable automation, build metadata, or published API metadata
+
+Do not classify a candidate as out of scope merely because the upgrade looks risky or low value.
+
+### 4. Resolve Upstream Versions
+
+Resolve current upstream versions from authoritative sources for each ecosystem. Use package registries, GitHub releases or tags, container registries, language and toolchain channels, schema publisher metadata, and project-specific release files where relevant.
+
+Use `./references/upgrade-sources.md` for source-of-truth selection. Record the source URL or command, lookup date, latest value, and confidence. If upstream resolution fails, keep the candidate in the plan with status `Blocked` or `Unknown` instead of dropping it.
+
+### 5. Classify Candidates
+
+Build one numbered candidate record for every discovered upgrade opportunity. If a version surface is already current, summarize it separately as up to date unless the user asked for a full inventory.
+
+Each candidate must include:
+
+- Current value and latest value
+- Upgrade type: patch, minor, major, digest, SHA, runtime, schema, channel, or unknown
+- Source of truth and confidence
+- Reward rating and reasons
+- Risk rating and reasons
+- Required validation
+- Recommendation
+
+Use `./references/risk-reward.md` for the reward and risk model. Risk affects ordering and recommendation, not inclusion.
+
+### 6. Present the Upgrade Matrix
+
+Present a Markdown matrix grouped by ecosystem and surface. Include every candidate, including high-risk, blocked, unknown, and low-reward upgrades.
+
+Use this shape:
+
+```text
+| # | Ecosystem | Surface | Current | Latest | Type | Reward | Risk | Confidence | Recommendation | Validation |
+|---|-----------|---------|---------|--------|------|--------|------|------------|----------------|------------|
+```
+
+After the matrix, list up-to-date surfaces and unresolved upstream lookups separately. Make the distinction between "not selected yet", "not recommended", and "blocked" explicit.
+
+### 7. Ask for Selection
+
+Ask the user which upgrades to apply. Offer these choices:
+
+- Apply all upgrades
+- Apply only low-risk upgrades
+- Apply only selected candidate numbers
+- Audit only
+- Apply all except custom exclusions
+
+Do not apply upgrades until the user explicitly selects a scope. If the user asks for audit-only, stop after reporting the matrix.
+
+### 8. Apply Selected Upgrades
+
+Apply only selected candidates. Preserve each ecosystem's normal update mechanism:
+
+- Use package manager commands for manifests and lockfiles.
+- Use targeted YAML, JSON, TOML, or lockfile-aware edits for configuration values.
+- Do not hand-edit lockfiles when a package manager owns them.
+- Preserve library constraints unless the user explicitly chooses to tighten them.
+- Keep generated files under their generator's ownership where that generator is known.
+
+Process upgrades in dependency-aware order: toolchain and package manager pins first, package manifests and lockfiles next, CI and release configuration after that, then documentation or template references.
+
+### 9. Verify and Summarize
+
+Run the relevant verification for the selected upgrades: package manager checks, lockfile consistency checks, tests, build commands, and CI or release validators present in the repo. After edits, invoke the `lint-and-fix` skill to run project linters and formatters.
+
+Summarize the result under these headings:
+
+- Upgraded
+- Skipped by user
+- Blocked
+- Failed
+- Already up to date
+- Follow-up validation
+
+Include any commands that failed and the concrete candidate numbers affected.
+
+## Reference Navigation
+
+- `./references/version-surfaces.md` - surfaces to discover before resolving upstream versions
+- `./references/upgrade-sources.md` - authoritative upstream sources by ecosystem
+- `./references/risk-reward.md` - reward, risk, confidence, recommendation, and validation model
+
+## Error Handling
+
+- **Upstream source unavailable:** Keep the candidate in the matrix with `Unknown` latest value, low confidence, and a clear blocked reason.
+- **Ambiguous ownership:** Ask before editing if a version could be generated, owned by a lockfile, or part of public library compatibility metadata.
+- **Package manager update fails:** Capture the failure, mark only the affected candidates as failed, and ask whether to continue with independent candidates.
+- **High-risk migration notes:** Include the upgrade in the matrix with the migration note summarized and validation expanded. Do not hide it.
+- **Conflicting lockfiles:** Stop before editing and ask which package manager owns the project.

--- a/dist/codex/plugins/upgrade-everything/skills/upgrade-everything/references/risk-reward.md
+++ b/dist/codex/plugins/upgrade-everything/skills/upgrade-everything/references/risk-reward.md
@@ -1,0 +1,73 @@
+# Risk and Reward
+
+Use this model to make upgrade recommendations without hiding any candidate. Risk affects ordering, validation, and recommendation; it never removes a candidate from the plan.
+
+## Reward Dimensions
+
+| Dimension                | Higher reward when                                                                 |
+| ------------------------ | ---------------------------------------------------------------------------------- |
+| Security                 | The upgrade fixes a known vulnerability, unsafe default, or exposed CI dependency. |
+| Bug fixes                | Release notes mention correctness, stability, or crash fixes relevant to the repo. |
+| Compatibility            | The upgrade restores support for current platforms, package managers, or APIs.     |
+| Template alignment       | The repo should match current project templates, workflows, or generated files.    |
+| Stale transitive cleanup | The upgrade refreshes old transitive dependencies or lockfile resolution.          |
+| Ecosystem support        | The current version is near end-of-support or unsupported by upstream tooling.     |
+| Maintainer policy        | The repo's policy expects current minor or patch releases.                         |
+
+## Risk Dimensions
+
+| Dimension                   | Higher risk when                                                                               |
+| --------------------------- | ---------------------------------------------------------------------------------------------- |
+| SemVer major changes        | The upgrade crosses a major boundary or the ecosystem does not follow SemVer reliably.         |
+| Runtime or toolchain jumps  | The upgrade changes compiler, interpreter, package manager, or build image behavior.           |
+| Lockfile churn              | The upgrade changes many transitive dependencies or multiple ecosystem lockfiles.              |
+| Deprecated packages         | The current or target package is deprecated, renamed, archived, or superseded.                 |
+| Migration notes             | Upstream requires config changes, code changes, data migrations, or manual intervention.       |
+| Changelog warnings          | Release notes mention breaking changes, removals, changed defaults, or security model changes. |
+| Public library constraints  | Tightening a manifest range could constrain downstream users.                                  |
+| CI blast radius             | The dependency is used across many jobs, publish paths, release automation, or templates.      |
+| Repo-specific test coverage | The repo lacks tests or checks that exercise the upgraded dependency.                          |
+
+## Ratings
+
+| Rating  | Reward meaning                                                  | Risk meaning                                                          |
+| ------- | --------------------------------------------------------------- | --------------------------------------------------------------------- |
+| High    | Strong repo-specific benefit or security relevance.             | Requires migration review, broad validation, or explicit user choice. |
+| Medium  | Clear maintenance value with limited direct feature impact.     | Behavior could change, but validation is available and bounded.       |
+| Low     | Mostly currency, tidy-up, or alignment value.                   | Narrow impact, patch-level change, or strong automated validation.    |
+| Unknown | Reward cannot be evaluated from available upstream information. | Risk cannot be evaluated from available upstream information.         |
+
+## Recommendation Labels
+
+| Label       | Meaning                                                                                    |
+| ----------- | ------------------------------------------------------------------------------------------ |
+| Recommended | Reward is clear and risk is low or manageable with available validation.                   |
+| Optional    | Upgrade is valid, but reward is mostly maintenance or repo policy alignment.               |
+| Review      | Upgrade should be considered, but migration notes, major changes, or blast radius matter.  |
+| Blocked     | Upstream data, ownership, package manager state, or validation prerequisites are missing.  |
+| Hold        | The repo appears to have an intentional hold policy, but the candidate remains selectable. |
+
+## Candidate Matrix Fields
+
+| Field        | Required content                                                              |
+| ------------ | ----------------------------------------------------------------------------- |
+| `#`          | Stable candidate number used for user selection.                              |
+| `Ecosystem`  | Package manager, runtime, CI, container, schema, marketplace, or other owner. |
+| `Surface`    | File path and version surface, concise enough to scan.                        |
+| `Current`    | Current version, tag, SHA, digest, range, channel, or unknown value.          |
+| `Latest`     | Latest resolved upstream value, or `Unknown` / `Blocked`.                     |
+| `Type`       | Patch, minor, major, digest, SHA, runtime, schema, channel, or unknown.       |
+| `Reward`     | Rating plus the most important reason.                                        |
+| `Risk`       | Rating plus the most important reason.                                        |
+| `Confidence` | High, medium, low, or unknown based on upstream source quality.               |
+| `Validation` | Commands or checks required before calling the upgrade complete.              |
+
+## Validation Guidance
+
+- Package dependencies: run the ecosystem's resolver, tests, and lockfile consistency checks.
+- Runtime or toolchain upgrades: run build, test, lint, and any smoke tests that execute the produced artifact.
+- GitHub Actions and reusable workflows: validate workflow syntax and run local checks that mirror the changed CI behavior where possible.
+- Container images: rebuild affected images and run the repo's container smoke tests or entrypoint checks.
+- Release tooling: run dry-run or config validation commands before claiming success.
+- Schema URLs and config versions: run the tool that consumes the config.
+- Marketplace and plugin versions: run manifest validation and recompute derived catalog metadata.

--- a/dist/codex/plugins/upgrade-everything/skills/upgrade-everything/references/upgrade-sources.md
+++ b/dist/codex/plugins/upgrade-everything/skills/upgrade-everything/references/upgrade-sources.md
@@ -1,0 +1,51 @@
+# Upgrade Sources
+
+Resolve latest versions from authoritative sources and record the source used for every candidate. Prefer machine-readable registry or release metadata over scraping human-readable pages.
+
+## Source Selection
+
+| Ecosystem or surface     | Authoritative sources                                                           | Typical lookup method                                           | Confidence notes                                                                   |
+| ------------------------ | ------------------------------------------------------------------------------- | --------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| npm and Corepack         | npm registry, package manager metadata, Corepack                                | `npm view`, registry JSON, `corepack use`                       | Highest when registry metadata and lockfile update agree.                          |
+| Python                   | PyPI JSON API, uv or pip resolver output, project lockfile                      | `uv lock --upgrade-package`, PyPI JSON, `pip index versions`    | Prefer uv for uv-managed projects and package manager output for lockfile changes. |
+| Go modules and tools     | Go module proxy, module tags, GitHub releases for install tools                 | `go list -m -u -json`, `go install` dry run, GitHub API         | Check module path replacements and major-version suffixes.                         |
+| Rust crates              | crates.io index, `cargo update`, `cargo metadata`                               | `cargo update -p`, crates.io API                                | Distinguish library compatibility constraints from binary application pins.        |
+| Ruby                     | RubyGems API, Bundler resolver                                                  | `bundle update <gem>`, RubyGems versions API                    | Bundler output is preferred when a `Gemfile.lock` exists.                          |
+| Swift packages           | Git tags from package remotes, `Package.resolved`                               | `swift package update`, GitHub tags                             | SemVer tags are conventional, but validate package resolution.                     |
+| PHP Composer             | Packagist API, Composer resolver                                                | `composer outdated`, `composer update vendor/package`           | Composer constraints may be public library API promises.                           |
+| GitHub Actions           | GitHub releases, tags, commit API, action metadata                              | GitHub API, `gh release view`, `gh api repos/.../commits/<ref>` | SHA pins need the version comment or commit ancestry to assess drift.              |
+| Reusable workflows       | GitHub releases, tags, workflow repository release notes                        | GitHub API, repository tags                                     | Treat workflow input changes as API changes.                                       |
+| Container images         | Docker Hub, GHCR, registry manifest APIs, image labels                          | Registry API, `docker buildx imagetools inspect`                | Tags can be mutable; digest comparison improves confidence.                        |
+| Language runtimes        | Official release indexes and toolchain channels                                 | Node.js index, Python downloads, Go downloads, Rust channels    | Runtime upgrades require repo-specific validation beyond version lookup.           |
+| Zig and niche toolchains | Official release JSON, project release pages, package manager metadata          | Publisher API or release index                                  | Confidence depends on whether the publisher exposes stable machine-readable data.  |
+| Schema URLs              | Schema publisher versioned URLs, Schema Store catalog, project release metadata | Publisher catalog or repository tags                            | Some schemas expose only moving URLs. Mark those as unpinnable, not missing.       |
+| Marketplace/plugin data  | Marketplace manifest, local plugin manifests, release tags                      | `jq`, local manifest reads, repository releases                 | Recompute derived catalog state after changing individual plugin versions.         |
+| Release tools            | Tool release pages, package registries, action releases                         | GitHub releases, package registry APIs                          | Validate generated release config with the tool's own check or dry-run.            |
+| Unclassified literals    | The publisher identified from surrounding context                               | Context-specific                                                | Keep confidence low until the upstream owner is known.                             |
+
+## Lookup Policy
+
+1. Record the exact audit date from `date`.
+1. Resolve upstream from the closest owner of the version surface.
+1. Use the repository's native package manager when it owns lockfile changes.
+1. Prefer official APIs and registry metadata over blog posts, search results, or mirrors.
+1. Check changelogs and migration notes for major, runtime, toolchain, and reusable workflow upgrades.
+1. If the source of truth cannot be identified, keep the candidate and mark source `Unknown`.
+1. If the source is unreachable, keep the candidate and mark status `Blocked`.
+
+## Confidence Labels
+
+| Confidence | Use when                                                                                            |
+| ---------- | --------------------------------------------------------------------------------------------------- |
+| High       | Official registry or release metadata identifies the latest version and the package manager agrees. |
+| Medium     | Official tags or releases exist, but changelog, resolver, or lockfile confirmation is incomplete.   |
+| Low        | The candidate is inferred from context, a moving channel, a mutable tag, or incomplete metadata.    |
+| Unknown    | No authoritative source could be resolved.                                                          |
+
+## Applying Sources to Edits
+
+- Use package manager commands for dependencies and lockfiles.
+- Use targeted structured edits for workflow refs, runtime files, schema URLs, marketplace metadata, and release config.
+- Preserve existing held-major or held-channel policy unless the user explicitly selects a major or channel migration.
+- Never downgrade a SHA, digest, or exact pin to a mutable tag while upgrading.
+- Keep a blocked candidate in the summary with the source attempted and the next information needed.

--- a/dist/codex/plugins/upgrade-everything/skills/upgrade-everything/references/version-surfaces.md
+++ b/dist/codex/plugins/upgrade-everything/skills/upgrade-everything/references/version-surfaces.md
@@ -1,0 +1,45 @@
+# Version Surfaces
+
+Use this checklist to find every repository version reference before resolving upstream versions. It extends the `pin-everything` surface audit with upgrade-oriented surfaces such as release tools, schema URLs, marketplace metadata, and version-like literals in docs or scripts.
+
+## Exclusions
+
+Exclude generated, vendored, and cache directories from all searches unless the user explicitly asks to audit them:
+
+- `.git/`
+- `node_modules/`
+- `.yarn/`
+- `.lake/`
+- `vendor/`
+- `dist/`
+- `target/`
+- `.venv/`
+- package manager cache directories
+- generated coverage or build output directories
+
+## Surface Checklist
+
+| Surface family                 | Common files and patterns                                                                                                                                                         | Capture                                                                                       | Notes                                                                                 |
+| ------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| Package manifests              | `package.json`, `pyproject.toml`, `requirements*.txt`, `uv.lock`, `poetry.lock`, `Pipfile.lock`, `go.mod`, `Cargo.toml`, `Gemfile`, `*.gemspec`, `Package.swift`, `composer.json` | Direct dependencies, dev dependencies, tool dependencies, language directives, workspace pins | Preserve public library compatibility ranges unless the user selects a tightening.    |
+| Lockfiles                      | `yarn.lock`, `package-lock.json`, `pnpm-lock.yaml`, `uv.lock`, `poetry.lock`, `Cargo.lock`, `Gemfile.lock`, `Package.resolved`, `composer.lock`                                   | Locked package versions and transitive upgrade opportunities                                  | Do not hand-edit lockfiles when a package manager owns them.                          |
+| GitHub Actions                 | `.github/workflows/*.{yml,yaml}`, `.github/actions/**/action.{yml,yaml}`                                                                                                          | `uses:` refs, action versions, setup action inputs, reusable workflow refs                    | Include SHA-pinned refs by resolving the adjacent version comment when available.     |
+| Reusable workflows             | Workflow `uses:` values containing `.github/workflows/`                                                                                                                           | Calling repo, workflow path, ref, exposed inputs                                              | Treat org-owned reusable workflows as upstream dependencies.                          |
+| Language runtimes              | `.tool-versions`, `.nvmrc`, `.node-version`, `.ruby-version`, `.python-version`, `rust-toolchain.toml`, `go.mod`, `build.zig.zon`, workflow runtime inputs                        | Runtime channel or exact version                                                              | Runtime jumps often carry higher risk than package patch upgrades.                    |
+| Container images               | `Dockerfile*`, `docker-compose*.yml`, `.devcontainer/**`, Kubernetes manifests, Helm values                                                                                       | Image name, tag, digest, base image family                                                    | Prefer digest-aware registry metadata when available.                                 |
+| Devcontainer features          | `.devcontainer/devcontainer.json`, `.devcontainer/*.json`                                                                                                                         | Feature IDs, feature versions, image tags                                                     | Treat features as dependencies even when they are not package-manager dependencies.   |
+| Tool install commands          | `Makefile`, `justfile`, `Taskfile*.yml`, `bin/*`, `scripts/*`, `*.sh`, workflow `run:` blocks, Markdown setup docs                                                                | `go install`, `cargo install`, `pip install`, `uv add`, `uv tool install`, `uvx`, `npx` pins  | Preserve the original install verb when upgrading.                                    |
+| Package manager pins           | `packageManager` in `package.json`, `.yarnrc.yml`, `.npmrc`, `.pnpmfile.cjs`, Corepack metadata                                                                                   | Package manager name, version, integrity suffix                                               | Package manager changes can affect all dependency resolution.                         |
+| Schema URLs                    | `$schema` fields in JSON, YAML, TOML-adjacent config, and Markdown examples                                                                                                       | Schema URL, version segment, publisher                                                        | Some publishers expose only moving URLs; keep those as blocked or unpinnable.         |
+| Release tooling                | `.goreleaser*.yml`, `cliff.toml`, release workflows, Homebrew formula files, package publishing config                                                                            | Tool versions, action refs, changelog tool pins, formula versions                             | Validate release configs with their native dry-run or check command when available.   |
+| Marketplace and plugin data    | `.claude-plugin/marketplace.json`, plugin manifests, extension manifests, action metadata                                                                                         | Plugin versions, catalog state, manifest dependency versions                                  | Recompute derived catalog or aggregate versions after selected upgrades.              |
+| Documentation version literals | `README.md`, `docs/**/*.md`, skill references, command templates                                                                                                                  | Real install commands, versioned examples, template defaults                                  | Distinguish real tool commands from placeholders such as `OWNER/REPO` or `<version>`. |
+| Config version literals        | `*.json`, `*.jsonc`, `*.yaml`, `*.yml`, `*.toml`, `*.ini`, `*.conf`                                                                                                               | Version-like strings not covered elsewhere                                                    | Treat as low confidence until tied to an upstream source.                             |
+
+## Candidate Rules
+
+- A candidate is any version surface where a current upstream value can be newer, unknown, blocked, or intentionally held.
+- High-risk candidates stay in the matrix. Risk changes recommendation and validation, not inclusion.
+- Low-reward candidates stay in the matrix. Reward changes priority, not inclusion.
+- If a surface appears in generated output and source input, report the source input as the editable candidate and summarize the generated output as affected.
+- If the same dependency appears in multiple places, group the occurrences under one candidate only when they share an owner and can be upgraded together.

--- a/dist/opencode/skills/upgrade-everything
+++ b/dist/opencode/skills/upgrade-everything
@@ -1,0 +1,1 @@
+../../../plugins/upgrade-everything/skills/upgrade-everything

--- a/plugins/upgrade-everything/.claude-plugin/plugin.json
+++ b/plugins/upgrade-everything/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "author": {
+    "name": "Christopher Boone"
+  },
+  "description": "Assess every version reference in a repository, evaluate available upgrades with repo-specific risk and reward, and present selectable upgrade options.",
+  "homepage": "https://github.com/cboone/cboone-cc-plugins",
+  "keywords": ["dependencies", "maintenance", "risk", "upgrades", "versioning"],
+  "license": "MIT",
+  "name": "upgrade-everything",
+  "repository": "https://github.com/cboone/cboone-cc-plugins",
+  "skills": "./skills",
+  "version": "1.0.0"
+}

--- a/plugins/upgrade-everything/README.md
+++ b/plugins/upgrade-everything/README.md
@@ -1,0 +1,43 @@
+# Upgrade Everything
+
+Assess every version reference in a repository, evaluate available upgrades with repo-specific risk and reward, and present selectable upgrade options.
+
+**Type:** Skill
+**Trigger:** `/upgrade-everything` (also activates automatically)
+
+## Installation
+
+Add the [`cboone/cboone-cc-plugins`](https://github.com/cboone/cboone-cc-plugins) marketplace in Claude Code:
+
+```text
+/plugin marketplace add cboone/cboone-cc-plugins
+```
+
+Then select **Upgrade Everything** from the available plugins.
+
+## What It Does
+
+Builds a complete upgrade audit for the current repository by inventorying version references, resolving current upstream versions, and evaluating each available upgrade against repo-specific reward and risk. The result is a selectable Markdown matrix that includes every discovered upgrade candidate, including high-risk or low-value items, so the user can decide what to apply.
+
+The skill applies only the upgrades the user explicitly selects. When applying upgrades, it preserves each ecosystem's normal update mechanism: package manager commands for manifests and lockfiles, targeted structured edits for configuration, and no hand-edited lockfiles when a package manager owns them.
+
+## Usage
+
+```text
+/upgrade-everything
+```
+
+## Examples
+
+- "upgrade everything"
+- "check dependency upgrades"
+- "what can be upgraded in this repo?"
+- "assess upgrades but do not apply anything"
+
+## See Also
+
+- [Pin Everything](../pin-everything/README.md): harden mutable version references before or after upgrade review
+- [Update Everything](../update-everything/README.md): audit plugin template drift rather than dependency currency
+- [Release](../release/README.md): update release metadata after selected upgrades land
+- [Lint and Fix](../lint-and-fix/README.md): format and verify files after upgrades
+- [All plugins](../../README.md)

--- a/plugins/upgrade-everything/skills/upgrade-everything/SKILL.md
+++ b/plugins/upgrade-everything/skills/upgrade-everything/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: upgrade-everything
+description: >-
+  Assess every version reference in a repository, check current upstream
+  versions, evaluate repo-specific risk and reward, and present selectable
+  upgrade options. Use when the user says "upgrade everything", "upgrade all
+  versions", "check dependency upgrades", "assess upgrades", "update
+  dependencies", "what can be upgraded", or asks for a full upgrade audit.
+  Always includes every discovered upgrade candidate in the plan and applies
+  upgrades only after explicit user selection.
+---
+
+# Upgrade Everything
+
+Audit every version reference in a repository, resolve current upstream versions, evaluate each available upgrade with repo-specific reward and risk, then apply only the upgrades the user explicitly selects.
+
+## Workflow
+
+### 1. Record the Audit Date
+
+Run `date` before searching for upstream versions. Upgrade data is date-sensitive, so include the exact date in the audit summary and in any later note about unresolved or stale upstream information.
+
+### 2. Detect Repository Shape
+
+Detect the repository root, project languages, package managers, CI systems, release tooling, and whether the repo is an application, public library, template, plugin marketplace, or monorepo. Exclude generated, vendored, and cache directories from all version searches.
+
+Always exclude at least:
+
+- `.git/`
+- `node_modules/`
+- `.yarn/`
+- `.lake/`
+- `vendor/`
+- `dist/`
+- `target/`
+- `.venv/`
+- lockfile cache directories
+
+Use `./references/version-surfaces.md` to decide which files and literals to inspect.
+
+### 3. Discover Version Surfaces
+
+Use the `pin-everything` surface coverage as the baseline, then add upgrade-specific surfaces. Inventory package manifests and lockfiles, GitHub Actions refs, reusable workflows, language runtime files, Docker and devcontainer images, tool install commands, package manager pins, schema URLs, marketplace and plugin versions, release config versions, and unclassified version-like literals in scripts, docs, and config.
+
+For each discovered surface, record:
+
+- File path and owning ecosystem
+- Current value and surrounding context
+- Whether a package manager, lockfile, generator, or template owns the value
+- Whether the surface is user-facing documentation, executable automation, build metadata, or published API metadata
+
+Do not classify a candidate as out of scope merely because the upgrade looks risky or low value.
+
+### 4. Resolve Upstream Versions
+
+Resolve current upstream versions from authoritative sources for each ecosystem. Use package registries, GitHub releases or tags, container registries, language and toolchain channels, schema publisher metadata, and project-specific release files where relevant.
+
+Use `./references/upgrade-sources.md` for source-of-truth selection. Record the source URL or command, lookup date, latest value, and confidence. If upstream resolution fails, keep the candidate in the plan with status `Blocked` or `Unknown` instead of dropping it.
+
+### 5. Classify Candidates
+
+Build one numbered candidate record for every discovered upgrade opportunity. If a version surface is already current, summarize it separately as up to date unless the user asked for a full inventory.
+
+Each candidate must include:
+
+- Current value and latest value
+- Upgrade type: patch, minor, major, digest, SHA, runtime, schema, channel, or unknown
+- Source of truth and confidence
+- Reward rating and reasons
+- Risk rating and reasons
+- Required validation
+- Recommendation
+
+Use `./references/risk-reward.md` for the reward and risk model. Risk affects ordering and recommendation, not inclusion.
+
+### 6. Present the Upgrade Matrix
+
+Present a Markdown matrix grouped by ecosystem and surface. Include every candidate, including high-risk, blocked, unknown, and low-reward upgrades.
+
+Use this shape:
+
+```text
+| # | Ecosystem | Surface | Current | Latest | Type | Reward | Risk | Confidence | Recommendation | Validation |
+|---|-----------|---------|---------|--------|------|--------|------|------------|----------------|------------|
+```
+
+After the matrix, list up-to-date surfaces and unresolved upstream lookups separately. Make the distinction between "not selected yet", "not recommended", and "blocked" explicit.
+
+### 7. Ask for Selection
+
+Ask the user which upgrades to apply. Offer these choices:
+
+- Apply all upgrades
+- Apply only low-risk upgrades
+- Apply only selected candidate numbers
+- Audit only
+- Apply all except custom exclusions
+
+Do not apply upgrades until the user explicitly selects a scope. If the user asks for audit-only, stop after reporting the matrix.
+
+### 8. Apply Selected Upgrades
+
+Apply only selected candidates. Preserve each ecosystem's normal update mechanism:
+
+- Use package manager commands for manifests and lockfiles.
+- Use targeted YAML, JSON, TOML, or lockfile-aware edits for configuration values.
+- Do not hand-edit lockfiles when a package manager owns them.
+- Preserve library constraints unless the user explicitly chooses to tighten them.
+- Keep generated files under their generator's ownership where that generator is known.
+
+Process upgrades in dependency-aware order: toolchain and package manager pins first, package manifests and lockfiles next, CI and release configuration after that, then documentation or template references.
+
+### 9. Verify and Summarize
+
+Run the relevant verification for the selected upgrades: package manager checks, lockfile consistency checks, tests, build commands, and CI or release validators present in the repo. After edits, invoke the `lint-and-fix` skill to run project linters and formatters.
+
+Summarize the result under these headings:
+
+- Upgraded
+- Skipped by user
+- Blocked
+- Failed
+- Already up to date
+- Follow-up validation
+
+Include any commands that failed and the concrete candidate numbers affected.
+
+## Reference Navigation
+
+- `./references/version-surfaces.md` - surfaces to discover before resolving upstream versions
+- `./references/upgrade-sources.md` - authoritative upstream sources by ecosystem
+- `./references/risk-reward.md` - reward, risk, confidence, recommendation, and validation model
+
+## Error Handling
+
+- **Upstream source unavailable:** Keep the candidate in the matrix with `Unknown` latest value, low confidence, and a clear blocked reason.
+- **Ambiguous ownership:** Ask before editing if a version could be generated, owned by a lockfile, or part of public library compatibility metadata.
+- **Package manager update fails:** Capture the failure, mark only the affected candidates as failed, and ask whether to continue with independent candidates.
+- **High-risk migration notes:** Include the upgrade in the matrix with the migration note summarized and validation expanded. Do not hide it.
+- **Conflicting lockfiles:** Stop before editing and ask which package manager owns the project.

--- a/plugins/upgrade-everything/skills/upgrade-everything/references/risk-reward.md
+++ b/plugins/upgrade-everything/skills/upgrade-everything/references/risk-reward.md
@@ -1,0 +1,73 @@
+# Risk and Reward
+
+Use this model to make upgrade recommendations without hiding any candidate. Risk affects ordering, validation, and recommendation; it never removes a candidate from the plan.
+
+## Reward Dimensions
+
+| Dimension                | Higher reward when                                                                 |
+| ------------------------ | ---------------------------------------------------------------------------------- |
+| Security                 | The upgrade fixes a known vulnerability, unsafe default, or exposed CI dependency. |
+| Bug fixes                | Release notes mention correctness, stability, or crash fixes relevant to the repo. |
+| Compatibility            | The upgrade restores support for current platforms, package managers, or APIs.     |
+| Template alignment       | The repo should match current project templates, workflows, or generated files.    |
+| Stale transitive cleanup | The upgrade refreshes old transitive dependencies or lockfile resolution.          |
+| Ecosystem support        | The current version is near end-of-support or unsupported by upstream tooling.     |
+| Maintainer policy        | The repo's policy expects current minor or patch releases.                         |
+
+## Risk Dimensions
+
+| Dimension                   | Higher risk when                                                                               |
+| --------------------------- | ---------------------------------------------------------------------------------------------- |
+| SemVer major changes        | The upgrade crosses a major boundary or the ecosystem does not follow SemVer reliably.         |
+| Runtime or toolchain jumps  | The upgrade changes compiler, interpreter, package manager, or build image behavior.           |
+| Lockfile churn              | The upgrade changes many transitive dependencies or multiple ecosystem lockfiles.              |
+| Deprecated packages         | The current or target package is deprecated, renamed, archived, or superseded.                 |
+| Migration notes             | Upstream requires config changes, code changes, data migrations, or manual intervention.       |
+| Changelog warnings          | Release notes mention breaking changes, removals, changed defaults, or security model changes. |
+| Public library constraints  | Tightening a manifest range could constrain downstream users.                                  |
+| CI blast radius             | The dependency is used across many jobs, publish paths, release automation, or templates.      |
+| Repo-specific test coverage | The repo lacks tests or checks that exercise the upgraded dependency.                          |
+
+## Ratings
+
+| Rating  | Reward meaning                                                  | Risk meaning                                                          |
+| ------- | --------------------------------------------------------------- | --------------------------------------------------------------------- |
+| High    | Strong repo-specific benefit or security relevance.             | Requires migration review, broad validation, or explicit user choice. |
+| Medium  | Clear maintenance value with limited direct feature impact.     | Behavior could change, but validation is available and bounded.       |
+| Low     | Mostly currency, tidy-up, or alignment value.                   | Narrow impact, patch-level change, or strong automated validation.    |
+| Unknown | Reward cannot be evaluated from available upstream information. | Risk cannot be evaluated from available upstream information.         |
+
+## Recommendation Labels
+
+| Label       | Meaning                                                                                    |
+| ----------- | ------------------------------------------------------------------------------------------ |
+| Recommended | Reward is clear and risk is low or manageable with available validation.                   |
+| Optional    | Upgrade is valid, but reward is mostly maintenance or repo policy alignment.               |
+| Review      | Upgrade should be considered, but migration notes, major changes, or blast radius matter.  |
+| Blocked     | Upstream data, ownership, package manager state, or validation prerequisites are missing.  |
+| Hold        | The repo appears to have an intentional hold policy, but the candidate remains selectable. |
+
+## Candidate Matrix Fields
+
+| Field        | Required content                                                              |
+| ------------ | ----------------------------------------------------------------------------- |
+| `#`          | Stable candidate number used for user selection.                              |
+| `Ecosystem`  | Package manager, runtime, CI, container, schema, marketplace, or other owner. |
+| `Surface`    | File path and version surface, concise enough to scan.                        |
+| `Current`    | Current version, tag, SHA, digest, range, channel, or unknown value.          |
+| `Latest`     | Latest resolved upstream value, or `Unknown` / `Blocked`.                     |
+| `Type`       | Patch, minor, major, digest, SHA, runtime, schema, channel, or unknown.       |
+| `Reward`     | Rating plus the most important reason.                                        |
+| `Risk`       | Rating plus the most important reason.                                        |
+| `Confidence` | High, medium, low, or unknown based on upstream source quality.               |
+| `Validation` | Commands or checks required before calling the upgrade complete.              |
+
+## Validation Guidance
+
+- Package dependencies: run the ecosystem's resolver, tests, and lockfile consistency checks.
+- Runtime or toolchain upgrades: run build, test, lint, and any smoke tests that execute the produced artifact.
+- GitHub Actions and reusable workflows: validate workflow syntax and run local checks that mirror the changed CI behavior where possible.
+- Container images: rebuild affected images and run the repo's container smoke tests or entrypoint checks.
+- Release tooling: run dry-run or config validation commands before claiming success.
+- Schema URLs and config versions: run the tool that consumes the config.
+- Marketplace and plugin versions: run manifest validation and recompute derived catalog metadata.

--- a/plugins/upgrade-everything/skills/upgrade-everything/references/upgrade-sources.md
+++ b/plugins/upgrade-everything/skills/upgrade-everything/references/upgrade-sources.md
@@ -1,0 +1,51 @@
+# Upgrade Sources
+
+Resolve latest versions from authoritative sources and record the source used for every candidate. Prefer machine-readable registry or release metadata over scraping human-readable pages.
+
+## Source Selection
+
+| Ecosystem or surface     | Authoritative sources                                                           | Typical lookup method                                           | Confidence notes                                                                   |
+| ------------------------ | ------------------------------------------------------------------------------- | --------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| npm and Corepack         | npm registry, package manager metadata, Corepack                                | `npm view`, registry JSON, `corepack use`                       | Highest when registry metadata and lockfile update agree.                          |
+| Python                   | PyPI JSON API, uv or pip resolver output, project lockfile                      | `uv lock --upgrade-package`, PyPI JSON, `pip index versions`    | Prefer uv for uv-managed projects and package manager output for lockfile changes. |
+| Go modules and tools     | Go module proxy, module tags, GitHub releases for install tools                 | `go list -m -u -json`, `go install` dry run, GitHub API         | Check module path replacements and major-version suffixes.                         |
+| Rust crates              | crates.io index, `cargo update`, `cargo metadata`                               | `cargo update -p`, crates.io API                                | Distinguish library compatibility constraints from binary application pins.        |
+| Ruby                     | RubyGems API, Bundler resolver                                                  | `bundle update <gem>`, RubyGems versions API                    | Bundler output is preferred when a `Gemfile.lock` exists.                          |
+| Swift packages           | Git tags from package remotes, `Package.resolved`                               | `swift package update`, GitHub tags                             | SemVer tags are conventional, but validate package resolution.                     |
+| PHP Composer             | Packagist API, Composer resolver                                                | `composer outdated`, `composer update vendor/package`           | Composer constraints may be public library API promises.                           |
+| GitHub Actions           | GitHub releases, tags, commit API, action metadata                              | GitHub API, `gh release view`, `gh api repos/.../commits/<ref>` | SHA pins need the version comment or commit ancestry to assess drift.              |
+| Reusable workflows       | GitHub releases, tags, workflow repository release notes                        | GitHub API, repository tags                                     | Treat workflow input changes as API changes.                                       |
+| Container images         | Docker Hub, GHCR, registry manifest APIs, image labels                          | Registry API, `docker buildx imagetools inspect`                | Tags can be mutable; digest comparison improves confidence.                        |
+| Language runtimes        | Official release indexes and toolchain channels                                 | Node.js index, Python downloads, Go downloads, Rust channels    | Runtime upgrades require repo-specific validation beyond version lookup.           |
+| Zig and niche toolchains | Official release JSON, project release pages, package manager metadata          | Publisher API or release index                                  | Confidence depends on whether the publisher exposes stable machine-readable data.  |
+| Schema URLs              | Schema publisher versioned URLs, Schema Store catalog, project release metadata | Publisher catalog or repository tags                            | Some schemas expose only moving URLs. Mark those as unpinnable, not missing.       |
+| Marketplace/plugin data  | Marketplace manifest, local plugin manifests, release tags                      | `jq`, local manifest reads, repository releases                 | Recompute derived catalog state after changing individual plugin versions.         |
+| Release tools            | Tool release pages, package registries, action releases                         | GitHub releases, package registry APIs                          | Validate generated release config with the tool's own check or dry-run.            |
+| Unclassified literals    | The publisher identified from surrounding context                               | Context-specific                                                | Keep confidence low until the upstream owner is known.                             |
+
+## Lookup Policy
+
+1. Record the exact audit date from `date`.
+1. Resolve upstream from the closest owner of the version surface.
+1. Use the repository's native package manager when it owns lockfile changes.
+1. Prefer official APIs and registry metadata over blog posts, search results, or mirrors.
+1. Check changelogs and migration notes for major, runtime, toolchain, and reusable workflow upgrades.
+1. If the source of truth cannot be identified, keep the candidate and mark source `Unknown`.
+1. If the source is unreachable, keep the candidate and mark status `Blocked`.
+
+## Confidence Labels
+
+| Confidence | Use when                                                                                            |
+| ---------- | --------------------------------------------------------------------------------------------------- |
+| High       | Official registry or release metadata identifies the latest version and the package manager agrees. |
+| Medium     | Official tags or releases exist, but changelog, resolver, or lockfile confirmation is incomplete.   |
+| Low        | The candidate is inferred from context, a moving channel, a mutable tag, or incomplete metadata.    |
+| Unknown    | No authoritative source could be resolved.                                                          |
+
+## Applying Sources to Edits
+
+- Use package manager commands for dependencies and lockfiles.
+- Use targeted structured edits for workflow refs, runtime files, schema URLs, marketplace metadata, and release config.
+- Preserve existing held-major or held-channel policy unless the user explicitly selects a major or channel migration.
+- Never downgrade a SHA, digest, or exact pin to a mutable tag while upgrading.
+- Keep a blocked candidate in the summary with the source attempted and the next information needed.

--- a/plugins/upgrade-everything/skills/upgrade-everything/references/version-surfaces.md
+++ b/plugins/upgrade-everything/skills/upgrade-everything/references/version-surfaces.md
@@ -1,0 +1,45 @@
+# Version Surfaces
+
+Use this checklist to find every repository version reference before resolving upstream versions. It extends the `pin-everything` surface audit with upgrade-oriented surfaces such as release tools, schema URLs, marketplace metadata, and version-like literals in docs or scripts.
+
+## Exclusions
+
+Exclude generated, vendored, and cache directories from all searches unless the user explicitly asks to audit them:
+
+- `.git/`
+- `node_modules/`
+- `.yarn/`
+- `.lake/`
+- `vendor/`
+- `dist/`
+- `target/`
+- `.venv/`
+- package manager cache directories
+- generated coverage or build output directories
+
+## Surface Checklist
+
+| Surface family                 | Common files and patterns                                                                                                                                                         | Capture                                                                                       | Notes                                                                                 |
+| ------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| Package manifests              | `package.json`, `pyproject.toml`, `requirements*.txt`, `uv.lock`, `poetry.lock`, `Pipfile.lock`, `go.mod`, `Cargo.toml`, `Gemfile`, `*.gemspec`, `Package.swift`, `composer.json` | Direct dependencies, dev dependencies, tool dependencies, language directives, workspace pins | Preserve public library compatibility ranges unless the user selects a tightening.    |
+| Lockfiles                      | `yarn.lock`, `package-lock.json`, `pnpm-lock.yaml`, `uv.lock`, `poetry.lock`, `Cargo.lock`, `Gemfile.lock`, `Package.resolved`, `composer.lock`                                   | Locked package versions and transitive upgrade opportunities                                  | Do not hand-edit lockfiles when a package manager owns them.                          |
+| GitHub Actions                 | `.github/workflows/*.{yml,yaml}`, `.github/actions/**/action.{yml,yaml}`                                                                                                          | `uses:` refs, action versions, setup action inputs, reusable workflow refs                    | Include SHA-pinned refs by resolving the adjacent version comment when available.     |
+| Reusable workflows             | Workflow `uses:` values containing `.github/workflows/`                                                                                                                           | Calling repo, workflow path, ref, exposed inputs                                              | Treat org-owned reusable workflows as upstream dependencies.                          |
+| Language runtimes              | `.tool-versions`, `.nvmrc`, `.node-version`, `.ruby-version`, `.python-version`, `rust-toolchain.toml`, `go.mod`, `build.zig.zon`, workflow runtime inputs                        | Runtime channel or exact version                                                              | Runtime jumps often carry higher risk than package patch upgrades.                    |
+| Container images               | `Dockerfile*`, `docker-compose*.yml`, `.devcontainer/**`, Kubernetes manifests, Helm values                                                                                       | Image name, tag, digest, base image family                                                    | Prefer digest-aware registry metadata when available.                                 |
+| Devcontainer features          | `.devcontainer/devcontainer.json`, `.devcontainer/*.json`                                                                                                                         | Feature IDs, feature versions, image tags                                                     | Treat features as dependencies even when they are not package-manager dependencies.   |
+| Tool install commands          | `Makefile`, `justfile`, `Taskfile*.yml`, `bin/*`, `scripts/*`, `*.sh`, workflow `run:` blocks, Markdown setup docs                                                                | `go install`, `cargo install`, `pip install`, `uv add`, `uv tool install`, `uvx`, `npx` pins  | Preserve the original install verb when upgrading.                                    |
+| Package manager pins           | `packageManager` in `package.json`, `.yarnrc.yml`, `.npmrc`, `.pnpmfile.cjs`, Corepack metadata                                                                                   | Package manager name, version, integrity suffix                                               | Package manager changes can affect all dependency resolution.                         |
+| Schema URLs                    | `$schema` fields in JSON, YAML, TOML-adjacent config, and Markdown examples                                                                                                       | Schema URL, version segment, publisher                                                        | Some publishers expose only moving URLs; keep those as blocked or unpinnable.         |
+| Release tooling                | `.goreleaser*.yml`, `cliff.toml`, release workflows, Homebrew formula files, package publishing config                                                                            | Tool versions, action refs, changelog tool pins, formula versions                             | Validate release configs with their native dry-run or check command when available.   |
+| Marketplace and plugin data    | `.claude-plugin/marketplace.json`, plugin manifests, extension manifests, action metadata                                                                                         | Plugin versions, catalog state, manifest dependency versions                                  | Recompute derived catalog or aggregate versions after selected upgrades.              |
+| Documentation version literals | `README.md`, `docs/**/*.md`, skill references, command templates                                                                                                                  | Real install commands, versioned examples, template defaults                                  | Distinguish real tool commands from placeholders such as `OWNER/REPO` or `<version>`. |
+| Config version literals        | `*.json`, `*.jsonc`, `*.yaml`, `*.yml`, `*.toml`, `*.ini`, `*.conf`                                                                                                               | Version-like strings not covered elsewhere                                                    | Treat as low confidence until tied to an upstream source.                             |
+
+## Candidate Rules
+
+- A candidate is any version surface where a current upstream value can be newer, unknown, blocked, or intentionally held.
+- High-risk candidates stay in the matrix. Risk changes recommendation and validation, not inclusion.
+- Low-reward candidates stay in the matrix. Reward changes priority, not inclusion.
+- If a surface appears in generated output and source input, report the source input as the editable candidate and summarize the generated output as affected.
+- If the same dependency appears in multiple places, group the occurrences under one candidate only when they share an owner and can be upgraded together.


### PR DESCRIPTION
## Summary

- Add the `upgrade-everything` skill plugin for full repository upgrade audits.
- Document version surfaces, upstream lookup sources, and risk/reward classification.
- Register the plugin in the marketplace and README, with catalog metadata recomputed.

## Test plan

- [x] `yarn lint:fix`
- [x] `yarn validate`
- [x] `yarn lint`
