### PR TITLE
Add write-homebrew-formula skill

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -2,7 +2,7 @@
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "metadata": {
     "description": "Claude Code commands, hooks, and skills from Christopher Boone (cboone.github.io)",
-    "version": "catalog-M59-m106-p114-n51"
+    "version": "catalog-M60-m106-p114-n52"
   },
   "name": "cboone-cc-plugins",
   "owner": {
@@ -610,6 +610,20 @@
       "repository": "https://github.com/cboone/cboone-cc-plugins",
       "source": "./dist/codex/plugins/write-go-code",
       "version": "1.2.0"
+    },
+    {
+      "author": {
+        "name": "Christopher Boone"
+      },
+      "category": "ci-and-release",
+      "description": "Write or update Homebrew formulae using current Homebrew guidance and cboone/homebrew-tap conventions.",
+      "homepage": "https://github.com/cboone/cboone-cc-plugins",
+      "keywords": ["formula", "homebrew", "release", "ruby", "tap"],
+      "license": "MIT",
+      "name": "write-homebrew-formula",
+      "repository": "https://github.com/cboone/cboone-cc-plugins",
+      "source": "./dist/codex/plugins/write-homebrew-formula",
+      "version": "1.0.0"
     },
     {
       "author": {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "metadata": {
     "description": "Claude Code commands, hooks, and skills from Christopher Boone (cboone.github.io)",
-    "version": "catalog-M59-m106-p114-n51"
+    "version": "catalog-M60-m106-p114-n52"
   },
   "name": "cboone-cc-plugins",
   "owner": {
@@ -610,6 +610,20 @@
       "repository": "https://github.com/cboone/cboone-cc-plugins",
       "source": "./plugins/write-go-code",
       "version": "1.2.0"
+    },
+    {
+      "author": {
+        "name": "Christopher Boone"
+      },
+      "category": "ci-and-release",
+      "description": "Write or update Homebrew formulae using current Homebrew guidance and cboone/homebrew-tap conventions.",
+      "homepage": "https://github.com/cboone/cboone-cc-plugins",
+      "keywords": ["formula", "homebrew", "release", "ruby", "tap"],
+      "license": "MIT",
+      "name": "write-homebrew-formula",
+      "repository": "https://github.com/cboone/cboone-cc-plugins",
+      "source": "./plugins/write-homebrew-formula",
+      "version": "1.0.0"
     },
     {
       "author": {

--- a/README.md
+++ b/README.md
@@ -136,10 +136,12 @@ Each skill links to its own README. The `Trigger` column shows the slash command
 | [Setup Installers](./plugins/setup-installers/README.md) | `/setup-installers` | Set up installer and distribution methods for Go, Swift, Rust, and Zig projects: Homebrew tap, go/cargo install, and release workflow. |
 | [Setup Secret Scanning](./plugins/setup-secret-scanning/README.md) | `/setup-secret-scanning` | Set up secret scanning with gitleaks and TruffleHog GitHub Actions workflows and optional gitleaks configuration. |
 | [Upgrade Everything](./plugins/upgrade-everything/README.md) | `/upgrade-everything` | Assess every version reference in a repository, evaluate available upgrades with repo-specific risk and reward, and present selectable upgrade options. |
+| [Write Homebrew Formula](./plugins/write-homebrew-formula/README.md) | `/write-homebrew-formula` | Write or update Homebrew formulae using current Homebrew guidance and cboone/homebrew-tap conventions. |
 
 **External tools:**
 
 - *Pin Everything:* [`gh`](https://cli.github.com/), [`jq`](https://jqlang.org/); optional [`corepack`](https://github.com/nodejs/corepack) (only when pinning Yarn or pnpm) and [`reuse`](https://reuse.software/) (only in REUSE-licensed repos)
+- *Write Homebrew Formula:* [Homebrew](https://brew.sh/) for formula audit, style, install, and test validation
 
 ### Agents
 

--- a/dist/codex/plugins/write-homebrew-formula/.claude-plugin/plugin.json
+++ b/dist/codex/plugins/write-homebrew-formula/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "author": {
+    "name": "Christopher Boone"
+  },
+  "description": "Write or update Homebrew formulae using current Homebrew guidance and cboone/homebrew-tap conventions.",
+  "homepage": "https://github.com/cboone/cboone-cc-plugins",
+  "keywords": ["formula", "homebrew", "release", "ruby", "tap"],
+  "license": "MIT",
+  "name": "write-homebrew-formula",
+  "repository": "https://github.com/cboone/cboone-cc-plugins",
+  "skills": "./skills",
+  "version": "1.0.0"
+}

--- a/dist/codex/plugins/write-homebrew-formula/README.md
+++ b/dist/codex/plugins/write-homebrew-formula/README.md
@@ -1,0 +1,39 @@
+# Write Homebrew Formula
+
+Write or update Homebrew formulae using current Homebrew guidance and `cboone/homebrew-tap` conventions.
+
+**Type:** Skill
+**Trigger:** `/write-homebrew-formula`
+
+## Installation
+
+See the [marketplace install instructions](../../../../README.md#install).
+
+## Requirements
+
+- [Homebrew](https://brew.sh/) for formula audit, style, install, and test validation.
+
+## What It Does
+
+Guides formula authoring for stable release formulae, HEAD-only pre-release formulae, Go source builds, GoReleaser-generated outputs, and shell tools with services or setup caveats. Uses `cboone/homebrew-tap` as the only cboone-specific pattern source, while treating official Homebrew documentation as the source for generic formula behavior.
+
+## Usage
+
+```text
+/write-homebrew-formula
+```
+
+The skill gathers project metadata, selects the right formula pattern, writes or updates the Ruby formula, and validates the result with available Homebrew tooling.
+
+## Examples
+
+- "write a Homebrew formula for this Go CLI"
+- "update this HEAD-only formula to a stable release"
+- "review this formula against cboone/homebrew-tap conventions"
+- "add caveats and a service block to this shell-tool formula"
+
+## See Also
+
+- [Add GoReleaser Homebrew](../add-goreleaser-homebrew/README.md): add GoReleaser with Homebrew tap publishing
+- [Setup Installers](../setup-installers/README.md): set up standalone Homebrew distribution for a project
+- [All plugins](../../../../README.md)

--- a/dist/codex/plugins/write-homebrew-formula/skills/write-homebrew-formula/SKILL.md
+++ b/dist/codex/plugins/write-homebrew-formula/skills/write-homebrew-formula/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: write-homebrew-formula
+description: >-
+  Write or update Homebrew formulae using current Homebrew guidance and
+  cboone/homebrew-tap conventions.
+---
+
+# Write Homebrew Formula
+
+Write or update Homebrew formulae with official Homebrew rules and `cboone/homebrew-tap` conventions.
+
+## Scope Boundaries
+
+- Use `cboone/homebrew-tap` as the only cboone-specific formula pattern source.
+- Do not use abandoned tap repositories such as `homebrew-bopca`, `homebrew-heliocron`, or `diurnal-terminal` for conventions or examples.
+- Treat official Homebrew documentation as the source of truth for generic formula DSL behavior.
+- When a formula rule may have changed recently, check today's date first and refresh the relevant official Homebrew documentation before editing.
+
+## Workflow
+
+### 1. Gather Context
+
+Identify whether the user wants a new formula, an update to an existing formula, a review, or a migration from HEAD-only to stable.
+
+Collect these facts before editing:
+
+- Formula path and tap repository, if one exists
+- Project name, marketed name, binary names, and expected formula filename
+- Homepage, source URL, license, release tag or branch, and SHA-256 values
+- Build type: prebuilt archive, Go source build, GoReleaser output, shell script, or mixed assets
+- Platform constraints: macOS-only, Linux support, Intel, Apple Silicon, or arm64-only
+- Runtime, build, and test dependencies
+- Optional assets: completions, man pages, config files, service files, launchd plists, caveats, `post_install`, and `post_uninstall`
+- Testable behavior that avoids credentials, destructive actions, GUI-only behavior, or user input
+
+### 2. Load References
+
+Read only the reference files needed for the requested formula type:
+
+| Reference                          | Use When                                                                  |
+| ---------------------------------- | ------------------------------------------------------------------------- |
+| `./references/homebrew-current.md` | You need current Homebrew DSL, naming, test, service, or validation rules |
+| `./references/cboone-tap.md`       | You need `cboone/homebrew-tap` conventions or current local examples      |
+| `./references/patterns.md`         | You need a concrete formula template or migration shape                   |
+| `./references/validation.md`       | You are ready to run Homebrew checks                                      |
+
+### 3. Choose the Formula Shape
+
+Select the smallest matching pattern:
+
+- **Stable prebuilt release**: use `url`, `sha256`, optional `version`, platform or architecture blocks, and `bin.install`.
+- **Stable source build**: use a release tarball plus build dependencies, such as `depends_on "go" => :build` and `std_go_args` for Go projects.
+- **HEAD-only pre-release**: use `head "...git", branch: "main"` with no stable `url` or `sha256`.
+- **GoReleaser-managed formula**: preserve generated structure, review for consistency, and prefer updating the release configuration upstream rather than hand-editing generated output.
+- **Shell tool**: install scripts directly, add completions/config assets when present, and use service or lifecycle blocks only when the tool genuinely needs them.
+
+### 4. Write or Update the Formula
+
+Apply the selected pattern and keep edits scoped to the requested formula.
+
+Required defaults:
+
+- Formula filename is lowercase and matches the marketed formula name.
+- Class name is strict CamelCase derived from the filename.
+- Use `desc`, `homepage`, and `license`.
+- Use `license "MIT"` only when the project license is actually MIT.
+- Use stable release `url` plus `sha256` when a tagged release exists.
+- Use `head` for pre-release source installs when no stable release exists.
+- Use `depends_on` for build, runtime, and test dependencies so Homebrew puts build-time tools on `PATH`.
+- Use `caveats` only for packaging-specific setup or non-standard paths.
+- Prefer functional tests. If practical behavior cannot be tested without credentials, GUI access, services, or heavy setup, use the existing tap convention of `assert_match` on help or version output.
+
+### 5. Validate
+
+Run the relevant checks from `./references/validation.md`.
+
+If Homebrew is unavailable, report which checks were skipped and why. If a check fails, diagnose the cause from the output and adjust the formula instead of forcing the command through.
+
+### 6. Summarize
+
+Report:
+
+- Formula files created or changed
+- Pattern selected and why
+- Source URLs, tags, branches, and SHA-256 values used
+- Tests and validation commands run
+- Any skipped validation and the reason
+- Any remaining manual work, such as waiting for a first tagged release or filling in SHA-256 values
+
+## Error Handling
+
+- If the project has no stable release and the user requested a stable formula, explain the gap and offer a HEAD-only formula or release checklist.
+- If SHA-256 values are unavailable, leave explicit placeholders only when the user is preparing a draft and list the exact artifacts that need checksums.
+- If the formula requires secrets, credentials, or private URLs, use environment variables and never write secrets into the formula.
+- If current `cboone/homebrew-tap` examples conflict with official Homebrew guidance, call out the conflict and prefer official Homebrew behavior unless the user explicitly chooses the tap convention.
+
+## Sources
+
+- Homebrew Formula Cookbook: <https://docs.brew.sh/Formula-Cookbook>
+- Homebrew acceptable formulae: <https://docs.brew.sh/Acceptable-Formulae>
+- Homebrew `Formula` API: <https://docs.brew.sh/rubydoc/Formula.html>

--- a/dist/codex/plugins/write-homebrew-formula/skills/write-homebrew-formula/references/cboone-tap.md
+++ b/dist/codex/plugins/write-homebrew-formula/skills/write-homebrew-formula/references/cboone-tap.md
@@ -1,0 +1,106 @@
+# `cboone/homebrew-tap` Conventions
+
+Use `cboone/homebrew-tap` as the only cboone-specific pattern source. Do not derive conventions from abandoned taps or retired source repositories.
+
+## Current Formula Set
+
+As checked on 2026-05-03, `cboone/homebrew-tap` contained:
+
+- `Formula/bopca.rb`
+- `Formula/gh-problemas.rb`
+- `Formula/pbcopy2.rb`
+- `Formula/right-round.rb`
+
+Refresh the live list when working on a formula:
+
+```bash
+gh api repos/cboone/homebrew-tap/contents/Formula --jq '.[].path'
+```
+
+If a local checkout of `cboone/homebrew-tap` is available, prefer reading that checkout over remote GitHub content.
+
+## Tap Patterns
+
+### GoReleaser-generated macOS arm64 formula
+
+`bopca` shows a GoReleaser-generated formula with these traits:
+
+- Generated-file header
+- `desc`, `homepage`, `version`, and `license`
+- Runtime dependency on `container`
+- Build dependency on Go
+- macOS and arm64 constraints
+- Install step for the binary
+- Shared config/example files under `share`
+- Runtime completions generated from the executable
+- Man pages installed under `man1`
+- Heredoc caveats for DNS setup and config paths
+- Tests covering help output and version output
+
+When updating this kind of formula, prefer changing the upstream GoReleaser configuration that emits the formula rather than hand-editing generated output.
+
+### GoReleaser-generated cross-platform binary formula
+
+`gh-problemas` shows a generated formula with platform and architecture-specific release archive URLs:
+
+- Runtime dependency on `gh`
+- `on_macos` and `on_linux` blocks
+- Intel and arm64 checks inside each platform block
+- Per-platform `url`, `sha256`, and `def install`
+- Version-output test
+
+Use this pattern when the release process publishes separate prebuilt archives per OS and architecture.
+
+### Manual macOS binary formula
+
+`pbcopy2` shows a hand-written macOS-only formula:
+
+- `depends_on :macos`
+- Separate Intel and Apple Silicon release archives
+- One install block that installs multiple binaries
+- Version-output tests for each installed executable
+
+Use this pattern when the release assets are prebuilt binaries and the formula does not build from source.
+
+### HEAD-only Go source formula
+
+`right-round` shows a pre-release formula with:
+
+- `head "https://github.com/cboone/<name>.git", branch: "main"`
+- No stable `url` or `sha256`
+- `depends_on "go" => :build`
+- Go source build using `std_go_args`
+- Help-output test
+
+Use this pattern only when no tagged stable release is available or the user explicitly wants a HEAD install.
+
+## Local Conventions
+
+- Prefer `license "MIT"` for cboone-owned MIT-licensed projects, but verify the license instead of assuming.
+- Use heredoc `caveats` for setup instructions and config paths.
+- Install config examples under `share` unless a formula intentionally writes user config during `post_install`.
+- Use `generate_completions_from_executable` when the installed binary exposes completions.
+- Install man pages with `man1.install` when release assets include them.
+- Prefer a functional test when practical. Existing tap formulae often use `assert_match` against help or version output when functional tests are not practical.
+- Use `depends_on :macos` for macOS-only tools and `depends_on arch: :arm64` for arm64-only tools.
+
+## HEAD-to-Stable Migration Checklist
+
+When replacing a HEAD-only formula with a stable formula:
+
+1. Confirm a SemVer-style tag exists.
+1. Confirm release assets are published for the intended platforms and architectures.
+1. Add stable `url` and `sha256` values.
+1. Preserve `head` only if users should still be able to install from the development branch.
+1. Update the install block only if the release archive layout differs from the source tree.
+1. Run audit, style, install, and test checks.
+
+## Out-of-Scope Repositories
+
+Do not use these repositories as formula convention sources:
+
+- `cboone/homebrew-bopca`
+- `cboone/homebrew-heliocron`
+- `cboone/diurnal-terminal`
+
+They are abandoned for this skill's purposes.

--- a/dist/codex/plugins/write-homebrew-formula/skills/write-homebrew-formula/references/homebrew-current.md
+++ b/dist/codex/plugins/write-homebrew-formula/skills/write-homebrew-formula/references/homebrew-current.md
@@ -1,0 +1,119 @@
+# Current Homebrew Guidance
+
+This reference was checked against official Homebrew documentation on 2026-05-03. Refresh the linked docs when the task depends on current Homebrew behavior.
+
+## Authoritative Sources
+
+- [Formula Cookbook](https://docs.brew.sh/Formula-Cookbook)
+- [Acceptable Formulae](https://docs.brew.sh/Acceptable-Formulae)
+- [`Formula` Ruby API](https://docs.brew.sh/rubydoc/Formula.html)
+
+## Core Rules
+
+- A formula is Ruby code using the `Formula` API.
+- Stable formulae use a stable source `url` and `sha256`. Tagged release tarballs are preferred when they exist.
+- HEAD builds use `head "https://github.com/owner/repo.git", branch: "main"` and are for development or pre-release installs.
+- Formula names should follow how the project markets itself. The filename and class must correspond by strict CamelCase conversion, such as `foo-bar.rb` to `FooBar`.
+- `desc`, `homepage`, and `license` should be filled in. Use SPDX license identifiers where possible.
+- Declare dependencies with `depends_on`, including build-only dependencies such as `depends_on "go" => :build`.
+- Use `on_macos`, `on_linux`, `on_arm`, and `on_intel` blocks for platform-specific declarations outside `def install` and `test do`.
+- Inside `def install` and `test do`, use conditionals such as `OS.mac?`, `OS.linux?`, `Hardware::CPU.arm?`, and `Hardware::CPU.intel?`.
+- Use `uses_from_macos` when a dependency can come from macOS on supported versions but needs a Homebrew formula elsewhere.
+- Avoid Homebrew options for new `homebrew/core` formulae. In private taps, prefer simple always-on behavior unless the user explicitly needs variants.
+
+## Go Formulae
+
+Use Homebrew's Go helper for source builds:
+
+```ruby
+system "go", "build", *std_go_args(output: bin/"project-name"), "."
+```
+
+`std_go_args` currently supplies `-trimpath` and an output path, with optional `ldflags`, `gcflags`, and `tags`.
+
+For a `main` package below the repo root, pass that package path:
+
+```ruby
+system "go", "build", *std_go_args(output: bin/"project-name"), "./cmd/project-name"
+```
+
+## Completions and Man Pages
+
+Use `generate_completions_from_executable` when the installed executable can generate shell completions:
+
+```ruby
+generate_completions_from_executable(bin/"project-name", "completion")
+```
+
+Install manual pages under `man1`, `man5`, or another `share/man` path exposed by Homebrew helpers:
+
+```ruby
+man1.install Dir["man/man1/*"]
+```
+
+## Caveats
+
+Use `caveats` for setup instructions that are specific to the Homebrew package, non-standard paths, environment variables, service startup, or config files:
+
+```ruby
+def caveats
+  <<~EOS
+    Configuration file: #{etc}/project-name/config.yaml
+  EOS
+end
+```
+
+Keep caveats actionable. Do not repeat generic README content.
+
+## Services
+
+Use a `service` block when `brew services` should manage a launchd or systemd service.
+
+For package-provided service files, install the file and provide the service name:
+
+```ruby
+service do
+  name macos: "homebrew.mxcl.project-name"
+end
+```
+
+For formula-defined services, use `run`:
+
+```ruby
+service do
+  run [opt_bin/"project-name", "--config", etc/"project-name/config.yaml"]
+end
+```
+
+## Tests
+
+Homebrew prefers tests that exercise basic functionality without credentials, user input, network assumptions, or heavyweight services. `--help` and `--version` tests are weak, but better than no test when the tool cannot be exercised safely in the formula sandbox.
+
+Use assertions around command output when possible:
+
+```ruby
+test do
+  assert_match "expected text", shell_output("#{bin}/project-name --help")
+end
+```
+
+For commands that return expected failures, pass the expected status to `shell_output`:
+
+```ruby
+test do
+  assert_match "missing token", shell_output("#{bin}/project-name check 2>&1", 1)
+end
+```
+
+## Validation Commands
+
+Use these commands when available:
+
+```bash
+brew style Formula/project-name.rb
+brew audit --strict --online --formula Formula/project-name.rb
+brew install --build-from-source --verbose ./Formula/project-name.rb
+brew test project-name
+```
+
+For new formulae intended for `homebrew/core`, also use `brew audit --new --formula`.

--- a/dist/codex/plugins/write-homebrew-formula/skills/write-homebrew-formula/references/patterns.md
+++ b/dist/codex/plugins/write-homebrew-formula/skills/write-homebrew-formula/references/patterns.md
@@ -1,0 +1,146 @@
+# Formula Patterns
+
+These templates show shapes to adapt, not complete formulae to paste unchanged. Replace placeholders, verify licenses, and validate the result with Homebrew.
+
+## Stable Prebuilt Binary
+
+Use this when GitHub Releases or another stable source publishes archives that already contain binaries.
+
+```ruby
+class ProjectName < Formula
+  desc "Short project description"
+  homepage "https://github.com/OWNER/project-name"
+  version "0.1.0"
+  license "MIT"
+
+  on_macos do
+    on_intel do
+      url "https://github.com/OWNER/project-name/releases/download/v0.1.0/project-name-0.1.0-darwin-amd64.tar.gz"
+      sha256 "SHA256_FOR_DARWIN_AMD64"
+    end
+
+    on_arm do
+      url "https://github.com/OWNER/project-name/releases/download/v0.1.0/project-name-0.1.0-darwin-arm64.tar.gz"
+      sha256 "SHA256_FOR_DARWIN_ARM64"
+    end
+  end
+
+  def install
+    bin.install "project-name"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/project-name --version")
+  end
+end
+```
+
+Add `on_linux` blocks when Linux release assets exist. Use `depends_on :macos` when the project is macOS-only.
+
+## Stable Go Source Build
+
+Use this when the formula should build from a tagged source archive.
+
+```ruby
+class ProjectName < Formula
+  desc "Short project description"
+  homepage "https://github.com/OWNER/project-name"
+  url "https://github.com/OWNER/project-name/archive/refs/tags/v0.1.0.tar.gz"
+  sha256 "SHA256_FOR_SOURCE_TARBALL"
+  license "MIT"
+
+  depends_on "go" => :build
+
+  def install
+    system "go", "build", *std_go_args(output: bin/"project-name"), "."
+  end
+
+  test do
+    assert_match "project-name", shell_output("#{bin}/project-name --help")
+  end
+end
+```
+
+If the command lives below the repository root, replace `"."` with a package path such as `"./cmd/project-name"`.
+
+## HEAD-only Go Source Build
+
+Use this when no tagged release exists or the user intentionally wants a development build.
+
+```ruby
+class ProjectName < Formula
+  desc "Short project description"
+  homepage "https://github.com/OWNER/project-name"
+  head "https://github.com/OWNER/project-name.git", branch: "main"
+  license "MIT"
+
+  depends_on "go" => :build
+
+  def install
+    system "go", "build", *std_go_args(output: bin/"project-name"), "./cmd/project-name"
+  end
+
+  test do
+    assert_match "project-name", shell_output("#{bin}/project-name --help")
+  end
+end
+```
+
+Do not add stable `url` or `sha256` unless a stable source exists.
+
+## GoReleaser-generated Formula Review
+
+For GoReleaser-managed formulae, inspect these surfaces:
+
+- Generated-file header, if GoReleaser emits one
+- `desc`, `homepage`, `version`, and `license`
+- Platform and architecture URL blocks
+- Runtime dependencies
+- Installed binaries
+- Completions, man pages, and config assets included in release archives
+- Caveats and tests
+
+Prefer changing `.goreleaser.yml` in the source repository when generated output is wrong. Hand edits to generated formulae should be reserved for cases where the tap intentionally owns a manual override.
+
+## Shell Tool with Config and Service
+
+Use this when the package installs scripts and service assets instead of compiling a binary.
+
+```ruby
+class ProjectName < Formula
+  desc "Short project description"
+  homepage "https://github.com/OWNER/project-name"
+  url "https://github.com/OWNER/project-name/archive/refs/tags/v0.1.0.tar.gz"
+  sha256 "SHA256_FOR_SOURCE_TARBALL"
+  license "MIT"
+
+  depends_on "dependency-name"
+
+  def install
+    bin.install "scripts/project-name"
+    zsh_completion.install "completions/_project-name" if File.exist?("completions/_project-name")
+    (share/"project-name").install "config/project-name.conf.example"
+    prefix.install "LaunchAgents/homebrew.mxcl.project-name.plist"
+  end
+
+  def caveats
+    <<~EOS
+      Configuration example:
+        #{share}/project-name/project-name.conf.example
+
+      To start the service:
+        brew services start project-name
+    EOS
+  end
+
+  service do
+    name macos: "homebrew.mxcl.project-name"
+  end
+
+  test do
+    assert_match "project-name", shell_output("#{bin}/project-name --help")
+  end
+end
+```
+
+Use `post_install` only when the formula must initialize user-visible state after installation. Prefer installing examples and explaining setup in `caveats` when that is enough.

--- a/dist/codex/plugins/write-homebrew-formula/skills/write-homebrew-formula/references/validation.md
+++ b/dist/codex/plugins/write-homebrew-formula/skills/write-homebrew-formula/references/validation.md
@@ -1,0 +1,73 @@
+# Formula Validation
+
+Run the strongest checks available in the environment. Do not force through failures. Diagnose and adjust the formula.
+
+## Check Prerequisites
+
+```bash
+command -v brew
+brew --version
+```
+
+If Homebrew is not installed, skip local validation and report that limitation.
+
+## Style and Audit
+
+For a formula file in the current tap checkout:
+
+```bash
+brew style Formula/project-name.rb
+brew audit --strict --online --formula Formula/project-name.rb
+```
+
+For a new formula intended for `homebrew/core`, add the stricter new-formula audit:
+
+```bash
+brew audit --new --formula Formula/project-name.rb
+```
+
+For a private tap, `--new` can still be useful, but do not treat every `homebrew/core` policy warning as a private-tap blocker unless it affects correctness, maintainability, or user safety.
+
+## Install and Test
+
+Install from the local formula file or the tapped formula name:
+
+```bash
+brew install --build-from-source --verbose ./Formula/project-name.rb
+```
+
+Then run the formula test:
+
+```bash
+brew test project-name
+```
+
+If the formula is already installed and Homebrew reports that state, inspect the installed version before deciding whether reinstalling is appropriate.
+
+## GoReleaser Output
+
+For generated formulae:
+
+1. Validate the formula in the tap checkout.
+1. If the formula is wrong because generated fields are wrong, update the source repository's GoReleaser config.
+1. Regenerate the formula through the release process or document the manual tap override.
+
+## SHA-256 Values
+
+If checksums need to be computed for release assets:
+
+```bash
+shasum -a 256 path/to/archive.tar.gz
+```
+
+Use the checksum for the exact URL in the formula. Do not reuse checksums across platforms, architectures, or archives.
+
+## Reporting
+
+Always report:
+
+- Commands run
+- Passing checks
+- Failing checks and the relevant error
+- Skipped checks and why they were skipped
+- Any remaining placeholders, especially SHA-256 placeholders

--- a/dist/opencode/skills/write-homebrew-formula
+++ b/dist/opencode/skills/write-homebrew-formula
@@ -1,0 +1,1 @@
+../../../plugins/write-homebrew-formula/skills/write-homebrew-formula

--- a/plugins/write-homebrew-formula/.claude-plugin/plugin.json
+++ b/plugins/write-homebrew-formula/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "author": {
+    "name": "Christopher Boone"
+  },
+  "description": "Write or update Homebrew formulae using current Homebrew guidance and cboone/homebrew-tap conventions.",
+  "homepage": "https://github.com/cboone/cboone-cc-plugins",
+  "keywords": ["formula", "homebrew", "release", "ruby", "tap"],
+  "license": "MIT",
+  "name": "write-homebrew-formula",
+  "repository": "https://github.com/cboone/cboone-cc-plugins",
+  "skills": "./skills",
+  "version": "1.0.0"
+}

--- a/plugins/write-homebrew-formula/README.md
+++ b/plugins/write-homebrew-formula/README.md
@@ -1,0 +1,39 @@
+# Write Homebrew Formula
+
+Write or update Homebrew formulae using current Homebrew guidance and `cboone/homebrew-tap` conventions.
+
+**Type:** Skill
+**Trigger:** `/write-homebrew-formula`
+
+## Installation
+
+See the [marketplace install instructions](../../README.md#install).
+
+## Requirements
+
+- [Homebrew](https://brew.sh/) for formula audit, style, install, and test validation.
+
+## What It Does
+
+Guides formula authoring for stable release formulae, HEAD-only pre-release formulae, Go source builds, GoReleaser-generated outputs, and shell tools with services or setup caveats. Uses `cboone/homebrew-tap` as the only cboone-specific pattern source, while treating official Homebrew documentation as the source for generic formula behavior.
+
+## Usage
+
+```text
+/write-homebrew-formula
+```
+
+The skill gathers project metadata, selects the right formula pattern, writes or updates the Ruby formula, and validates the result with available Homebrew tooling.
+
+## Examples
+
+- "write a Homebrew formula for this Go CLI"
+- "update this HEAD-only formula to a stable release"
+- "review this formula against cboone/homebrew-tap conventions"
+- "add caveats and a service block to this shell-tool formula"
+
+## See Also
+
+- [Add GoReleaser Homebrew](../add-goreleaser-homebrew/README.md): add GoReleaser with Homebrew tap publishing
+- [Setup Installers](../setup-installers/README.md): set up standalone Homebrew distribution for a project
+- [All plugins](../../README.md)

--- a/plugins/write-homebrew-formula/skills/write-homebrew-formula/SKILL.md
+++ b/plugins/write-homebrew-formula/skills/write-homebrew-formula/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: write-homebrew-formula
+description: >-
+  Write or update Homebrew formulae using current Homebrew guidance and
+  cboone/homebrew-tap conventions. Use when the user says "write a Homebrew
+  formula", "update a formula", "add a brew formula", "review this formula",
+  "convert this HEAD formula to stable", or asks for Homebrew tap packaging.
+  Supports stable release formulae, HEAD-only formulae, Go source builds,
+  GoReleaser-generated outputs, shell tools, caveats, services, completions,
+  man pages, config files, and formula validation. Requires Homebrew for full
+  local validation.
+---
+
+# Write Homebrew Formula
+
+Write or update Homebrew formulae with official Homebrew rules and `cboone/homebrew-tap` conventions.
+
+## Scope Boundaries
+
+- Use `cboone/homebrew-tap` as the only cboone-specific formula pattern source.
+- Do not use abandoned tap repositories such as `homebrew-bopca`, `homebrew-heliocron`, or `diurnal-terminal` for conventions or examples.
+- Treat official Homebrew documentation as the source of truth for generic formula DSL behavior.
+- When a formula rule may have changed recently, check today's date first and refresh the relevant official Homebrew documentation before editing.
+
+## Workflow
+
+### 1. Gather Context
+
+Identify whether the user wants a new formula, an update to an existing formula, a review, or a migration from HEAD-only to stable.
+
+Collect these facts before editing:
+
+- Formula path and tap repository, if one exists
+- Project name, marketed name, binary names, and expected formula filename
+- Homepage, source URL, license, release tag or branch, and SHA-256 values
+- Build type: prebuilt archive, Go source build, GoReleaser output, shell script, or mixed assets
+- Platform constraints: macOS-only, Linux support, Intel, Apple Silicon, or arm64-only
+- Runtime, build, and test dependencies
+- Optional assets: completions, man pages, config files, service files, launchd plists, caveats, `post_install`, and `post_uninstall`
+- Testable behavior that avoids credentials, destructive actions, GUI-only behavior, or user input
+
+### 2. Load References
+
+Read only the reference files needed for the requested formula type:
+
+| Reference                          | Use When                                                                  |
+| ---------------------------------- | ------------------------------------------------------------------------- |
+| `./references/homebrew-current.md` | You need current Homebrew DSL, naming, test, service, or validation rules |
+| `./references/cboone-tap.md`       | You need `cboone/homebrew-tap` conventions or current local examples      |
+| `./references/patterns.md`         | You need a concrete formula template or migration shape                   |
+| `./references/validation.md`       | You are ready to run Homebrew checks                                      |
+
+### 3. Choose the Formula Shape
+
+Select the smallest matching pattern:
+
+- **Stable prebuilt release**: use `url`, `sha256`, optional `version`, platform or architecture blocks, and `bin.install`.
+- **Stable source build**: use a release tarball plus build dependencies, such as `depends_on "go" => :build` and `std_go_args` for Go projects.
+- **HEAD-only pre-release**: use `head "...git", branch: "main"` with no stable `url` or `sha256`.
+- **GoReleaser-managed formula**: preserve generated structure, review for consistency, and prefer updating the release configuration upstream rather than hand-editing generated output.
+- **Shell tool**: install scripts directly, add completions/config assets when present, and use service or lifecycle blocks only when the tool genuinely needs them.
+
+### 4. Write or Update the Formula
+
+Apply the selected pattern and keep edits scoped to the requested formula.
+
+Required defaults:
+
+- Formula filename is lowercase and matches the marketed formula name.
+- Class name is strict CamelCase derived from the filename.
+- Use `desc`, `homepage`, and `license`.
+- Use `license "MIT"` only when the project license is actually MIT.
+- Use stable release `url` plus `sha256` when a tagged release exists.
+- Use `head` for pre-release source installs when no stable release exists.
+- Use `depends_on` for build, runtime, and test dependencies so Homebrew puts build-time tools on `PATH`.
+- Use `caveats` only for packaging-specific setup or non-standard paths.
+- Prefer functional tests. If practical behavior cannot be tested without credentials, GUI access, services, or heavy setup, use the existing tap convention of `assert_match` on help or version output.
+
+### 5. Validate
+
+Run the relevant checks from `./references/validation.md`.
+
+If Homebrew is unavailable, report which checks were skipped and why. If a check fails, diagnose the cause from the output and adjust the formula instead of forcing the command through.
+
+### 6. Summarize
+
+Report:
+
+- Formula files created or changed
+- Pattern selected and why
+- Source URLs, tags, branches, and SHA-256 values used
+- Tests and validation commands run
+- Any skipped validation and the reason
+- Any remaining manual work, such as waiting for a first tagged release or filling in SHA-256 values
+
+## Error Handling
+
+- If the project has no stable release and the user requested a stable formula, explain the gap and offer a HEAD-only formula or release checklist.
+- If SHA-256 values are unavailable, leave explicit placeholders only when the user is preparing a draft and list the exact artifacts that need checksums.
+- If the formula requires secrets, credentials, or private URLs, use environment variables and never write secrets into the formula.
+- If current `cboone/homebrew-tap` examples conflict with official Homebrew guidance, call out the conflict and prefer official Homebrew behavior unless the user explicitly chooses the tap convention.
+
+## Sources
+
+- Homebrew Formula Cookbook: <https://docs.brew.sh/Formula-Cookbook>
+- Homebrew acceptable formulae: <https://docs.brew.sh/Acceptable-Formulae>
+- Homebrew `Formula` API: <https://docs.brew.sh/rubydoc/Formula.html>

--- a/plugins/write-homebrew-formula/skills/write-homebrew-formula/references/cboone-tap.md
+++ b/plugins/write-homebrew-formula/skills/write-homebrew-formula/references/cboone-tap.md
@@ -1,0 +1,106 @@
+# `cboone/homebrew-tap` Conventions
+
+Use `cboone/homebrew-tap` as the only cboone-specific pattern source. Do not derive conventions from abandoned taps or retired source repositories.
+
+## Current Formula Set
+
+As checked on 2026-05-03, `cboone/homebrew-tap` contained:
+
+- `Formula/bopca.rb`
+- `Formula/gh-problemas.rb`
+- `Formula/pbcopy2.rb`
+- `Formula/right-round.rb`
+
+Refresh the live list when working on a formula:
+
+```bash
+gh api repos/cboone/homebrew-tap/contents/Formula --jq '.[].path'
+```
+
+If a local checkout of `cboone/homebrew-tap` is available, prefer reading that checkout over remote GitHub content.
+
+## Tap Patterns
+
+### GoReleaser-generated macOS arm64 formula
+
+`bopca` shows a GoReleaser-generated formula with these traits:
+
+- Generated-file header
+- `desc`, `homepage`, `version`, and `license`
+- Runtime dependency on `container`
+- Build dependency on Go
+- macOS and arm64 constraints
+- Install step for the binary
+- Shared config/example files under `share`
+- Runtime completions generated from the executable
+- Man pages installed under `man1`
+- Heredoc caveats for DNS setup and config paths
+- Tests covering help output and version output
+
+When updating this kind of formula, prefer changing the upstream GoReleaser configuration that emits the formula rather than hand-editing generated output.
+
+### GoReleaser-generated cross-platform binary formula
+
+`gh-problemas` shows a generated formula with platform and architecture-specific release archive URLs:
+
+- Runtime dependency on `gh`
+- `on_macos` and `on_linux` blocks
+- Intel and arm64 checks inside each platform block
+- Per-platform `url`, `sha256`, and `def install`
+- Version-output test
+
+Use this pattern when the release process publishes separate prebuilt archives per OS and architecture.
+
+### Manual macOS binary formula
+
+`pbcopy2` shows a hand-written macOS-only formula:
+
+- `depends_on :macos`
+- Separate Intel and Apple Silicon release archives
+- One install block that installs multiple binaries
+- Version-output tests for each installed executable
+
+Use this pattern when the release assets are prebuilt binaries and the formula does not build from source.
+
+### HEAD-only Go source formula
+
+`right-round` shows a pre-release formula with:
+
+- `head "https://github.com/cboone/<name>.git", branch: "main"`
+- No stable `url` or `sha256`
+- `depends_on "go" => :build`
+- Go source build using `std_go_args`
+- Help-output test
+
+Use this pattern only when no tagged stable release is available or the user explicitly wants a HEAD install.
+
+## Local Conventions
+
+- Prefer `license "MIT"` for cboone-owned MIT-licensed projects, but verify the license instead of assuming.
+- Use heredoc `caveats` for setup instructions and config paths.
+- Install config examples under `share` unless a formula intentionally writes user config during `post_install`.
+- Use `generate_completions_from_executable` when the installed binary exposes completions.
+- Install man pages with `man1.install` when release assets include them.
+- Prefer a functional test when practical. Existing tap formulae often use `assert_match` against help or version output when functional tests are not practical.
+- Use `depends_on :macos` for macOS-only tools and `depends_on arch: :arm64` for arm64-only tools.
+
+## HEAD-to-Stable Migration Checklist
+
+When replacing a HEAD-only formula with a stable formula:
+
+1. Confirm a SemVer-style tag exists.
+1. Confirm release assets are published for the intended platforms and architectures.
+1. Add stable `url` and `sha256` values.
+1. Preserve `head` only if users should still be able to install from the development branch.
+1. Update the install block only if the release archive layout differs from the source tree.
+1. Run audit, style, install, and test checks.
+
+## Out-of-Scope Repositories
+
+Do not use these repositories as formula convention sources:
+
+- `cboone/homebrew-bopca`
+- `cboone/homebrew-heliocron`
+- `cboone/diurnal-terminal`
+
+They are abandoned for this skill's purposes.

--- a/plugins/write-homebrew-formula/skills/write-homebrew-formula/references/homebrew-current.md
+++ b/plugins/write-homebrew-formula/skills/write-homebrew-formula/references/homebrew-current.md
@@ -1,0 +1,119 @@
+# Current Homebrew Guidance
+
+This reference was checked against official Homebrew documentation on 2026-05-03. Refresh the linked docs when the task depends on current Homebrew behavior.
+
+## Authoritative Sources
+
+- [Formula Cookbook](https://docs.brew.sh/Formula-Cookbook)
+- [Acceptable Formulae](https://docs.brew.sh/Acceptable-Formulae)
+- [`Formula` Ruby API](https://docs.brew.sh/rubydoc/Formula.html)
+
+## Core Rules
+
+- A formula is Ruby code using the `Formula` API.
+- Stable formulae use a stable source `url` and `sha256`. Tagged release tarballs are preferred when they exist.
+- HEAD builds use `head "https://github.com/owner/repo.git", branch: "main"` and are for development or pre-release installs.
+- Formula names should follow how the project markets itself. The filename and class must correspond by strict CamelCase conversion, such as `foo-bar.rb` to `FooBar`.
+- `desc`, `homepage`, and `license` should be filled in. Use SPDX license identifiers where possible.
+- Declare dependencies with `depends_on`, including build-only dependencies such as `depends_on "go" => :build`.
+- Use `on_macos`, `on_linux`, `on_arm`, and `on_intel` blocks for platform-specific declarations outside `def install` and `test do`.
+- Inside `def install` and `test do`, use conditionals such as `OS.mac?`, `OS.linux?`, `Hardware::CPU.arm?`, and `Hardware::CPU.intel?`.
+- Use `uses_from_macos` when a dependency can come from macOS on supported versions but needs a Homebrew formula elsewhere.
+- Avoid Homebrew options for new `homebrew/core` formulae. In private taps, prefer simple always-on behavior unless the user explicitly needs variants.
+
+## Go Formulae
+
+Use Homebrew's Go helper for source builds:
+
+```ruby
+system "go", "build", *std_go_args(output: bin/"project-name"), "."
+```
+
+`std_go_args` currently supplies `-trimpath` and an output path, with optional `ldflags`, `gcflags`, and `tags`.
+
+For a `main` package below the repo root, pass that package path:
+
+```ruby
+system "go", "build", *std_go_args(output: bin/"project-name"), "./cmd/project-name"
+```
+
+## Completions and Man Pages
+
+Use `generate_completions_from_executable` when the installed executable can generate shell completions:
+
+```ruby
+generate_completions_from_executable(bin/"project-name", "completion")
+```
+
+Install manual pages under `man1`, `man5`, or another `share/man` path exposed by Homebrew helpers:
+
+```ruby
+man1.install Dir["man/man1/*"]
+```
+
+## Caveats
+
+Use `caveats` for setup instructions that are specific to the Homebrew package, non-standard paths, environment variables, service startup, or config files:
+
+```ruby
+def caveats
+  <<~EOS
+    Configuration file: #{etc}/project-name/config.yaml
+  EOS
+end
+```
+
+Keep caveats actionable. Do not repeat generic README content.
+
+## Services
+
+Use a `service` block when `brew services` should manage a launchd or systemd service.
+
+For package-provided service files, install the file and provide the service name:
+
+```ruby
+service do
+  name macos: "homebrew.mxcl.project-name"
+end
+```
+
+For formula-defined services, use `run`:
+
+```ruby
+service do
+  run [opt_bin/"project-name", "--config", etc/"project-name/config.yaml"]
+end
+```
+
+## Tests
+
+Homebrew prefers tests that exercise basic functionality without credentials, user input, network assumptions, or heavyweight services. `--help` and `--version` tests are weak, but better than no test when the tool cannot be exercised safely in the formula sandbox.
+
+Use assertions around command output when possible:
+
+```ruby
+test do
+  assert_match "expected text", shell_output("#{bin}/project-name --help")
+end
+```
+
+For commands that return expected failures, pass the expected status to `shell_output`:
+
+```ruby
+test do
+  assert_match "missing token", shell_output("#{bin}/project-name check 2>&1", 1)
+end
+```
+
+## Validation Commands
+
+Use these commands when available:
+
+```bash
+brew style Formula/project-name.rb
+brew audit --strict --online --formula Formula/project-name.rb
+brew install --build-from-source --verbose ./Formula/project-name.rb
+brew test project-name
+```
+
+For new formulae intended for `homebrew/core`, also use `brew audit --new --formula`.

--- a/plugins/write-homebrew-formula/skills/write-homebrew-formula/references/patterns.md
+++ b/plugins/write-homebrew-formula/skills/write-homebrew-formula/references/patterns.md
@@ -1,0 +1,146 @@
+# Formula Patterns
+
+These templates show shapes to adapt, not complete formulae to paste unchanged. Replace placeholders, verify licenses, and validate the result with Homebrew.
+
+## Stable Prebuilt Binary
+
+Use this when GitHub Releases or another stable source publishes archives that already contain binaries.
+
+```ruby
+class ProjectName < Formula
+  desc "Short project description"
+  homepage "https://github.com/OWNER/project-name"
+  version "0.1.0"
+  license "MIT"
+
+  on_macos do
+    on_intel do
+      url "https://github.com/OWNER/project-name/releases/download/v0.1.0/project-name-0.1.0-darwin-amd64.tar.gz"
+      sha256 "SHA256_FOR_DARWIN_AMD64"
+    end
+
+    on_arm do
+      url "https://github.com/OWNER/project-name/releases/download/v0.1.0/project-name-0.1.0-darwin-arm64.tar.gz"
+      sha256 "SHA256_FOR_DARWIN_ARM64"
+    end
+  end
+
+  def install
+    bin.install "project-name"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/project-name --version")
+  end
+end
+```
+
+Add `on_linux` blocks when Linux release assets exist. Use `depends_on :macos` when the project is macOS-only.
+
+## Stable Go Source Build
+
+Use this when the formula should build from a tagged source archive.
+
+```ruby
+class ProjectName < Formula
+  desc "Short project description"
+  homepage "https://github.com/OWNER/project-name"
+  url "https://github.com/OWNER/project-name/archive/refs/tags/v0.1.0.tar.gz"
+  sha256 "SHA256_FOR_SOURCE_TARBALL"
+  license "MIT"
+
+  depends_on "go" => :build
+
+  def install
+    system "go", "build", *std_go_args(output: bin/"project-name"), "."
+  end
+
+  test do
+    assert_match "project-name", shell_output("#{bin}/project-name --help")
+  end
+end
+```
+
+If the command lives below the repository root, replace `"."` with a package path such as `"./cmd/project-name"`.
+
+## HEAD-only Go Source Build
+
+Use this when no tagged release exists or the user intentionally wants a development build.
+
+```ruby
+class ProjectName < Formula
+  desc "Short project description"
+  homepage "https://github.com/OWNER/project-name"
+  head "https://github.com/OWNER/project-name.git", branch: "main"
+  license "MIT"
+
+  depends_on "go" => :build
+
+  def install
+    system "go", "build", *std_go_args(output: bin/"project-name"), "./cmd/project-name"
+  end
+
+  test do
+    assert_match "project-name", shell_output("#{bin}/project-name --help")
+  end
+end
+```
+
+Do not add stable `url` or `sha256` unless a stable source exists.
+
+## GoReleaser-generated Formula Review
+
+For GoReleaser-managed formulae, inspect these surfaces:
+
+- Generated-file header, if GoReleaser emits one
+- `desc`, `homepage`, `version`, and `license`
+- Platform and architecture URL blocks
+- Runtime dependencies
+- Installed binaries
+- Completions, man pages, and config assets included in release archives
+- Caveats and tests
+
+Prefer changing `.goreleaser.yml` in the source repository when generated output is wrong. Hand edits to generated formulae should be reserved for cases where the tap intentionally owns a manual override.
+
+## Shell Tool with Config and Service
+
+Use this when the package installs scripts and service assets instead of compiling a binary.
+
+```ruby
+class ProjectName < Formula
+  desc "Short project description"
+  homepage "https://github.com/OWNER/project-name"
+  url "https://github.com/OWNER/project-name/archive/refs/tags/v0.1.0.tar.gz"
+  sha256 "SHA256_FOR_SOURCE_TARBALL"
+  license "MIT"
+
+  depends_on "dependency-name"
+
+  def install
+    bin.install "scripts/project-name"
+    zsh_completion.install "completions/_project-name" if File.exist?("completions/_project-name")
+    (share/"project-name").install "config/project-name.conf.example"
+    prefix.install "LaunchAgents/homebrew.mxcl.project-name.plist"
+  end
+
+  def caveats
+    <<~EOS
+      Configuration example:
+        #{share}/project-name/project-name.conf.example
+
+      To start the service:
+        brew services start project-name
+    EOS
+  end
+
+  service do
+    name macos: "homebrew.mxcl.project-name"
+  end
+
+  test do
+    assert_match "project-name", shell_output("#{bin}/project-name --help")
+  end
+end
+```
+
+Use `post_install` only when the formula must initialize user-visible state after installation. Prefer installing examples and explaining setup in `caveats` when that is enough.

--- a/plugins/write-homebrew-formula/skills/write-homebrew-formula/references/validation.md
+++ b/plugins/write-homebrew-formula/skills/write-homebrew-formula/references/validation.md
@@ -1,0 +1,73 @@
+# Formula Validation
+
+Run the strongest checks available in the environment. Do not force through failures. Diagnose and adjust the formula.
+
+## Check Prerequisites
+
+```bash
+command -v brew
+brew --version
+```
+
+If Homebrew is not installed, skip local validation and report that limitation.
+
+## Style and Audit
+
+For a formula file in the current tap checkout:
+
+```bash
+brew style Formula/project-name.rb
+brew audit --strict --online --formula Formula/project-name.rb
+```
+
+For a new formula intended for `homebrew/core`, add the stricter new-formula audit:
+
+```bash
+brew audit --new --formula Formula/project-name.rb
+```
+
+For a private tap, `--new` can still be useful, but do not treat every `homebrew/core` policy warning as a private-tap blocker unless it affects correctness, maintainability, or user safety.
+
+## Install and Test
+
+Install from the local formula file or the tapped formula name:
+
+```bash
+brew install --build-from-source --verbose ./Formula/project-name.rb
+```
+
+Then run the formula test:
+
+```bash
+brew test project-name
+```
+
+If the formula is already installed and Homebrew reports that state, inspect the installed version before deciding whether reinstalling is appropriate.
+
+## GoReleaser Output
+
+For generated formulae:
+
+1. Validate the formula in the tap checkout.
+1. If the formula is wrong because generated fields are wrong, update the source repository's GoReleaser config.
+1. Regenerate the formula through the release process or document the manual tap override.
+
+## SHA-256 Values
+
+If checksums need to be computed for release assets:
+
+```bash
+shasum -a 256 path/to/archive.tar.gz
+```
+
+Use the checksum for the exact URL in the formula. Do not reuse checksums across platforms, architectures, or archives.
+
+## Reporting
+
+Always report:
+
+- Commands run
+- Passing checks
+- Failing checks and the relevant error
+- Skipped checks and why they were skipped
+- Any remaining placeholders, especially SHA-256 placeholders


### PR DESCRIPTION
## Summary

- Add a `write-homebrew-formula` skill for writing and updating Homebrew formulae.
- Capture current official Homebrew guidance separately from `cboone/homebrew-tap` conventions.
- Register the new plugin in the Claude, Codex, and OpenCode marketplace surfaces.

## Test plan

- [x] `yarn lint:fix`
- [x] `yarn lint`
- [x] `yarn validate`
- [x] `bin/compute-catalog-state .claude-plugin/marketplace.json`
- [x] `git diff --check main...HEAD`

## Closes

Closes #33
