### PR TITLE
feat: add /add-cobra-version skill

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -2,13 +2,27 @@
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "metadata": {
     "description": "Claude Code commands, hooks, and skills from Christopher Boone (cboone.github.io)",
-    "version": "catalog-M58-m103-p115-n50"
+    "version": "catalog-M59-m103-p115-n51"
   },
   "name": "cboone-cc-plugins",
   "owner": {
     "name": "Christopher Boone"
   },
   "plugins": [
+    {
+      "author": {
+        "name": "Christopher Boone"
+      },
+      "category": "ci-and-release",
+      "description": "Add a version subcommand with build metadata (version, commit hash, build date, Go runtime version, optional JSON output) to an existing Cobra-based Go CLI, wiring up ldflags in main.go, the cmd package, GoReleaser, and the Makefile.",
+      "homepage": "https://github.com/cboone/cboone-cc-plugins",
+      "keywords": ["cli", "cobra", "go", "golang", "version"],
+      "license": "MIT",
+      "name": "add-cobra-version",
+      "repository": "https://github.com/cboone/cboone-cc-plugins",
+      "source": "./dist/codex/plugins/add-cobra-version",
+      "version": "1.0.0"
+    },
     {
       "author": {
         "name": "Christopher Boone"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,13 +2,27 @@
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "metadata": {
     "description": "Claude Code commands, hooks, and skills from Christopher Boone (cboone.github.io)",
-    "version": "catalog-M58-m103-p115-n50"
+    "version": "catalog-M59-m103-p115-n51"
   },
   "name": "cboone-cc-plugins",
   "owner": {
     "name": "Christopher Boone"
   },
   "plugins": [
+    {
+      "author": {
+        "name": "Christopher Boone"
+      },
+      "category": "ci-and-release",
+      "description": "Add a version subcommand with build metadata (version, commit hash, build date, Go runtime version, optional JSON output) to an existing Cobra-based Go CLI, wiring up ldflags in main.go, the cmd package, GoReleaser, and the Makefile.",
+      "homepage": "https://github.com/cboone/cboone-cc-plugins",
+      "keywords": ["cli", "cobra", "go", "golang", "version"],
+      "license": "MIT",
+      "name": "add-cobra-version",
+      "repository": "https://github.com/cboone/cboone-cc-plugins",
+      "source": "./plugins/add-cobra-version",
+      "version": "1.0.0"
+    },
     {
       "author": {
         "name": "Christopher Boone"

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Each skill links to its own README. The `Trigger` column shows the slash command
 
 | Plugin | Trigger | What it does |
 | --- | --- | --- |
+| [Add Cobra Version](./plugins/add-cobra-version/README.md) | `/add-cobra-version` | Add a version subcommand with build metadata (version, commit hash, build date, Go runtime version, optional JSON output) to an existing Cobra-based Go CLI, wiring up ldflags in main.go, the cmd package, GoReleaser, and the Makefile. |
 | [Add GoReleaser Homebrew](./plugins/add-goreleaser-homebrew/README.md) | `/add-goreleaser-homebrew` | Add GoReleaser and Homebrew tap publishing to an existing Go CLI project with conditional support for completions, man pages, and macOS-only builds. |
 | [Optimize Runner Usage](./plugins/optimize-runner-usage/README.md) | `/optimize-runner-usage` | Add paths-ignore, concurrency groups, and timeout-minutes to existing GitHub Actions workflows. |
 | [Pin Everything](./plugins/pin-everything/README.md) | `/pin-everything` | Pin every version surface in a repository (action SHAs, packageManager integrity digests, dependency exact-pins, runtime version files, install commands) for one-shot supply-chain hardening. |

--- a/dist/codex/plugins/add-cobra-version/.claude-plugin/plugin.json
+++ b/dist/codex/plugins/add-cobra-version/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "author": {
+    "name": "Christopher Boone"
+  },
+  "description": "Add a version subcommand with build metadata (version, commit hash, build date, Go runtime version, optional JSON output) to an existing Cobra-based Go CLI, wiring up ldflags in main.go, the cmd package, GoReleaser, and the Makefile.",
+  "homepage": "https://github.com/cboone/cboone-cc-plugins",
+  "keywords": ["cli", "cobra", "go", "golang", "version"],
+  "license": "MIT",
+  "name": "add-cobra-version",
+  "repository": "https://github.com/cboone/cboone-cc-plugins",
+  "skills": "./skills",
+  "version": "1.0.0"
+}

--- a/dist/codex/plugins/add-cobra-version/README.md
+++ b/dist/codex/plugins/add-cobra-version/README.md
@@ -30,6 +30,7 @@ The skill detects the project's existing version wiring (basic `var version` onl
 
 - Adds `cmd/version.go` (skips or asks before overwriting if one already exists).
 - Adds package-level `commit` and `date` variables to `cmd/root.go` alongside `version`, exposing a `SetVersionInfo(v, c, d string)` helper. If only `SetVersion` exists, it is replaced.
+- Detects the root command variable in `package cmd` and uses that identifier when registering the generated `version` subcommand.
 - Adds `commit` and `date` package-level vars to `main.go` and updates the call to `cmd.SetVersionInfo`.
 - Extends GoReleaser `ldflags` to include `-X main.commit={{.ShortCommit}}` and `-X main.date={{.Date}}`.
 - Extends the Makefile `LDFLAGS` to include matching `-X` entries plus `COMMIT` and `DATE` variables.

--- a/dist/codex/plugins/add-cobra-version/README.md
+++ b/dist/codex/plugins/add-cobra-version/README.md
@@ -1,0 +1,47 @@
+# Add Cobra Version
+
+Add a `version` subcommand with full build metadata to an existing Cobra-based Go CLI.
+
+**Type:** Skill
+**Trigger:** `/add-cobra-version`
+
+## Installation
+
+See the [marketplace install instructions](../../../../README.md#install).
+
+## What It Does
+
+Generates a `cmd/version.go` and coordinates the matching ldflags wiring across `main.go`, `cmd/root.go`, `.goreleaser.yml`, and the `Makefile` so a Cobra CLI can report:
+
+- Version (from git tag, falling back to `"dev"`)
+- Commit hash (short)
+- Build date (UTC, ISO 8601)
+- Go runtime version (from `runtime.Version()`)
+
+Output is human-readable by default with an optional `--json` flag for scripts. Cobra's built-in `--version` flag continues to work and reports the same version string.
+
+## Usage
+
+```text
+/add-cobra-version
+```
+
+The skill detects the project's existing version wiring (basic `var version` only versus full `version`/`commit`/`date`) and then:
+
+- Adds `cmd/version.go` (skips or asks before overwriting if one already exists).
+- Adds package-level `commit` and `date` variables to `cmd/root.go` alongside `version`, exposing a `SetVersionInfo(v, c, d string)` helper. If only `SetVersion` exists, it is replaced.
+- Adds `commit` and `date` package-level vars to `main.go` and updates the call to `cmd.SetVersionInfo`.
+- Extends GoReleaser `ldflags` to include `-X main.commit={{.ShortCommit}}` and `-X main.date={{.Date}}`.
+- Extends the Makefile `LDFLAGS` to include matching `-X` entries plus `COMMIT` and `DATE` variables.
+
+## Examples
+
+- "add a version subcommand to this CLI": detects state and wires everything up
+- "wire up version, commit, and date ldflags": same behavior
+- "add `--json` to the version command": same behavior, ensures the `--json` flag is present
+
+## See Also
+
+- [Scaffold Go CLI](../scaffold-go-cli/README.md): scaffolding a brand-new Go CLI (starts with the basic `version` variable).
+- [Add GoReleaser Homebrew](../add-goreleaser-homebrew/README.md): adding GoReleaser and the release workflow when those are missing too.
+- [All plugins](../../../../README.md)

--- a/dist/codex/plugins/add-cobra-version/skills/add-cobra-version/SKILL.md
+++ b/dist/codex/plugins/add-cobra-version/skills/add-cobra-version/SKILL.md
@@ -33,9 +33,9 @@ Detection commands:
 
 ```bash
 # Find version declarations across the project.
-grep -rn 'var\s\+version\b' --include='*.go' .
-grep -rn 'var\s\+commit\b' --include='*.go' .
-grep -rn 'var\s\+date\b' --include='*.go' .
+grep -rnE '^[[:space:]]*var[[:space:]]+version([[:space:]=]|$)' --include='*.go' .
+grep -rnE '^[[:space:]]*var[[:space:]]+commit([[:space:]=]|$)' --include='*.go' .
+grep -rnE '^[[:space:]]*var[[:space:]]+date([[:space:]=]|$)' --include='*.go' .
 ```
 
 Also check for an existing version subcommand:
@@ -45,13 +45,13 @@ Also check for an existing version subcommand:
 test -f cmd/version.go && echo "cmd/version.go exists"
 
 # Existing version subcommand registration via &cobra.Command{ Use: "version", ... }.
-grep -rn 'Use:\s*"version"' --include='*.go' .
+grep -rnE 'Use:[[:space:]]*"version"' --include='*.go' .
 ```
 
 If a `cmd/version.go` already exists, read it. Decide:
 
 - If it already prints version, commit, date, and Go runtime version with a `--json` flag, treat it as up to date and skip step 5 (only continue with the wiring steps for any state still missing).
-- Otherwise, ask the user whether to overwrite. If they decline, abort the skill.
+- Otherwise, ask the user whether to overwrite. If they decline, skip step 5 and continue with the remaining wiring steps so the existing file is preserved while partial version state is repaired.
 
 ### 3. Detect ldflags Target Package
 
@@ -78,7 +78,7 @@ Use the result wherever templates reference `PROJECT-NAME`.
 Read `./references/version-go.md` for the `cmd/version.go` template and create the file from it.
 
 - Replace `PROJECT-NAME` with the binary name from step 4.
-- Do not modify the file if step 2 found an up-to-date `cmd/version.go` and the user chose to keep it.
+- Do not modify the file if step 2 found an up-to-date `cmd/version.go` or the user chose to keep the existing file.
 
 The generated subcommand:
 

--- a/dist/codex/plugins/add-cobra-version/skills/add-cobra-version/SKILL.md
+++ b/dist/codex/plugins/add-cobra-version/skills/add-cobra-version/SKILL.md
@@ -1,0 +1,200 @@
+---
+name: add-cobra-version
+description: >-
+  Add a version subcommand with build metadata (version, commit hash, build
+  date, Go runtime version, optional JSON output) to an existing Cobra-based Go
+  CLI, wiring up ldflags in main.go, the cmd package, GoReleaser, and the
+  Makefile.
+---
+
+# Add Cobra Version
+
+Add a `version` subcommand with version, commit hash, build date, and Go runtime version to an existing Cobra-based Go CLI, and coordinate the matching ldflags wiring across `main.go`, `cmd/root.go`, `.goreleaser.yml`, and the `Makefile`.
+
+## Workflow
+
+### 1. Verify the Project
+
+Confirm the current directory is a Go CLI project with Cobra:
+
+- `go.mod` exists. If not, abort with a message that this skill requires an existing Go module.
+- A Cobra root command exists. Check for `cmd/root.go` (the canonical location used by `scaffold-go-cli`); if absent, grep for `&cobra.Command{` in `*.go` and `cmd/*.go`. If no Cobra command is found, abort: this skill is Cobra-specific.
+- Read `go.mod` to extract the module path; needed when reasoning about ldflags `-X` targets.
+
+### 2. Detect Current Version State
+
+Determine which of three states the project is in. The state controls how aggressive the changes need to be.
+
+1. **No version wiring**: no `var version` declaration in any Go source file.
+1. **Basic version only**: `var version = "dev"` (or similar) exists, typically in `main.go` or `cmd/root.go`, but no `commit` or `date` variables.
+1. **Full version info already present**: `version`, `commit`, and `date` package-level variables all exist.
+
+Detection commands:
+
+```bash
+# Find version declarations across the project.
+grep -rn 'var\s\+version\b' --include='*.go' .
+grep -rn 'var\s\+commit\b' --include='*.go' .
+grep -rn 'var\s\+date\b' --include='*.go' .
+```
+
+Also check for an existing version subcommand:
+
+```bash
+# Existing cmd/version.go file.
+test -f cmd/version.go && echo "cmd/version.go exists"
+
+# Existing version subcommand registration via &cobra.Command{ Use: "version", ... }.
+grep -rn 'Use:\s*"version"' --include='*.go' .
+```
+
+If a `cmd/version.go` already exists, read it. Decide:
+
+- If it already prints version, commit, date, and Go runtime version with a `--json` flag, treat it as up to date and skip step 5 (only continue with the wiring steps for any state still missing).
+- Otherwise, ask the user whether to overwrite. If they decline, abort the skill.
+
+### 3. Detect ldflags Target Package
+
+The version variables can live in `package main` (`-X main.version=...`) or in the `cmd` package (`-X MODULE-PATH/cmd.version=...`). Pick a target convention:
+
+1. If `var version` already exists in `main.go` or any file in `package main`, target `main`. The `cmd` package will receive the values via a `SetVersionInfo` call from `main`.
+1. If `var version` exists only in the `cmd` package and `main.go` does not declare it, still target `main`: this skill standardizes on the `main`-declared, `cmd.SetVersionInfo`-injected pattern (it is the pattern produced by `scaffold-go-cli` and used by `bopca`). Plan to move the declaration into `main.go` and add the `commit`/`date` siblings there.
+1. If no `version` declaration exists anywhere, target `main`: the skill will add the variables to `main.go`.
+
+Record the chosen ldflags prefix (`main.`) and the resolved module path; both are used in steps 7 and 8.
+
+### 4. Determine Project Name for Output Headers
+
+The version subcommand prints a human-readable header that begins with the binary name (for example `bopca 1.2.3`). Determine the binary name in this precedence order:
+
+1. The `Use` field on the Cobra root command (read from `cmd/root.go`). Strip any trailing argument hints, for example `Use: "bopca [flags]"` becomes `bopca`.
+1. A `BINARY` or similar Makefile variable.
+1. The last segment of the module path in `go.mod`.
+
+Use the result wherever templates reference `PROJECT-NAME`.
+
+### 5. Generate `cmd/version.go`
+
+Read `./references/version-go.md` for the `cmd/version.go` template and create the file from it.
+
+- Replace `PROJECT-NAME` with the binary name from step 4.
+- Do not modify the file if step 2 found an up-to-date `cmd/version.go` and the user chose to keep it.
+
+The generated subcommand:
+
+- Prints version, commit, date, and `runtime.Version()` to `cmd.OutOrStdout()`.
+- Accepts a `--json` flag for machine-readable output.
+- Registers itself on `rootCmd` from its `init()` function, so no edits to `cmd/root.go` are required to wire it up.
+
+### 6. Update `cmd/root.go`
+
+Read `./references/root-go-update.md` for the modifications to apply.
+
+If the file already declares the package-level variables (`version`, `commit`, `date`) and exposes a `SetVersionInfo(v, c, d string)` function, leave it alone.
+
+Otherwise:
+
+- Add (or extend) the package-level `var ( ... )` block to declare `version = "dev"`, `commit = "none"`, and `date = "unknown"`.
+- Add a `SetVersionInfo(v, c, d string)` function that assigns the three variables and sets `rootCmd.Version = v` so Cobra's built-in `--version` flag still works. If a `SetVersion(v string)` function already exists, replace it with `SetVersionInfo`. If callers in `main.go` reference the old name, they will be updated in step 7.
+- If the file currently sets `Version: version` directly on `rootCmd` and nothing else, leave that field in place; `SetVersionInfo` will overwrite it at startup.
+
+### 7. Update `main.go`
+
+Read `./references/main-go-update.md` for the modifications to apply.
+
+If `main.go` already declares all three `version`, `commit`, `date` package-level variables and calls `cmd.SetVersionInfo(version, commit, date)` before `cmd.Execute()`, leave the file alone.
+
+Otherwise:
+
+- Ensure the package-level declarations include `version = "dev"`, `commit = "none"`, and `date = "unknown"`. Add missing siblings; do not remove unrelated variables.
+- Replace any existing `cmd.SetVersion(version)` call with `cmd.SetVersionInfo(version, commit, date)`.
+- If no `SetVersion`-style call exists yet, add `cmd.SetVersionInfo(version, commit, date)` immediately before `cmd.Execute()`.
+
+### 8. Update `.goreleaser.yml`
+
+Read `./references/goreleaser-update.md` for the modifications to apply.
+
+GoReleaser may use `.goreleaser.yml` or `.goreleaser.yaml`. Check both. If neither exists, skip this step and note in the summary that GoReleaser is not configured (the user can run `/add-goreleaser-homebrew` to add it).
+
+In the existing config, find the `builds[].ldflags` list. Ensure all three `-X` entries are present:
+
+```yaml
+- -X main.version={{.Version}}
+- -X main.commit={{.ShortCommit}}
+- -X main.date={{.Date}}
+```
+
+If `-X main.version=...` is already present, keep it. Add only the `-X` entries that are missing. Preserve any existing `-s -w` or other ldflags.
+
+### 9. Update the Makefile
+
+Read `./references/makefile-update.md` for the modifications to apply.
+
+If no `Makefile` exists in the project root, skip this step and note in the summary.
+
+Otherwise, ensure the Makefile defines:
+
+- `VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")`
+- `COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "none")`
+- `DATE ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)`
+
+Then ensure `LDFLAGS` (or the equivalent variable already in use) contains the matching `-X` entries:
+
+```makefile
+LDFLAGS := -s -w \
+	-X main.version=$(VERSION) \
+	-X main.commit=$(COMMIT) \
+	-X main.date=$(DATE)
+```
+
+Preserve any other flags already in `LDFLAGS`. Ensure the `build` target uses `$(LDFLAGS)` in its `go build` invocation; if it already uses a sub-variable, leave it alone.
+
+### 10. Verify the Build
+
+Run a quick build to confirm everything compiles and the new subcommand wires up cleanly:
+
+```bash
+go build ./...
+```
+
+If a Makefile build target now exists with the expanded ldflags, prefer:
+
+```bash
+make build
+```
+
+Then exercise the new command, ignoring exit code (the subcommand always exits 0 on success):
+
+```bash
+go run . version
+go run . version --json
+go run . --version
+```
+
+If any of those fail, inspect the error and fix the offending file before continuing.
+
+### 11. Summary
+
+Print a summary covering:
+
+- Files created (`cmd/version.go`).
+- Files modified (`main.go`, `cmd/root.go`, `.goreleaser.yml`, `Makefile`), one bullet each, noting whether the change was a clean add or a replacement of an existing `SetVersion`/`-X main.version` site.
+- Skipped steps and why (for example "no GoReleaser config detected; run `/add-goreleaser-homebrew` to set one up").
+- The three commands the user can now run: `<binary> version`, `<binary> version --json`, and `<binary> --version`.
+- A reminder that local builds without ldflags will display `dev` / `none` / `unknown`, and that a tagged GoReleaser release is what fills in real values.
+
+## Error Handling
+
+- If `go.mod` is missing, abort: this skill requires an existing Go module.
+- If no Cobra root command can be located, abort: this skill is Cobra-specific.
+- If `cmd/version.go` already exists and the user declines to overwrite it, skip step 5 but continue with the remaining wiring steps so partial state is repaired.
+- If the version variables are split between `main.go` and `cmd/root.go` in a way that conflicts (for example, both declare `var version` with different defaults), surface the conflict to the user and ask which file should own the canonical declarations before proceeding.
+- If `go build ./...` fails after the edits, show the error and attempt to fix it; do not leave the project in a broken state.
+
+## Reference Templates
+
+- `./references/version-go.md` -- the `cmd/version.go` template.
+- `./references/root-go-update.md` -- modifications to `cmd/root.go`.
+- `./references/main-go-update.md` -- modifications to `main.go`.
+- `./references/goreleaser-update.md` -- ldflags additions for `.goreleaser.yml`/`.goreleaser.yaml`.
+- `./references/makefile-update.md` -- `VERSION`/`COMMIT`/`DATE` and `LDFLAGS` additions for the Makefile.

--- a/dist/codex/plugins/add-cobra-version/skills/add-cobra-version/SKILL.md
+++ b/dist/codex/plugins/add-cobra-version/skills/add-cobra-version/SKILL.md
@@ -15,28 +15,37 @@ Add a `version` subcommand with version, commit hash, build date, and Go runtime
 
 ### 1. Verify the Project
 
-Confirm the current directory is a Go CLI project with Cobra:
+Confirm the current directory is a Go CLI project with Cobra using the `main.go` plus `cmd` package layout this skill updates:
 
 - `go.mod` exists. If not, abort with a message that this skill requires an existing Go module.
-- A Cobra root command exists. Check for `cmd/root.go` (the canonical location used by `scaffold-go-cli`); if absent, grep for `&cobra.Command{` in `*.go` and `cmd/*.go`. If no Cobra command is found, abort: this skill is Cobra-specific.
+- A Cobra root command exists in `package cmd`. Check `cmd/root.go` first (the canonical location used by `scaffold-go-cli`); if absent, inspect `cmd/*.go` for a package-level variable assigned to `&cobra.Command{`.
+- Record the root command variable identifier from that declaration, for example `rootCmd`, `cliCmd`, or `command`. Use this identifier everywhere the templates refer to the root command.
+- If Cobra commands exist only outside `package cmd`, abort with a message that this skill expects a `cmd` package root command that `main.go` runs via `cmd.Execute()`.
 - Read `go.mod` to extract the module path; needed when reasoning about ldflags `-X` targets.
 
 ### 2. Detect Current Version State
 
 Determine which of three states the project is in. The state controls how aggressive the changes need to be.
 
-1. **No version wiring**: no `var version` declaration in any Go source file.
-1. **Basic version only**: `var version = "dev"` (or similar) exists, typically in `main.go` or `cmd/root.go`, but no `commit` or `date` variables.
-1. **Full version info already present**: `version`, `commit`, and `date` package-level variables all exist.
+1. **No version wiring**: no package-level `version` declaration exists, either as `var version ...` or as a `version` entry in a top-level `var ( ... )` block.
+1. **Basic version only**: a package-level `version = "dev"` (or similar) declaration exists, typically in `main.go` or `cmd/root.go`, but package-level `commit` or `date` declarations are missing.
+1. **Full version info already present**: `version`, `commit`, and `date` package-level variables all exist, whether as single-line `var` declarations or entries in a top-level `var ( ... )` block.
 
 Detection commands:
 
 ```bash
-# Find version declarations across the project.
+# Find direct single-line declarations across the project.
 grep -rnE '^[[:space:]]*var[[:space:]]+version([[:space:]=]|$)' --include='*.go' .
 grep -rnE '^[[:space:]]*var[[:space:]]+commit([[:space:]=]|$)' --include='*.go' .
 grep -rnE '^[[:space:]]*var[[:space:]]+date([[:space:]=]|$)' --include='*.go' .
+
+# Also find identifiers inside top-level var (...) blocks.
+grep -rnE '^[[:space:]]*version[[:space:]]*=' --include='*.go' .
+grep -rnE '^[[:space:]]*commit[[:space:]]*=' --include='*.go' .
+grep -rnE '^[[:space:]]*date[[:space:]]*=' --include='*.go' .
 ```
+
+Read the surrounding context for every match and count only package-level declarations. Do not treat function-local variables as version wiring.
 
 Also check for an existing version subcommand:
 
@@ -67,7 +76,7 @@ Record the chosen ldflags prefix (`main.`) and the resolved module path; both ar
 
 The version subcommand prints a human-readable header that begins with the binary name (for example `bopca 1.2.3`). Determine the binary name in this precedence order:
 
-1. The `Use` field on the Cobra root command (read from `cmd/root.go`). Strip any trailing argument hints, for example `Use: "bopca [flags]"` becomes `bopca`.
+1. The `Use` field on the Cobra root command variable detected in step 1. Strip any trailing argument hints, for example `Use: "bopca [flags]"` becomes `bopca`.
 1. A `BINARY` or similar Makefile variable.
 1. The last segment of the module path in `go.mod`.
 
@@ -78,13 +87,14 @@ Use the result wherever templates reference `PROJECT-NAME`.
 Read `./references/version-go.md` for the `cmd/version.go` template and create the file from it.
 
 - Replace `PROJECT-NAME` with the binary name from step 4.
+- Replace `ROOT-COMMAND-VAR` with the root command variable identifier detected in step 1.
 - Do not modify the file if step 2 found an up-to-date `cmd/version.go` or the user chose to keep the existing file.
 
 The generated subcommand:
 
 - Prints version, commit, date, and `runtime.Version()` to `cmd.OutOrStdout()`.
 - Accepts a `--json` flag for machine-readable output.
-- Registers itself on `rootCmd` from its `init()` function, so no edits to `cmd/root.go` are required to wire it up.
+- Registers itself on the detected root command variable from its `init()` function, so no edits to `cmd/root.go` are required solely to wire up the subcommand.
 
 ### 6. Update `cmd/root.go`
 
@@ -95,8 +105,8 @@ If the file already declares the package-level variables (`version`, `commit`, `
 Otherwise:
 
 - Add (or extend) the package-level `var ( ... )` block to declare `version = "dev"`, `commit = "none"`, and `date = "unknown"`.
-- Add a `SetVersionInfo(v, c, d string)` function that assigns the three variables and sets `rootCmd.Version = v` so Cobra's built-in `--version` flag still works. If a `SetVersion(v string)` function already exists, replace it with `SetVersionInfo`. If callers in `main.go` reference the old name, they will be updated in step 7.
-- If the file currently sets `Version: version` directly on `rootCmd` and nothing else, leave that field in place; `SetVersionInfo` will overwrite it at startup.
+- Add a `SetVersionInfo(v, c, d string)` function that assigns the three variables and sets the detected root command variable's `Version` field so Cobra's built-in `--version` flag still works. If a `SetVersion(v string)` function already exists, replace it with `SetVersionInfo`. If callers in `main.go` reference the old name, they will be updated in step 7.
+- If the file currently sets `Version: version` directly on the detected root command variable and nothing else, leave that field in place; `SetVersionInfo` will overwrite it at startup.
 
 ### 7. Update `main.go`
 
@@ -187,6 +197,7 @@ Print a summary covering:
 
 - If `go.mod` is missing, abort: this skill requires an existing Go module.
 - If no Cobra root command can be located, abort: this skill is Cobra-specific.
+- If no package-level Cobra root command variable can be located in `package cmd`, abort: this skill updates the `main.go` plus `cmd` package layout used by `scaffold-go-cli` and does not safely patch arbitrary Cobra layouts.
 - If `cmd/version.go` already exists and the user declines to overwrite it, skip step 5 but continue with the remaining wiring steps so partial state is repaired.
 - If the version variables are split between `main.go` and `cmd/root.go` in a way that conflicts (for example, both declare `var version` with different defaults), surface the conflict to the user and ask which file should own the canonical declarations before proceeding.
 - If `go build ./...` fails after the edits, show the error and attempt to fix it; do not leave the project in a broken state.

--- a/dist/codex/plugins/add-cobra-version/skills/add-cobra-version/references/goreleaser-update.md
+++ b/dist/codex/plugins/add-cobra-version/skills/add-cobra-version/references/goreleaser-update.md
@@ -32,11 +32,11 @@ If `-X main.version=...` is absent (rare; this skill targets projects that alrea
 
 Use these GoReleaser template variables exactly as shown:
 
-| Variable          | Replaced with                                              |
-| ----------------- | ---------------------------------------------------------- |
-| `{{.Version}}`    | The semver tag without the leading `v` (for example `1.2.3`). |
-| `{{.ShortCommit}}` | Seven-character abbreviated commit SHA.                   |
-| `{{.Date}}`       | Build start time, RFC 3339 / ISO 8601.                    |
+| Variable           | Replaced with                                                 |
+| ------------------ | ------------------------------------------------------------- |
+| `{{.Version}}`     | The semver tag without the leading `v` (for example `1.2.3`). |
+| `{{.ShortCommit}}` | Seven-character abbreviated commit SHA.                       |
+| `{{.Date}}`        | Build start time, RFC 3339 / ISO 8601.                        |
 
 The `{{` and `}}` delimiters are Go template syntax; do not quote the entries. YAML allows them unquoted because they do not begin with a YAML metacharacter.
 

--- a/dist/codex/plugins/add-cobra-version/skills/add-cobra-version/references/goreleaser-update.md
+++ b/dist/codex/plugins/add-cobra-version/skills/add-cobra-version/references/goreleaser-update.md
@@ -1,0 +1,47 @@
+# .goreleaser.yml ldflags Update
+
+GoReleaser injects build metadata into the binary via the `builds[].ldflags` list. This skill needs all three `-X main.*` entries to be present.
+
+## Target State
+
+Find the build entry in `.goreleaser.yml` (or `.goreleaser.yaml`) and ensure its `ldflags` list contains:
+
+```yaml
+builds:
+  - main: .
+    binary: PROJECT-NAME
+    ldflags:
+      - -s -w
+      - -X main.version={{.Version}}
+      - -X main.commit={{.ShortCommit}}
+      - -X main.date={{.Date}}
+```
+
+`-s -w` is optional but customary (strips debug info and the symbol table for smaller binaries); preserve it if it is already present.
+
+## Edit Strategy
+
+1. Locate the `ldflags:` list under the relevant build entry. Most projects have a single build entry; if there are several, update each one.
+1. Read the existing list. For each of the three required `-X` entries, check whether it is present (look for the substring `main.version=`, `main.commit=`, and `main.date=` so values that already use a different template variable are still recognized).
+1. Append only the entries that are missing. Preserve the order of existing entries; new entries can be appended after the last existing line so diffs stay minimal.
+1. Do not change unrelated ldflags. In particular, leave `-s -w`, build tag flags, and any user-specific `-X` entries intact.
+
+If `-X main.version=...` is absent (rare; this skill targets projects that already have at least the basic version setup), add it alongside the others. The final order should be `version`, `commit`, `date` for readability.
+
+## GoReleaser Template Variables
+
+Use these GoReleaser template variables exactly as shown:
+
+| Variable          | Replaced with                                              |
+| ----------------- | ---------------------------------------------------------- |
+| `{{.Version}}`    | The semver tag without the leading `v` (for example `1.2.3`). |
+| `{{.ShortCommit}}` | Seven-character abbreviated commit SHA.                   |
+| `{{.Date}}`       | Build start time, RFC 3339 / ISO 8601.                    |
+
+The `{{` and `}}` delimiters are Go template syntax; do not quote the entries. YAML allows them unquoted because they do not begin with a YAML metacharacter.
+
+## Notes
+
+- If the project does not yet have a `.goreleaser.yml` or `.goreleaser.yaml`, this step is skipped. Suggest `/add-goreleaser-homebrew` to add one.
+- Some projects use `id:` or multiple build entries to produce variant binaries. Apply the ldflags update to every build entry that maps to the main binary.
+- Snapshot builds (`goreleaser release --snapshot`) substitute the same templates and produce a working `version` like `0.0.0-next-SNAPSHOT-abc1234`. The metadata in the binary will reflect the snapshot values, which is the expected behavior for local validation.

--- a/dist/codex/plugins/add-cobra-version/skills/add-cobra-version/references/main-go-update.md
+++ b/dist/codex/plugins/add-cobra-version/skills/add-cobra-version/references/main-go-update.md
@@ -1,0 +1,50 @@
+# main.go Modifications
+
+`main.go` declares the three `version`, `commit`, and `date` package-level variables that GoReleaser and the Makefile inject via `-X main.<name>=...` ldflags. It then calls `cmd.SetVersionInfo` to forward those values into the `cmd` package before running the CLI.
+
+## Target State
+
+After the modifications, the relevant portion of `main.go` should look like:
+
+```go
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/GITHUB-USERNAME/PROJECT-NAME/cmd"
+)
+
+// Build metadata, populated at link time via -X ldflags.
+var (
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
+)
+
+func main() {
+	cmd.SetVersionInfo(version, commit, date)
+	if err := cmd.Execute(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %s\n", err)
+		os.Exit(1)
+	}
+}
+```
+
+The exact `func main()` body may differ in real projects (signal handling, status-line cleanup, exit-code mapping). Preserve all of that. The two non-negotiable shape elements are:
+
+1. The `version`, `commit`, and `date` package-level variables.
+1. A `cmd.SetVersionInfo(version, commit, date)` call before `cmd.Execute()`.
+
+## Edit Strategy
+
+1. **Variable block.** If `var version = "dev"` already exists, promote it into a `var ( ... )` block (or an existing one) that also declares `commit = "none"` and `date = "unknown"`. If `commit` and `date` are already declared, leave them alone.
+1. **`cmd.SetVersion(version)` -> `cmd.SetVersionInfo(version, commit, date)`.** Replace any existing `cmd.SetVersion(version)` call with `cmd.SetVersionInfo(version, commit, date)`. If no such call exists, insert `cmd.SetVersionInfo(version, commit, date)` immediately before `cmd.Execute()`.
+1. **Imports.** No new imports are needed; `cmd` is already imported in any project that uses Cobra in this layout.
+
+## Notes
+
+- Ldflags target `main.<name>` because the variables live in `package main`. The `cmd` package receives the values through the `SetVersionInfo` call rather than via separate `-X` entries. This avoids needing to know the full module path in `.goreleaser.yml` and the Makefile.
+- Defaults of `"dev"`, `"none"`, `"unknown"` make it obvious when a binary was built without ldflags (`go run .`, plain `go build .`).
+- If the project has additional initialization in `main` (signal handling, output cleanup), leave it. `SetVersionInfo` is cheap and safe to call at any point before `Execute`; placing it as the first line of `main()` is conventional but not required.

--- a/dist/codex/plugins/add-cobra-version/skills/add-cobra-version/references/makefile-update.md
+++ b/dist/codex/plugins/add-cobra-version/skills/add-cobra-version/references/makefile-update.md
@@ -1,0 +1,49 @@
+# Makefile LDFLAGS Update
+
+The Makefile mirrors GoReleaser's ldflags so local `make build` produces a binary with the same metadata wiring (just sourced from `git` and `date` instead of GoReleaser templates).
+
+## Target State
+
+Ensure these definitions are present near the top of the Makefile, alongside any existing `VERSION` variable:
+
+```makefile
+VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
+COMMIT  ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "none")
+DATE    ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
+
+LDFLAGS := -s -w \
+	-X main.version=$(VERSION) \
+	-X main.commit=$(COMMIT) \
+	-X main.date=$(DATE)
+```
+
+The `build` target uses `$(LDFLAGS)`:
+
+```makefile
+build:
+	mkdir -p $(OUTDIR)
+	go build -ldflags "$(LDFLAGS)" -o $(OUTDIR)/$(BINARY) .
+```
+
+Some projects already wrap `-ldflags` differently (for example `go build $(LDFLAGS) ...` where `LDFLAGS` already includes the `-ldflags "..."` shape). Preserve whichever shape is in use. The non-negotiable invariant is that the three `-X main.*` entries reach `go build`.
+
+## Edit Strategy
+
+1. **`VERSION` variable.** If it already exists, leave it. If not, add it using the `git describe --tags --always --dirty` fallback shown above.
+1. **`COMMIT` variable.** Add it if missing. Use `git rev-parse --short HEAD` with the `echo "none"` fallback so make does not fail in a non-git checkout.
+1. **`DATE` variable.** Add it if missing. Use `date -u +%Y-%m-%dT%H:%M:%SZ` so the date is UTC and matches GoReleaser's RFC 3339 formatting.
+1. **`LDFLAGS` variable.** Find the existing definition. Append the missing `-X main.commit=...` and `-X main.date=...` entries. Do not remove any existing entries.
+1. **`build` target.** Confirm it passes `$(LDFLAGS)` to `go build`. If it already does (whether as `-ldflags "$(LDFLAGS)"` or as a self-contained `$(LDFLAGS)` shorthand), leave it alone. If not, update it to do so.
+
+## Important Make Conventions
+
+- Use tabs (not spaces) for recipe indentation. Make is unforgiving about this.
+- Use `?=` for `VERSION`, `COMMIT`, and `DATE` so values can be overridden from the environment (for example by CI or by a developer pinning a specific commit). Use `:=` for `LDFLAGS` so the `-X` substitution happens once at parse time.
+- Do not export the variables. They only need to be visible to recipes in this Makefile, and exporting them can leak into `go build`'s environment in surprising ways.
+
+## Notes
+
+- The `git describe --tags --always --dirty` fallback echoes `dev` when the repo has no tags. This matches the package-level default in `main.go` and keeps the local-build experience predictable.
+- The `git rev-parse --short HEAD` fallback echoes `none` to match `main.go`'s default. A non-git checkout (rare for development, common for source tarballs) will then show `commit: none` in the version output.
+- The `date -u` fallback never fails; it always produces a value, so no `||` clause is needed.
+- Some projects use `BUILD_DATE` instead of `DATE`, or `GIT_COMMIT` instead of `COMMIT`. Either is fine; keep the existing names. The only thing that has to match between the Makefile and `main.go` is the right-hand side of each `-X` entry (`main.version`, `main.commit`, `main.date`).

--- a/dist/codex/plugins/add-cobra-version/skills/add-cobra-version/references/root-go-update.md
+++ b/dist/codex/plugins/add-cobra-version/skills/add-cobra-version/references/root-go-update.md
@@ -1,0 +1,58 @@
+# cmd/root.go Modifications
+
+`cmd/root.go` owns the package-level `version`, `commit`, and `date` variables used by `cmd/version.go` and any other command that needs build metadata. It also exposes the `SetVersionInfo` setter that `main.go` calls at startup.
+
+## Target State
+
+After the modifications, the relevant portions of `cmd/root.go` should look like the snippet below. Other content in the file (flag wiring, `init()`, custom usage templates, etc.) is preserved.
+
+```go
+package cmd
+
+import "github.com/spf13/cobra"
+
+var (
+	// Version info populated at startup by SetVersionInfo (called from main).
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
+)
+
+var rootCmd = &cobra.Command{
+	Use:           "PROJECT-NAME",
+	Short:         "PROJECT-DESCRIPTION",
+	Version:       version,
+	SilenceUsage:  true,
+	SilenceErrors: true,
+}
+
+// Execute runs the root command.
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+// SetVersionInfo sets the build metadata reported by the version subcommand
+// and Cobra's built-in --version flag. Call from main.go after parsing
+// ldflags-injected variables.
+func SetVersionInfo(v, c, d string) {
+	version = v
+	commit = c
+	date = d
+	rootCmd.Version = v
+}
+```
+
+## Edit Strategy
+
+The file usually already has most of this content (from `scaffold-go-cli` or hand-rolled). Apply only the parts that are missing.
+
+1. **Variable block.** Find the existing `var version` declaration (if any). Promote it into a `var ( ... )` block that also declares `commit = "none"` and `date = "unknown"`. If `commit` and `date` are already declared, leave them alone.
+1. **`SetVersion` -> `SetVersionInfo`.** If a `SetVersion(v string)` function exists, replace it with `SetVersionInfo(v, c, d string)` as shown above. Update any in-package callers; `main.go` is updated separately in `./main-go-update.md`.
+1. **`Version: version` field on `rootCmd`.** Keep it if it exists. `SetVersionInfo` overwrites it at startup, but having a default lets `--version` print `dev` on local builds even before `SetVersionInfo` runs (for example in tests that exercise the root command directly).
+1. **Imports.** No new imports are needed beyond `github.com/spf13/cobra`.
+
+## Notes
+
+- The default values (`"dev"`, `"none"`, `"unknown"`) match the pattern used by `bopca` and several reference Cobra CLIs. They make local-build output unambiguous: anyone seeing `commit: none` immediately understands the binary was not built through GoReleaser or `make build`.
+- Do not move the variables to a new `cmd/version_info.go` file; keeping them in `cmd/root.go` puts them next to `rootCmd` (which they configure via `SetVersionInfo`), and matches the existing single-file layout produced by `scaffold-go-cli`.
+- If the project uses Viper or other initialization in `cmd/root.go`, leave that code untouched. The variable block and `SetVersionInfo` can sit alongside it.

--- a/dist/codex/plugins/add-cobra-version/skills/add-cobra-version/references/root-go-update.md
+++ b/dist/codex/plugins/add-cobra-version/skills/add-cobra-version/references/root-go-update.md
@@ -6,6 +6,8 @@
 
 After the modifications, the relevant portions of `cmd/root.go` should look like the snippet below. Other content in the file (flag wiring, `init()`, custom usage templates, etc.) is preserved.
 
+The snippet uses `rootCmd`, which is the identifier produced by `scaffold-go-cli`. If step 1 detected a different root command variable identifier, keep that identifier and use it consistently instead of renaming it to `rootCmd`.
+
 ```go
 package cmd
 
@@ -48,11 +50,11 @@ The file usually already has most of this content (from `scaffold-go-cli` or han
 
 1. **Variable block.** Find the existing `var version` declaration (if any). Promote it into a `var ( ... )` block that also declares `commit = "none"` and `date = "unknown"`. If `commit` and `date` are already declared, leave them alone.
 1. **`SetVersion` -> `SetVersionInfo`.** If a `SetVersion(v string)` function exists, replace it with `SetVersionInfo(v, c, d string)` as shown above. Update any in-package callers; `main.go` is updated separately in `./main-go-update.md`.
-1. **`Version: version` field on `rootCmd`.** Keep it if it exists. `SetVersionInfo` overwrites it at startup, but having a default lets `--version` print `dev` on local builds even before `SetVersionInfo` runs (for example in tests that exercise the root command directly).
+1. **`Version: version` field on the root command.** Keep it if it exists. `SetVersionInfo` overwrites it at startup, but having a default lets `--version` print `dev` on local builds even before `SetVersionInfo` runs (for example in tests that exercise the root command directly).
 1. **Imports.** No new imports are needed beyond `github.com/spf13/cobra`.
 
 ## Notes
 
 - The default values (`"dev"`, `"none"`, `"unknown"`) match the pattern used by `bopca` and several reference Cobra CLIs. They make local-build output unambiguous: anyone seeing `commit: none` immediately understands the binary was not built through GoReleaser or `make build`.
-- Do not move the variables to a new `cmd/version_info.go` file; keeping them in `cmd/root.go` puts them next to `rootCmd` (which they configure via `SetVersionInfo`), and matches the existing single-file layout produced by `scaffold-go-cli`.
+- Do not move the variables to a new `cmd/version_info.go` file; keeping them in `cmd/root.go` puts them next to the root command variable (which they configure via `SetVersionInfo`), and matches the existing single-file layout produced by `scaffold-go-cli`.
 - If the project uses Viper or other initialization in `cmd/root.go`, leave that code untouched. The variable block and `SetVersionInfo` can sit alongside it.

--- a/dist/codex/plugins/add-cobra-version/skills/add-cobra-version/references/version-go.md
+++ b/dist/codex/plugins/add-cobra-version/skills/add-cobra-version/references/version-go.md
@@ -1,0 +1,69 @@
+# cmd/version.go Template
+
+Use this template for the `version` subcommand. Replace `PROJECT-NAME` with the binary name as it should appear in the human-readable header (for example `bopca`, `right-round`).
+
+```go
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"runtime"
+
+	"github.com/spf13/cobra"
+)
+
+type versionInfo struct {
+	Version   string `json:"version"`
+	Commit    string `json:"commit"`
+	Date      string `json:"date"`
+	GoVersion string `json:"goVersion"`
+}
+
+var versionJSON bool
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print version information",
+	Long:  `Print version information for PROJECT-NAME, including the commit hash, build date, and Go runtime version.`,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		info := versionInfo{
+			Version:   version,
+			Commit:    commit,
+			Date:      date,
+			GoVersion: runtime.Version(),
+		}
+
+		out := cmd.OutOrStdout()
+
+		if versionJSON {
+			encoded, err := json.MarshalIndent(info, "", "  ")
+			if err != nil {
+				return fmt.Errorf("encode version info: %w", err)
+			}
+			fmt.Fprintln(out, string(encoded))
+			return nil
+		}
+
+		fmt.Fprintf(out, "PROJECT-NAME %s\n", info.Version)
+		fmt.Fprintf(out, "  commit: %s\n", info.Commit)
+		fmt.Fprintf(out, "  built:  %s\n", info.Date)
+		fmt.Fprintf(out, "  go:     %s\n", info.GoVersion)
+		return nil
+	},
+}
+
+func init() {
+	versionCmd.Flags().BoolVar(&versionJSON, "json", false, "Output version information as JSON")
+	rootCmd.AddCommand(versionCmd)
+}
+```
+
+## Notes
+
+- The `version`, `commit`, and `date` package-level variables come from `cmd/root.go` (see `./root-go-update.md`). They are populated at startup by `SetVersionInfo`, called from `main.go` (see `./main-go-update.md`).
+- `runtime.Version()` is read at execution time, so the Go runtime version always matches the binary's actual toolchain. There is no need to inject it via ldflags.
+- Output is written to `cmd.OutOrStdout()` so tests can capture it with `rootCmd.SetOut(...)`.
+- The JSON encoder uses indented output to keep the human-piping case (`<binary> version --json | jq`) readable while still being machine-parseable.
+- Cobra's built-in `--version` flag (set on the root command via `rootCmd.Version = v`) continues to work and emits a single-line "PROJECT-NAME version VERSION" string. The subcommand exists for the richer multi-line output.
+- Project-specific commands (for example bopca's `output.Print`) are intentionally not used here. Use plain `fmt.Fprintf` so the subcommand has no extra dependencies and can drop into any Cobra project.

--- a/dist/codex/plugins/add-cobra-version/skills/add-cobra-version/references/version-go.md
+++ b/dist/codex/plugins/add-cobra-version/skills/add-cobra-version/references/version-go.md
@@ -1,6 +1,6 @@
 # cmd/version.go Template
 
-Use this template for the `version` subcommand. Replace `PROJECT-NAME` with the binary name as it should appear in the human-readable header (for example `bopca`, `right-round`).
+Use this template for the `version` subcommand. Replace `PROJECT-NAME` with the binary name as it should appear in the human-readable header (for example `bopca`, `right-round`). Replace `ROOT-COMMAND-VAR` with the root command variable identifier detected from the target project's `package cmd` root command declaration.
 
 ```go
 package cmd
@@ -55,7 +55,7 @@ var versionCmd = &cobra.Command{
 
 func init() {
 	versionCmd.Flags().BoolVar(&versionJSON, "json", false, "Output version information as JSON")
-	rootCmd.AddCommand(versionCmd)
+	ROOT-COMMAND-VAR.AddCommand(versionCmd)
 }
 ```
 
@@ -63,7 +63,7 @@ func init() {
 
 - The `version`, `commit`, and `date` package-level variables come from `cmd/root.go` (see `./root-go-update.md`). They are populated at startup by `SetVersionInfo`, called from `main.go` (see `./main-go-update.md`).
 - `runtime.Version()` is read at execution time, so the Go runtime version always matches the binary's actual toolchain. There is no need to inject it via ldflags.
-- Output is written to `cmd.OutOrStdout()` so tests can capture it with `rootCmd.SetOut(...)`.
+- Output is written to `cmd.OutOrStdout()` so tests can capture it with the root command's `SetOut(...)` method.
 - The JSON encoder uses indented output to keep the human-piping case (`<binary> version --json | jq`) readable while still being machine-parseable.
-- Cobra's built-in `--version` flag (set on the root command via `rootCmd.Version = v`) continues to work and emits a single-line "PROJECT-NAME version VERSION" string. The subcommand exists for the richer multi-line output.
+- Cobra's built-in `--version` flag (set on the root command via `SetVersionInfo`) continues to work and emits a single-line "PROJECT-NAME version VERSION" string. The subcommand exists for the richer multi-line output.
 - Project-specific commands (for example bopca's `output.Print`) are intentionally not used here. Use plain `fmt.Fprintf` so the subcommand has no extra dependencies and can drop into any Cobra project.

--- a/dist/opencode/skills/add-cobra-version
+++ b/dist/opencode/skills/add-cobra-version
@@ -1,0 +1,1 @@
+../../../plugins/add-cobra-version/skills/add-cobra-version

--- a/plugins/add-cobra-version/.claude-plugin/plugin.json
+++ b/plugins/add-cobra-version/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "author": {
+    "name": "Christopher Boone"
+  },
+  "description": "Add a version subcommand with build metadata (version, commit hash, build date, Go runtime version, optional JSON output) to an existing Cobra-based Go CLI, wiring up ldflags in main.go, the cmd package, GoReleaser, and the Makefile.",
+  "homepage": "https://github.com/cboone/cboone-cc-plugins",
+  "keywords": ["cli", "cobra", "go", "golang", "version"],
+  "license": "MIT",
+  "name": "add-cobra-version",
+  "repository": "https://github.com/cboone/cboone-cc-plugins",
+  "skills": "./skills",
+  "version": "1.0.0"
+}

--- a/plugins/add-cobra-version/README.md
+++ b/plugins/add-cobra-version/README.md
@@ -30,6 +30,7 @@ The skill detects the project's existing version wiring (basic `var version` onl
 
 - Adds `cmd/version.go` (skips or asks before overwriting if one already exists).
 - Adds package-level `commit` and `date` variables to `cmd/root.go` alongside `version`, exposing a `SetVersionInfo(v, c, d string)` helper. If only `SetVersion` exists, it is replaced.
+- Detects the root command variable in `package cmd` and uses that identifier when registering the generated `version` subcommand.
 - Adds `commit` and `date` package-level vars to `main.go` and updates the call to `cmd.SetVersionInfo`.
 - Extends GoReleaser `ldflags` to include `-X main.commit={{.ShortCommit}}` and `-X main.date={{.Date}}`.
 - Extends the Makefile `LDFLAGS` to include matching `-X` entries plus `COMMIT` and `DATE` variables.

--- a/plugins/add-cobra-version/README.md
+++ b/plugins/add-cobra-version/README.md
@@ -1,0 +1,47 @@
+# Add Cobra Version
+
+Add a `version` subcommand with full build metadata to an existing Cobra-based Go CLI.
+
+**Type:** Skill
+**Trigger:** `/add-cobra-version`
+
+## Installation
+
+See the [marketplace install instructions](../../README.md#install).
+
+## What It Does
+
+Generates a `cmd/version.go` and coordinates the matching ldflags wiring across `main.go`, `cmd/root.go`, `.goreleaser.yml`, and the `Makefile` so a Cobra CLI can report:
+
+- Version (from git tag, falling back to `"dev"`)
+- Commit hash (short)
+- Build date (UTC, ISO 8601)
+- Go runtime version (from `runtime.Version()`)
+
+Output is human-readable by default with an optional `--json` flag for scripts. Cobra's built-in `--version` flag continues to work and reports the same version string.
+
+## Usage
+
+```text
+/add-cobra-version
+```
+
+The skill detects the project's existing version wiring (basic `var version` only versus full `version`/`commit`/`date`) and then:
+
+- Adds `cmd/version.go` (skips or asks before overwriting if one already exists).
+- Adds package-level `commit` and `date` variables to `cmd/root.go` alongside `version`, exposing a `SetVersionInfo(v, c, d string)` helper. If only `SetVersion` exists, it is replaced.
+- Adds `commit` and `date` package-level vars to `main.go` and updates the call to `cmd.SetVersionInfo`.
+- Extends GoReleaser `ldflags` to include `-X main.commit={{.ShortCommit}}` and `-X main.date={{.Date}}`.
+- Extends the Makefile `LDFLAGS` to include matching `-X` entries plus `COMMIT` and `DATE` variables.
+
+## Examples
+
+- "add a version subcommand to this CLI": detects state and wires everything up
+- "wire up version, commit, and date ldflags": same behavior
+- "add `--json` to the version command": same behavior, ensures the `--json` flag is present
+
+## See Also
+
+- [Scaffold Go CLI](../scaffold-go-cli/README.md): scaffolding a brand-new Go CLI (starts with the basic `version` variable).
+- [Add GoReleaser Homebrew](../add-goreleaser-homebrew/README.md): adding GoReleaser and the release workflow when those are missing too.
+- [All plugins](../../README.md)

--- a/plugins/add-cobra-version/skills/add-cobra-version/SKILL.md
+++ b/plugins/add-cobra-version/skills/add-cobra-version/SKILL.md
@@ -1,0 +1,207 @@
+---
+name: add-cobra-version
+description: >-
+  Add a version subcommand with build metadata to an existing Cobra-based Go
+  CLI. Use when the user says "add a version subcommand", "add the version
+  command", "wire up version, commit, and date", "add build metadata to
+  version", "add a /version command to this CLI", "make the version command
+  print commit and build date", or wants `cmd/version.go` plus matching
+  ldflags wired up in `main.go`, `cmd/root.go`, `.goreleaser.yml`, and the
+  `Makefile`. Detects whether the project already has a basic `version`
+  variable or no version wiring at all, then applies the changes
+  idempotently. Pairs with scaffold-go-cli (which seeds the basic version
+  variable) and add-goreleaser-homebrew (which sets up GoReleaser when it is
+  missing).
+---
+
+# Add Cobra Version
+
+Add a `version` subcommand with version, commit hash, build date, and Go runtime version to an existing Cobra-based Go CLI, and coordinate the matching ldflags wiring across `main.go`, `cmd/root.go`, `.goreleaser.yml`, and the `Makefile`.
+
+## Workflow
+
+### 1. Verify the Project
+
+Confirm the current directory is a Go CLI project with Cobra:
+
+- `go.mod` exists. If not, abort with a message that this skill requires an existing Go module.
+- A Cobra root command exists. Check for `cmd/root.go` (the canonical location used by `scaffold-go-cli`); if absent, grep for `&cobra.Command{` in `*.go` and `cmd/*.go`. If no Cobra command is found, abort: this skill is Cobra-specific.
+- Read `go.mod` to extract the module path; needed when reasoning about ldflags `-X` targets.
+
+### 2. Detect Current Version State
+
+Determine which of three states the project is in. The state controls how aggressive the changes need to be.
+
+1. **No version wiring**: no `var version` declaration in any Go source file.
+1. **Basic version only**: `var version = "dev"` (or similar) exists, typically in `main.go` or `cmd/root.go`, but no `commit` or `date` variables.
+1. **Full version info already present**: `version`, `commit`, and `date` package-level variables all exist.
+
+Detection commands:
+
+```bash
+# Find version declarations across the project.
+grep -rn 'var\s\+version\b' --include='*.go' .
+grep -rn 'var\s\+commit\b' --include='*.go' .
+grep -rn 'var\s\+date\b' --include='*.go' .
+```
+
+Also check for an existing version subcommand:
+
+```bash
+# Existing cmd/version.go file.
+test -f cmd/version.go && echo "cmd/version.go exists"
+
+# Existing version subcommand registration via &cobra.Command{ Use: "version", ... }.
+grep -rn 'Use:\s*"version"' --include='*.go' .
+```
+
+If a `cmd/version.go` already exists, read it. Decide:
+
+- If it already prints version, commit, date, and Go runtime version with a `--json` flag, treat it as up to date and skip step 5 (only continue with the wiring steps for any state still missing).
+- Otherwise, ask the user whether to overwrite. If they decline, abort the skill.
+
+### 3. Detect ldflags Target Package
+
+The version variables can live in `package main` (`-X main.version=...`) or in the `cmd` package (`-X MODULE-PATH/cmd.version=...`). Pick a target convention:
+
+1. If `var version` already exists in `main.go` or any file in `package main`, target `main`. The `cmd` package will receive the values via a `SetVersionInfo` call from `main`.
+1. If `var version` exists only in the `cmd` package and `main.go` does not declare it, still target `main`: this skill standardizes on the `main`-declared, `cmd.SetVersionInfo`-injected pattern (it is the pattern produced by `scaffold-go-cli` and used by `bopca`). Plan to move the declaration into `main.go` and add the `commit`/`date` siblings there.
+1. If no `version` declaration exists anywhere, target `main`: the skill will add the variables to `main.go`.
+
+Record the chosen ldflags prefix (`main.`) and the resolved module path; both are used in steps 7 and 8.
+
+### 4. Determine Project Name for Output Headers
+
+The version subcommand prints a human-readable header that begins with the binary name (for example `bopca 1.2.3`). Determine the binary name in this precedence order:
+
+1. The `Use` field on the Cobra root command (read from `cmd/root.go`). Strip any trailing argument hints, for example `Use: "bopca [flags]"` becomes `bopca`.
+1. A `BINARY` or similar Makefile variable.
+1. The last segment of the module path in `go.mod`.
+
+Use the result wherever templates reference `PROJECT-NAME`.
+
+### 5. Generate `cmd/version.go`
+
+Read `./references/version-go.md` for the `cmd/version.go` template and create the file from it.
+
+- Replace `PROJECT-NAME` with the binary name from step 4.
+- Do not modify the file if step 2 found an up-to-date `cmd/version.go` and the user chose to keep it.
+
+The generated subcommand:
+
+- Prints version, commit, date, and `runtime.Version()` to `cmd.OutOrStdout()`.
+- Accepts a `--json` flag for machine-readable output.
+- Registers itself on `rootCmd` from its `init()` function, so no edits to `cmd/root.go` are required to wire it up.
+
+### 6. Update `cmd/root.go`
+
+Read `./references/root-go-update.md` for the modifications to apply.
+
+If the file already declares the package-level variables (`version`, `commit`, `date`) and exposes a `SetVersionInfo(v, c, d string)` function, leave it alone.
+
+Otherwise:
+
+- Add (or extend) the package-level `var ( ... )` block to declare `version = "dev"`, `commit = "none"`, and `date = "unknown"`.
+- Add a `SetVersionInfo(v, c, d string)` function that assigns the three variables and sets `rootCmd.Version = v` so Cobra's built-in `--version` flag still works. If a `SetVersion(v string)` function already exists, replace it with `SetVersionInfo`. If callers in `main.go` reference the old name, they will be updated in step 7.
+- If the file currently sets `Version: version` directly on `rootCmd` and nothing else, leave that field in place; `SetVersionInfo` will overwrite it at startup.
+
+### 7. Update `main.go`
+
+Read `./references/main-go-update.md` for the modifications to apply.
+
+If `main.go` already declares all three `version`, `commit`, `date` package-level variables and calls `cmd.SetVersionInfo(version, commit, date)` before `cmd.Execute()`, leave the file alone.
+
+Otherwise:
+
+- Ensure the package-level declarations include `version = "dev"`, `commit = "none"`, and `date = "unknown"`. Add missing siblings; do not remove unrelated variables.
+- Replace any existing `cmd.SetVersion(version)` call with `cmd.SetVersionInfo(version, commit, date)`.
+- If no `SetVersion`-style call exists yet, add `cmd.SetVersionInfo(version, commit, date)` immediately before `cmd.Execute()`.
+
+### 8. Update `.goreleaser.yml`
+
+Read `./references/goreleaser-update.md` for the modifications to apply.
+
+GoReleaser may use `.goreleaser.yml` or `.goreleaser.yaml`. Check both. If neither exists, skip this step and note in the summary that GoReleaser is not configured (the user can run `/add-goreleaser-homebrew` to add it).
+
+In the existing config, find the `builds[].ldflags` list. Ensure all three `-X` entries are present:
+
+```yaml
+- -X main.version={{.Version}}
+- -X main.commit={{.ShortCommit}}
+- -X main.date={{.Date}}
+```
+
+If `-X main.version=...` is already present, keep it. Add only the `-X` entries that are missing. Preserve any existing `-s -w` or other ldflags.
+
+### 9. Update the Makefile
+
+Read `./references/makefile-update.md` for the modifications to apply.
+
+If no `Makefile` exists in the project root, skip this step and note in the summary.
+
+Otherwise, ensure the Makefile defines:
+
+- `VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")`
+- `COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "none")`
+- `DATE ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)`
+
+Then ensure `LDFLAGS` (or the equivalent variable already in use) contains the matching `-X` entries:
+
+```makefile
+LDFLAGS := -s -w \
+	-X main.version=$(VERSION) \
+	-X main.commit=$(COMMIT) \
+	-X main.date=$(DATE)
+```
+
+Preserve any other flags already in `LDFLAGS`. Ensure the `build` target uses `$(LDFLAGS)` in its `go build` invocation; if it already uses a sub-variable, leave it alone.
+
+### 10. Verify the Build
+
+Run a quick build to confirm everything compiles and the new subcommand wires up cleanly:
+
+```bash
+go build ./...
+```
+
+If a Makefile build target now exists with the expanded ldflags, prefer:
+
+```bash
+make build
+```
+
+Then exercise the new command, ignoring exit code (the subcommand always exits 0 on success):
+
+```bash
+go run . version
+go run . version --json
+go run . --version
+```
+
+If any of those fail, inspect the error and fix the offending file before continuing.
+
+### 11. Summary
+
+Print a summary covering:
+
+- Files created (`cmd/version.go`).
+- Files modified (`main.go`, `cmd/root.go`, `.goreleaser.yml`, `Makefile`), one bullet each, noting whether the change was a clean add or a replacement of an existing `SetVersion`/`-X main.version` site.
+- Skipped steps and why (for example "no GoReleaser config detected; run `/add-goreleaser-homebrew` to set one up").
+- The three commands the user can now run: `<binary> version`, `<binary> version --json`, and `<binary> --version`.
+- A reminder that local builds without ldflags will display `dev` / `none` / `unknown`, and that a tagged GoReleaser release is what fills in real values.
+
+## Error Handling
+
+- If `go.mod` is missing, abort: this skill requires an existing Go module.
+- If no Cobra root command can be located, abort: this skill is Cobra-specific.
+- If `cmd/version.go` already exists and the user declines to overwrite it, skip step 5 but continue with the remaining wiring steps so partial state is repaired.
+- If the version variables are split between `main.go` and `cmd/root.go` in a way that conflicts (for example, both declare `var version` with different defaults), surface the conflict to the user and ask which file should own the canonical declarations before proceeding.
+- If `go build ./...` fails after the edits, show the error and attempt to fix it; do not leave the project in a broken state.
+
+## Reference Templates
+
+- `./references/version-go.md` -- the `cmd/version.go` template.
+- `./references/root-go-update.md` -- modifications to `cmd/root.go`.
+- `./references/main-go-update.md` -- modifications to `main.go`.
+- `./references/goreleaser-update.md` -- ldflags additions for `.goreleaser.yml`/`.goreleaser.yaml`.
+- `./references/makefile-update.md` -- `VERSION`/`COMMIT`/`DATE` and `LDFLAGS` additions for the Makefile.

--- a/plugins/add-cobra-version/skills/add-cobra-version/SKILL.md
+++ b/plugins/add-cobra-version/skills/add-cobra-version/SKILL.md
@@ -22,28 +22,37 @@ Add a `version` subcommand with version, commit hash, build date, and Go runtime
 
 ### 1. Verify the Project
 
-Confirm the current directory is a Go CLI project with Cobra:
+Confirm the current directory is a Go CLI project with Cobra using the `main.go` plus `cmd` package layout this skill updates:
 
 - `go.mod` exists. If not, abort with a message that this skill requires an existing Go module.
-- A Cobra root command exists. Check for `cmd/root.go` (the canonical location used by `scaffold-go-cli`); if absent, grep for `&cobra.Command{` in `*.go` and `cmd/*.go`. If no Cobra command is found, abort: this skill is Cobra-specific.
+- A Cobra root command exists in `package cmd`. Check `cmd/root.go` first (the canonical location used by `scaffold-go-cli`); if absent, inspect `cmd/*.go` for a package-level variable assigned to `&cobra.Command{`.
+- Record the root command variable identifier from that declaration, for example `rootCmd`, `cliCmd`, or `command`. Use this identifier everywhere the templates refer to the root command.
+- If Cobra commands exist only outside `package cmd`, abort with a message that this skill expects a `cmd` package root command that `main.go` runs via `cmd.Execute()`.
 - Read `go.mod` to extract the module path; needed when reasoning about ldflags `-X` targets.
 
 ### 2. Detect Current Version State
 
 Determine which of three states the project is in. The state controls how aggressive the changes need to be.
 
-1. **No version wiring**: no `var version` declaration in any Go source file.
-1. **Basic version only**: `var version = "dev"` (or similar) exists, typically in `main.go` or `cmd/root.go`, but no `commit` or `date` variables.
-1. **Full version info already present**: `version`, `commit`, and `date` package-level variables all exist.
+1. **No version wiring**: no package-level `version` declaration exists, either as `var version ...` or as a `version` entry in a top-level `var ( ... )` block.
+1. **Basic version only**: a package-level `version = "dev"` (or similar) declaration exists, typically in `main.go` or `cmd/root.go`, but package-level `commit` or `date` declarations are missing.
+1. **Full version info already present**: `version`, `commit`, and `date` package-level variables all exist, whether as single-line `var` declarations or entries in a top-level `var ( ... )` block.
 
 Detection commands:
 
 ```bash
-# Find version declarations across the project.
+# Find direct single-line declarations across the project.
 grep -rnE '^[[:space:]]*var[[:space:]]+version([[:space:]=]|$)' --include='*.go' .
 grep -rnE '^[[:space:]]*var[[:space:]]+commit([[:space:]=]|$)' --include='*.go' .
 grep -rnE '^[[:space:]]*var[[:space:]]+date([[:space:]=]|$)' --include='*.go' .
+
+# Also find identifiers inside top-level var (...) blocks.
+grep -rnE '^[[:space:]]*version[[:space:]]*=' --include='*.go' .
+grep -rnE '^[[:space:]]*commit[[:space:]]*=' --include='*.go' .
+grep -rnE '^[[:space:]]*date[[:space:]]*=' --include='*.go' .
 ```
+
+Read the surrounding context for every match and count only package-level declarations. Do not treat function-local variables as version wiring.
 
 Also check for an existing version subcommand:
 
@@ -74,7 +83,7 @@ Record the chosen ldflags prefix (`main.`) and the resolved module path; both ar
 
 The version subcommand prints a human-readable header that begins with the binary name (for example `bopca 1.2.3`). Determine the binary name in this precedence order:
 
-1. The `Use` field on the Cobra root command (read from `cmd/root.go`). Strip any trailing argument hints, for example `Use: "bopca [flags]"` becomes `bopca`.
+1. The `Use` field on the Cobra root command variable detected in step 1. Strip any trailing argument hints, for example `Use: "bopca [flags]"` becomes `bopca`.
 1. A `BINARY` or similar Makefile variable.
 1. The last segment of the module path in `go.mod`.
 
@@ -85,13 +94,14 @@ Use the result wherever templates reference `PROJECT-NAME`.
 Read `./references/version-go.md` for the `cmd/version.go` template and create the file from it.
 
 - Replace `PROJECT-NAME` with the binary name from step 4.
+- Replace `ROOT-COMMAND-VAR` with the root command variable identifier detected in step 1.
 - Do not modify the file if step 2 found an up-to-date `cmd/version.go` or the user chose to keep the existing file.
 
 The generated subcommand:
 
 - Prints version, commit, date, and `runtime.Version()` to `cmd.OutOrStdout()`.
 - Accepts a `--json` flag for machine-readable output.
-- Registers itself on `rootCmd` from its `init()` function, so no edits to `cmd/root.go` are required to wire it up.
+- Registers itself on the detected root command variable from its `init()` function, so no edits to `cmd/root.go` are required solely to wire up the subcommand.
 
 ### 6. Update `cmd/root.go`
 
@@ -102,8 +112,8 @@ If the file already declares the package-level variables (`version`, `commit`, `
 Otherwise:
 
 - Add (or extend) the package-level `var ( ... )` block to declare `version = "dev"`, `commit = "none"`, and `date = "unknown"`.
-- Add a `SetVersionInfo(v, c, d string)` function that assigns the three variables and sets `rootCmd.Version = v` so Cobra's built-in `--version` flag still works. If a `SetVersion(v string)` function already exists, replace it with `SetVersionInfo`. If callers in `main.go` reference the old name, they will be updated in step 7.
-- If the file currently sets `Version: version` directly on `rootCmd` and nothing else, leave that field in place; `SetVersionInfo` will overwrite it at startup.
+- Add a `SetVersionInfo(v, c, d string)` function that assigns the three variables and sets the detected root command variable's `Version` field so Cobra's built-in `--version` flag still works. If a `SetVersion(v string)` function already exists, replace it with `SetVersionInfo`. If callers in `main.go` reference the old name, they will be updated in step 7.
+- If the file currently sets `Version: version` directly on the detected root command variable and nothing else, leave that field in place; `SetVersionInfo` will overwrite it at startup.
 
 ### 7. Update `main.go`
 
@@ -194,6 +204,7 @@ Print a summary covering:
 
 - If `go.mod` is missing, abort: this skill requires an existing Go module.
 - If no Cobra root command can be located, abort: this skill is Cobra-specific.
+- If no package-level Cobra root command variable can be located in `package cmd`, abort: this skill updates the `main.go` plus `cmd` package layout used by `scaffold-go-cli` and does not safely patch arbitrary Cobra layouts.
 - If `cmd/version.go` already exists and the user declines to overwrite it, skip step 5 but continue with the remaining wiring steps so partial state is repaired.
 - If the version variables are split between `main.go` and `cmd/root.go` in a way that conflicts (for example, both declare `var version` with different defaults), surface the conflict to the user and ask which file should own the canonical declarations before proceeding.
 - If `go build ./...` fails after the edits, show the error and attempt to fix it; do not leave the project in a broken state.

--- a/plugins/add-cobra-version/skills/add-cobra-version/SKILL.md
+++ b/plugins/add-cobra-version/skills/add-cobra-version/SKILL.md
@@ -40,9 +40,9 @@ Detection commands:
 
 ```bash
 # Find version declarations across the project.
-grep -rn 'var\s\+version\b' --include='*.go' .
-grep -rn 'var\s\+commit\b' --include='*.go' .
-grep -rn 'var\s\+date\b' --include='*.go' .
+grep -rnE '^[[:space:]]*var[[:space:]]+version([[:space:]=]|$)' --include='*.go' .
+grep -rnE '^[[:space:]]*var[[:space:]]+commit([[:space:]=]|$)' --include='*.go' .
+grep -rnE '^[[:space:]]*var[[:space:]]+date([[:space:]=]|$)' --include='*.go' .
 ```
 
 Also check for an existing version subcommand:
@@ -52,13 +52,13 @@ Also check for an existing version subcommand:
 test -f cmd/version.go && echo "cmd/version.go exists"
 
 # Existing version subcommand registration via &cobra.Command{ Use: "version", ... }.
-grep -rn 'Use:\s*"version"' --include='*.go' .
+grep -rnE 'Use:[[:space:]]*"version"' --include='*.go' .
 ```
 
 If a `cmd/version.go` already exists, read it. Decide:
 
 - If it already prints version, commit, date, and Go runtime version with a `--json` flag, treat it as up to date and skip step 5 (only continue with the wiring steps for any state still missing).
-- Otherwise, ask the user whether to overwrite. If they decline, abort the skill.
+- Otherwise, ask the user whether to overwrite. If they decline, skip step 5 and continue with the remaining wiring steps so the existing file is preserved while partial version state is repaired.
 
 ### 3. Detect ldflags Target Package
 
@@ -85,7 +85,7 @@ Use the result wherever templates reference `PROJECT-NAME`.
 Read `./references/version-go.md` for the `cmd/version.go` template and create the file from it.
 
 - Replace `PROJECT-NAME` with the binary name from step 4.
-- Do not modify the file if step 2 found an up-to-date `cmd/version.go` and the user chose to keep it.
+- Do not modify the file if step 2 found an up-to-date `cmd/version.go` or the user chose to keep the existing file.
 
 The generated subcommand:
 

--- a/plugins/add-cobra-version/skills/add-cobra-version/references/goreleaser-update.md
+++ b/plugins/add-cobra-version/skills/add-cobra-version/references/goreleaser-update.md
@@ -32,11 +32,11 @@ If `-X main.version=...` is absent (rare; this skill targets projects that alrea
 
 Use these GoReleaser template variables exactly as shown:
 
-| Variable          | Replaced with                                              |
-| ----------------- | ---------------------------------------------------------- |
-| `{{.Version}}`    | The semver tag without the leading `v` (for example `1.2.3`). |
-| `{{.ShortCommit}}` | Seven-character abbreviated commit SHA.                   |
-| `{{.Date}}`       | Build start time, RFC 3339 / ISO 8601.                    |
+| Variable           | Replaced with                                                 |
+| ------------------ | ------------------------------------------------------------- |
+| `{{.Version}}`     | The semver tag without the leading `v` (for example `1.2.3`). |
+| `{{.ShortCommit}}` | Seven-character abbreviated commit SHA.                       |
+| `{{.Date}}`        | Build start time, RFC 3339 / ISO 8601.                        |
 
 The `{{` and `}}` delimiters are Go template syntax; do not quote the entries. YAML allows them unquoted because they do not begin with a YAML metacharacter.
 

--- a/plugins/add-cobra-version/skills/add-cobra-version/references/goreleaser-update.md
+++ b/plugins/add-cobra-version/skills/add-cobra-version/references/goreleaser-update.md
@@ -1,0 +1,47 @@
+# .goreleaser.yml ldflags Update
+
+GoReleaser injects build metadata into the binary via the `builds[].ldflags` list. This skill needs all three `-X main.*` entries to be present.
+
+## Target State
+
+Find the build entry in `.goreleaser.yml` (or `.goreleaser.yaml`) and ensure its `ldflags` list contains:
+
+```yaml
+builds:
+  - main: .
+    binary: PROJECT-NAME
+    ldflags:
+      - -s -w
+      - -X main.version={{.Version}}
+      - -X main.commit={{.ShortCommit}}
+      - -X main.date={{.Date}}
+```
+
+`-s -w` is optional but customary (strips debug info and the symbol table for smaller binaries); preserve it if it is already present.
+
+## Edit Strategy
+
+1. Locate the `ldflags:` list under the relevant build entry. Most projects have a single build entry; if there are several, update each one.
+1. Read the existing list. For each of the three required `-X` entries, check whether it is present (look for the substring `main.version=`, `main.commit=`, and `main.date=` so values that already use a different template variable are still recognized).
+1. Append only the entries that are missing. Preserve the order of existing entries; new entries can be appended after the last existing line so diffs stay minimal.
+1. Do not change unrelated ldflags. In particular, leave `-s -w`, build tag flags, and any user-specific `-X` entries intact.
+
+If `-X main.version=...` is absent (rare; this skill targets projects that already have at least the basic version setup), add it alongside the others. The final order should be `version`, `commit`, `date` for readability.
+
+## GoReleaser Template Variables
+
+Use these GoReleaser template variables exactly as shown:
+
+| Variable          | Replaced with                                              |
+| ----------------- | ---------------------------------------------------------- |
+| `{{.Version}}`    | The semver tag without the leading `v` (for example `1.2.3`). |
+| `{{.ShortCommit}}` | Seven-character abbreviated commit SHA.                   |
+| `{{.Date}}`       | Build start time, RFC 3339 / ISO 8601.                    |
+
+The `{{` and `}}` delimiters are Go template syntax; do not quote the entries. YAML allows them unquoted because they do not begin with a YAML metacharacter.
+
+## Notes
+
+- If the project does not yet have a `.goreleaser.yml` or `.goreleaser.yaml`, this step is skipped. Suggest `/add-goreleaser-homebrew` to add one.
+- Some projects use `id:` or multiple build entries to produce variant binaries. Apply the ldflags update to every build entry that maps to the main binary.
+- Snapshot builds (`goreleaser release --snapshot`) substitute the same templates and produce a working `version` like `0.0.0-next-SNAPSHOT-abc1234`. The metadata in the binary will reflect the snapshot values, which is the expected behavior for local validation.

--- a/plugins/add-cobra-version/skills/add-cobra-version/references/main-go-update.md
+++ b/plugins/add-cobra-version/skills/add-cobra-version/references/main-go-update.md
@@ -1,0 +1,50 @@
+# main.go Modifications
+
+`main.go` declares the three `version`, `commit`, and `date` package-level variables that GoReleaser and the Makefile inject via `-X main.<name>=...` ldflags. It then calls `cmd.SetVersionInfo` to forward those values into the `cmd` package before running the CLI.
+
+## Target State
+
+After the modifications, the relevant portion of `main.go` should look like:
+
+```go
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/GITHUB-USERNAME/PROJECT-NAME/cmd"
+)
+
+// Build metadata, populated at link time via -X ldflags.
+var (
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
+)
+
+func main() {
+	cmd.SetVersionInfo(version, commit, date)
+	if err := cmd.Execute(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %s\n", err)
+		os.Exit(1)
+	}
+}
+```
+
+The exact `func main()` body may differ in real projects (signal handling, status-line cleanup, exit-code mapping). Preserve all of that. The two non-negotiable shape elements are:
+
+1. The `version`, `commit`, and `date` package-level variables.
+1. A `cmd.SetVersionInfo(version, commit, date)` call before `cmd.Execute()`.
+
+## Edit Strategy
+
+1. **Variable block.** If `var version = "dev"` already exists, promote it into a `var ( ... )` block (or an existing one) that also declares `commit = "none"` and `date = "unknown"`. If `commit` and `date` are already declared, leave them alone.
+1. **`cmd.SetVersion(version)` -> `cmd.SetVersionInfo(version, commit, date)`.** Replace any existing `cmd.SetVersion(version)` call with `cmd.SetVersionInfo(version, commit, date)`. If no such call exists, insert `cmd.SetVersionInfo(version, commit, date)` immediately before `cmd.Execute()`.
+1. **Imports.** No new imports are needed; `cmd` is already imported in any project that uses Cobra in this layout.
+
+## Notes
+
+- Ldflags target `main.<name>` because the variables live in `package main`. The `cmd` package receives the values through the `SetVersionInfo` call rather than via separate `-X` entries. This avoids needing to know the full module path in `.goreleaser.yml` and the Makefile.
+- Defaults of `"dev"`, `"none"`, `"unknown"` make it obvious when a binary was built without ldflags (`go run .`, plain `go build .`).
+- If the project has additional initialization in `main` (signal handling, output cleanup), leave it. `SetVersionInfo` is cheap and safe to call at any point before `Execute`; placing it as the first line of `main()` is conventional but not required.

--- a/plugins/add-cobra-version/skills/add-cobra-version/references/makefile-update.md
+++ b/plugins/add-cobra-version/skills/add-cobra-version/references/makefile-update.md
@@ -1,0 +1,49 @@
+# Makefile LDFLAGS Update
+
+The Makefile mirrors GoReleaser's ldflags so local `make build` produces a binary with the same metadata wiring (just sourced from `git` and `date` instead of GoReleaser templates).
+
+## Target State
+
+Ensure these definitions are present near the top of the Makefile, alongside any existing `VERSION` variable:
+
+```makefile
+VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
+COMMIT  ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "none")
+DATE    ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
+
+LDFLAGS := -s -w \
+	-X main.version=$(VERSION) \
+	-X main.commit=$(COMMIT) \
+	-X main.date=$(DATE)
+```
+
+The `build` target uses `$(LDFLAGS)`:
+
+```makefile
+build:
+	mkdir -p $(OUTDIR)
+	go build -ldflags "$(LDFLAGS)" -o $(OUTDIR)/$(BINARY) .
+```
+
+Some projects already wrap `-ldflags` differently (for example `go build $(LDFLAGS) ...` where `LDFLAGS` already includes the `-ldflags "..."` shape). Preserve whichever shape is in use. The non-negotiable invariant is that the three `-X main.*` entries reach `go build`.
+
+## Edit Strategy
+
+1. **`VERSION` variable.** If it already exists, leave it. If not, add it using the `git describe --tags --always --dirty` fallback shown above.
+1. **`COMMIT` variable.** Add it if missing. Use `git rev-parse --short HEAD` with the `echo "none"` fallback so make does not fail in a non-git checkout.
+1. **`DATE` variable.** Add it if missing. Use `date -u +%Y-%m-%dT%H:%M:%SZ` so the date is UTC and matches GoReleaser's RFC 3339 formatting.
+1. **`LDFLAGS` variable.** Find the existing definition. Append the missing `-X main.commit=...` and `-X main.date=...` entries. Do not remove any existing entries.
+1. **`build` target.** Confirm it passes `$(LDFLAGS)` to `go build`. If it already does (whether as `-ldflags "$(LDFLAGS)"` or as a self-contained `$(LDFLAGS)` shorthand), leave it alone. If not, update it to do so.
+
+## Important Make Conventions
+
+- Use tabs (not spaces) for recipe indentation. Make is unforgiving about this.
+- Use `?=` for `VERSION`, `COMMIT`, and `DATE` so values can be overridden from the environment (for example by CI or by a developer pinning a specific commit). Use `:=` for `LDFLAGS` so the `-X` substitution happens once at parse time.
+- Do not export the variables. They only need to be visible to recipes in this Makefile, and exporting them can leak into `go build`'s environment in surprising ways.
+
+## Notes
+
+- The `git describe --tags --always --dirty` fallback echoes `dev` when the repo has no tags. This matches the package-level default in `main.go` and keeps the local-build experience predictable.
+- The `git rev-parse --short HEAD` fallback echoes `none` to match `main.go`'s default. A non-git checkout (rare for development, common for source tarballs) will then show `commit: none` in the version output.
+- The `date -u` fallback never fails; it always produces a value, so no `||` clause is needed.
+- Some projects use `BUILD_DATE` instead of `DATE`, or `GIT_COMMIT` instead of `COMMIT`. Either is fine; keep the existing names. The only thing that has to match between the Makefile and `main.go` is the right-hand side of each `-X` entry (`main.version`, `main.commit`, `main.date`).

--- a/plugins/add-cobra-version/skills/add-cobra-version/references/root-go-update.md
+++ b/plugins/add-cobra-version/skills/add-cobra-version/references/root-go-update.md
@@ -1,0 +1,58 @@
+# cmd/root.go Modifications
+
+`cmd/root.go` owns the package-level `version`, `commit`, and `date` variables used by `cmd/version.go` and any other command that needs build metadata. It also exposes the `SetVersionInfo` setter that `main.go` calls at startup.
+
+## Target State
+
+After the modifications, the relevant portions of `cmd/root.go` should look like the snippet below. Other content in the file (flag wiring, `init()`, custom usage templates, etc.) is preserved.
+
+```go
+package cmd
+
+import "github.com/spf13/cobra"
+
+var (
+	// Version info populated at startup by SetVersionInfo (called from main).
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
+)
+
+var rootCmd = &cobra.Command{
+	Use:           "PROJECT-NAME",
+	Short:         "PROJECT-DESCRIPTION",
+	Version:       version,
+	SilenceUsage:  true,
+	SilenceErrors: true,
+}
+
+// Execute runs the root command.
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+// SetVersionInfo sets the build metadata reported by the version subcommand
+// and Cobra's built-in --version flag. Call from main.go after parsing
+// ldflags-injected variables.
+func SetVersionInfo(v, c, d string) {
+	version = v
+	commit = c
+	date = d
+	rootCmd.Version = v
+}
+```
+
+## Edit Strategy
+
+The file usually already has most of this content (from `scaffold-go-cli` or hand-rolled). Apply only the parts that are missing.
+
+1. **Variable block.** Find the existing `var version` declaration (if any). Promote it into a `var ( ... )` block that also declares `commit = "none"` and `date = "unknown"`. If `commit` and `date` are already declared, leave them alone.
+1. **`SetVersion` -> `SetVersionInfo`.** If a `SetVersion(v string)` function exists, replace it with `SetVersionInfo(v, c, d string)` as shown above. Update any in-package callers; `main.go` is updated separately in `./main-go-update.md`.
+1. **`Version: version` field on `rootCmd`.** Keep it if it exists. `SetVersionInfo` overwrites it at startup, but having a default lets `--version` print `dev` on local builds even before `SetVersionInfo` runs (for example in tests that exercise the root command directly).
+1. **Imports.** No new imports are needed beyond `github.com/spf13/cobra`.
+
+## Notes
+
+- The default values (`"dev"`, `"none"`, `"unknown"`) match the pattern used by `bopca` and several reference Cobra CLIs. They make local-build output unambiguous: anyone seeing `commit: none` immediately understands the binary was not built through GoReleaser or `make build`.
+- Do not move the variables to a new `cmd/version_info.go` file; keeping them in `cmd/root.go` puts them next to `rootCmd` (which they configure via `SetVersionInfo`), and matches the existing single-file layout produced by `scaffold-go-cli`.
+- If the project uses Viper or other initialization in `cmd/root.go`, leave that code untouched. The variable block and `SetVersionInfo` can sit alongside it.

--- a/plugins/add-cobra-version/skills/add-cobra-version/references/root-go-update.md
+++ b/plugins/add-cobra-version/skills/add-cobra-version/references/root-go-update.md
@@ -6,6 +6,8 @@
 
 After the modifications, the relevant portions of `cmd/root.go` should look like the snippet below. Other content in the file (flag wiring, `init()`, custom usage templates, etc.) is preserved.
 
+The snippet uses `rootCmd`, which is the identifier produced by `scaffold-go-cli`. If step 1 detected a different root command variable identifier, keep that identifier and use it consistently instead of renaming it to `rootCmd`.
+
 ```go
 package cmd
 
@@ -48,11 +50,11 @@ The file usually already has most of this content (from `scaffold-go-cli` or han
 
 1. **Variable block.** Find the existing `var version` declaration (if any). Promote it into a `var ( ... )` block that also declares `commit = "none"` and `date = "unknown"`. If `commit` and `date` are already declared, leave them alone.
 1. **`SetVersion` -> `SetVersionInfo`.** If a `SetVersion(v string)` function exists, replace it with `SetVersionInfo(v, c, d string)` as shown above. Update any in-package callers; `main.go` is updated separately in `./main-go-update.md`.
-1. **`Version: version` field on `rootCmd`.** Keep it if it exists. `SetVersionInfo` overwrites it at startup, but having a default lets `--version` print `dev` on local builds even before `SetVersionInfo` runs (for example in tests that exercise the root command directly).
+1. **`Version: version` field on the root command.** Keep it if it exists. `SetVersionInfo` overwrites it at startup, but having a default lets `--version` print `dev` on local builds even before `SetVersionInfo` runs (for example in tests that exercise the root command directly).
 1. **Imports.** No new imports are needed beyond `github.com/spf13/cobra`.
 
 ## Notes
 
 - The default values (`"dev"`, `"none"`, `"unknown"`) match the pattern used by `bopca` and several reference Cobra CLIs. They make local-build output unambiguous: anyone seeing `commit: none` immediately understands the binary was not built through GoReleaser or `make build`.
-- Do not move the variables to a new `cmd/version_info.go` file; keeping them in `cmd/root.go` puts them next to `rootCmd` (which they configure via `SetVersionInfo`), and matches the existing single-file layout produced by `scaffold-go-cli`.
+- Do not move the variables to a new `cmd/version_info.go` file; keeping them in `cmd/root.go` puts them next to the root command variable (which they configure via `SetVersionInfo`), and matches the existing single-file layout produced by `scaffold-go-cli`.
 - If the project uses Viper or other initialization in `cmd/root.go`, leave that code untouched. The variable block and `SetVersionInfo` can sit alongside it.

--- a/plugins/add-cobra-version/skills/add-cobra-version/references/version-go.md
+++ b/plugins/add-cobra-version/skills/add-cobra-version/references/version-go.md
@@ -1,0 +1,69 @@
+# cmd/version.go Template
+
+Use this template for the `version` subcommand. Replace `PROJECT-NAME` with the binary name as it should appear in the human-readable header (for example `bopca`, `right-round`).
+
+```go
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"runtime"
+
+	"github.com/spf13/cobra"
+)
+
+type versionInfo struct {
+	Version   string `json:"version"`
+	Commit    string `json:"commit"`
+	Date      string `json:"date"`
+	GoVersion string `json:"goVersion"`
+}
+
+var versionJSON bool
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print version information",
+	Long:  `Print version information for PROJECT-NAME, including the commit hash, build date, and Go runtime version.`,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		info := versionInfo{
+			Version:   version,
+			Commit:    commit,
+			Date:      date,
+			GoVersion: runtime.Version(),
+		}
+
+		out := cmd.OutOrStdout()
+
+		if versionJSON {
+			encoded, err := json.MarshalIndent(info, "", "  ")
+			if err != nil {
+				return fmt.Errorf("encode version info: %w", err)
+			}
+			fmt.Fprintln(out, string(encoded))
+			return nil
+		}
+
+		fmt.Fprintf(out, "PROJECT-NAME %s\n", info.Version)
+		fmt.Fprintf(out, "  commit: %s\n", info.Commit)
+		fmt.Fprintf(out, "  built:  %s\n", info.Date)
+		fmt.Fprintf(out, "  go:     %s\n", info.GoVersion)
+		return nil
+	},
+}
+
+func init() {
+	versionCmd.Flags().BoolVar(&versionJSON, "json", false, "Output version information as JSON")
+	rootCmd.AddCommand(versionCmd)
+}
+```
+
+## Notes
+
+- The `version`, `commit`, and `date` package-level variables come from `cmd/root.go` (see `./root-go-update.md`). They are populated at startup by `SetVersionInfo`, called from `main.go` (see `./main-go-update.md`).
+- `runtime.Version()` is read at execution time, so the Go runtime version always matches the binary's actual toolchain. There is no need to inject it via ldflags.
+- Output is written to `cmd.OutOrStdout()` so tests can capture it with `rootCmd.SetOut(...)`.
+- The JSON encoder uses indented output to keep the human-piping case (`<binary> version --json | jq`) readable while still being machine-parseable.
+- Cobra's built-in `--version` flag (set on the root command via `rootCmd.Version = v`) continues to work and emits a single-line "PROJECT-NAME version VERSION" string. The subcommand exists for the richer multi-line output.
+- Project-specific commands (for example bopca's `output.Print`) are intentionally not used here. Use plain `fmt.Fprintf` so the subcommand has no extra dependencies and can drop into any Cobra project.

--- a/plugins/add-cobra-version/skills/add-cobra-version/references/version-go.md
+++ b/plugins/add-cobra-version/skills/add-cobra-version/references/version-go.md
@@ -1,6 +1,6 @@
 # cmd/version.go Template
 
-Use this template for the `version` subcommand. Replace `PROJECT-NAME` with the binary name as it should appear in the human-readable header (for example `bopca`, `right-round`).
+Use this template for the `version` subcommand. Replace `PROJECT-NAME` with the binary name as it should appear in the human-readable header (for example `bopca`, `right-round`). Replace `ROOT-COMMAND-VAR` with the root command variable identifier detected from the target project's `package cmd` root command declaration.
 
 ```go
 package cmd
@@ -55,7 +55,7 @@ var versionCmd = &cobra.Command{
 
 func init() {
 	versionCmd.Flags().BoolVar(&versionJSON, "json", false, "Output version information as JSON")
-	rootCmd.AddCommand(versionCmd)
+	ROOT-COMMAND-VAR.AddCommand(versionCmd)
 }
 ```
 
@@ -63,7 +63,7 @@ func init() {
 
 - The `version`, `commit`, and `date` package-level variables come from `cmd/root.go` (see `./root-go-update.md`). They are populated at startup by `SetVersionInfo`, called from `main.go` (see `./main-go-update.md`).
 - `runtime.Version()` is read at execution time, so the Go runtime version always matches the binary's actual toolchain. There is no need to inject it via ldflags.
-- Output is written to `cmd.OutOrStdout()` so tests can capture it with `rootCmd.SetOut(...)`.
+- Output is written to `cmd.OutOrStdout()` so tests can capture it with the root command's `SetOut(...)` method.
 - The JSON encoder uses indented output to keep the human-piping case (`<binary> version --json | jq`) readable while still being machine-parseable.
-- Cobra's built-in `--version` flag (set on the root command via `rootCmd.Version = v`) continues to work and emits a single-line "PROJECT-NAME version VERSION" string. The subcommand exists for the richer multi-line output.
+- Cobra's built-in `--version` flag (set on the root command via `SetVersionInfo`) continues to work and emits a single-line "PROJECT-NAME version VERSION" string. The subcommand exists for the richer multi-line output.
 - Project-specific commands (for example bopca's `output.Print`) are intentionally not used here. Use plain `fmt.Fprintf` so the subcommand has no extra dependencies and can drop into any Cobra project.


### PR DESCRIPTION
## Summary

- Adds the `/add-cobra-version` skill, which wires a Cobra `version` subcommand (version, short commit, build date, `runtime.Version()`, optional `--json`) into an existing Go CLI and coordinates ldflags across `main.go`, `cmd/root.go`, `.goreleaser.yml`, and the `Makefile`.
- Idempotent: detects whether the project has no version wiring, only a basic `var version`, or full version info, and applies just the missing pieces; replaces any existing `cmd.SetVersion(v)` shape with `cmd.SetVersionInfo(v, c, d)`.
- Skill ships five reference templates (`version-go.md`, `root-go-update.md`, `main-go-update.md`, `goreleaser-update.md`, `makefile-update.md`) plus a per-plugin `README.md`; registered in `marketplace.json` (category `ci-and-release`, alphabetically before `add-community-files`); catalog state bumped to `catalog-M59-m103-p115-n51`; Codex and OpenCode mirrors regenerated.

## Test plan

- [ ] `bin/validate-json` passes
- [ ] `bin/validate-plugins` passes
- [ ] `yarn lint` reports zero markdownlint and prettier errors
- [ ] `bin/build-codex-marketplace` and `bin/build-opencode-mirror` produce no diff
- [ ] Manually run the new skill in Claude Code against a Cobra CLI in each of the three states (no version wiring, basic `var version`, full version info) and confirm: `cmd/version.go` is created or left alone correctly, `cmd.SetVersionInfo` is wired up in `main.go` and `cmd/root.go`, `.goreleaser.yml` ldflags include all three `-X main.*` entries, and `Makefile` declares `VERSION`/`COMMIT`/`DATE` plus matching `LDFLAGS`.
- [ ] `go build ./...` and `<binary> version` (plain and `--json`) succeed in the test project

## Closes

Closes #37
