### PR TITLE
Preserve in-progress issue labels

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -2,7 +2,7 @@
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "metadata": {
     "description": "Claude Code commands, hooks, and skills from Christopher Boone (cboone.github.io)",
-    "version": "catalog-M61-m108-p97-n53"
+    "version": "catalog-M61-m108-p100-n53"
   },
   "name": "cboone-cc-plugins",
   "owner": {
@@ -77,7 +77,7 @@
       "name": "address-issue",
       "repository": "https://github.com/cboone/cboone-cc-plugins",
       "source": "./dist/codex/plugins/address-issue",
-      "version": "1.0.1"
+      "version": "1.0.2"
     },
     {
       "author": {
@@ -203,7 +203,7 @@
       "name": "create-worktree-from-issue",
       "repository": "https://github.com/cboone/cboone-cc-plugins",
       "source": "./dist/codex/plugins/create-worktree-from-issue",
-      "version": "1.3.1"
+      "version": "1.3.2"
     },
     {
       "author": {
@@ -525,7 +525,7 @@
       "name": "suggest-next-issue",
       "repository": "https://github.com/cboone/cboone-cc-plugins",
       "source": "./dist/codex/plugins/suggest-next-issue",
-      "version": "1.1.3"
+      "version": "1.1.4"
     },
     {
       "author": {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "metadata": {
     "description": "Claude Code commands, hooks, and skills from Christopher Boone (cboone.github.io)",
-    "version": "catalog-M61-m108-p97-n53"
+    "version": "catalog-M61-m108-p100-n53"
   },
   "name": "cboone-cc-plugins",
   "owner": {
@@ -77,7 +77,7 @@
       "name": "address-issue",
       "repository": "https://github.com/cboone/cboone-cc-plugins",
       "source": "./plugins/address-issue",
-      "version": "1.0.1"
+      "version": "1.0.2"
     },
     {
       "author": {
@@ -203,7 +203,7 @@
       "name": "create-worktree-from-issue",
       "repository": "https://github.com/cboone/cboone-cc-plugins",
       "source": "./plugins/create-worktree-from-issue",
-      "version": "1.3.1"
+      "version": "1.3.2"
     },
     {
       "author": {
@@ -525,7 +525,7 @@
       "name": "suggest-next-issue",
       "repository": "https://github.com/cboone/cboone-cc-plugins",
       "source": "./plugins/suggest-next-issue",
-      "version": "1.1.3"
+      "version": "1.1.4"
     },
     {
       "author": {

--- a/dist/codex/plugins/address-issue/.claude-plugin/plugin.json
+++ b/dist/codex/plugins/address-issue/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "name": "address-issue",
   "repository": "https://github.com/cboone/cboone-cc-plugins",
   "skills": "./skills",
-  "version": "1.0.1"
+  "version": "1.0.2"
 }

--- a/dist/codex/plugins/address-issue/README.md
+++ b/dist/codex/plugins/address-issue/README.md
@@ -11,7 +11,7 @@ See the [marketplace install instructions](../../../../README.md#install).
 
 ## What It Does
 
-Fetches a GitHub issue by number or search text, classifies it (bug fix, feature, documentation, refactor, or chore), extracts sub-tasks from task list checkboxes, plans the work, executes changes, and commits with conventional commit messages that reference the issue number. Marks the issue "in progress" at the start and removes the label when done.
+Fetches a GitHub issue by number or search text, classifies it (bug fix, feature, documentation, refactor, or chore), extracts sub-tasks from task list checkboxes, plans the work, executes changes, and commits with conventional commit messages that reference the issue number. Marks the issue "in progress" at the start and leaves that label in place until the related PR is merged or the user explicitly abandons the effort.
 
 ## Usage
 

--- a/dist/codex/plugins/address-issue/skills/address-issue/SKILL.md
+++ b/dist/codex/plugins/address-issue/skills/address-issue/SKILL.md
@@ -66,7 +66,7 @@ The `gh label create` command is safe to run even if the label already exists. `
 
 Self-assignment is idempotent, safe to re-run if the assignee already exists.
 
-If any command fails, warn the user but continue. Status marking is best-effort and must never block the primary workflow. Record whether this step succeeded for use in step 9.
+If any command fails, warn the user but continue. Status marking is best-effort and must never block the primary workflow. Record whether this step succeeded for the completion summary.
 
 ### 4. Display Issue Context
 
@@ -166,17 +166,13 @@ docs: update installation instructions (#88)
 
 For multi-commit cases, each commit references the same issue number.
 
-### 9. Mark Issue Done
+### 9. Leave Issue In Progress
 
-**Skip this step if**: step 3 was skipped (closed issue) or step 3 failed (status marking unsuccessful).
+Do not remove the "in progress" label after local implementation or committing.
 
-Remove the "in progress" label:
+The label means the issue has active work associated with it. Keep it in place until the related pull request is merged or the user explicitly abandons the effort.
 
-```bash
-gh issue edit NUMBER --remove-label "in progress"
-```
-
-Best-effort: if the command fails, warn the user but do not treat it as an error.
+If step 3 succeeded, report that issue status cleanup is deferred until PR merge or explicit abandonment. If step 3 was skipped or failed, report that no issue status was retained. Do not add PR merge automation or invent an abandonment workflow.
 
 ### 10. Report Completion
 
@@ -195,6 +191,8 @@ Display a summary of what was done:
 ```
 
 If any changes were skipped, list them with explanations.
+
+If step 3 succeeded, include a note that issue #NUMBER remains labeled "in progress" until the related PR merges or the user explicitly abandons the effort.
 
 ### 11. Offer Next Steps
 

--- a/dist/codex/plugins/create-worktree-from-issue/.claude-plugin/plugin.json
+++ b/dist/codex/plugins/create-worktree-from-issue/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "name": "create-worktree-from-issue",
   "repository": "https://github.com/cboone/cboone-cc-plugins",
   "skills": "./skills",
-  "version": "1.3.1"
+  "version": "1.3.2"
 }

--- a/dist/codex/plugins/create-worktree-from-issue/README.md
+++ b/dist/codex/plugins/create-worktree-from-issue/README.md
@@ -12,7 +12,7 @@ See the [marketplace install instructions](../../../../README.md#install).
 
 ## What It Does
 
-Finds a GitHub issue by number or fuzzy text search, derives a branch name from the issue title and labels, self-assigns the issue, labels it "in progress", and creates a worktree via `workmux add` with the full issue context injected as a task prompt.
+Finds a GitHub issue by number or fuzzy text search, derives a branch name from the issue title and labels, self-assigns the issue, labels it "in progress", and creates a worktree via `workmux add` with the full issue context injected as a task prompt. The "in progress" label is retained until the related PR is merged or the user explicitly abandons the effort.
 
 ## Usage
 

--- a/dist/codex/plugins/create-worktree-from-issue/skills/create-worktree-from-issue/SKILL.md
+++ b/dist/codex/plugins/create-worktree-from-issue/skills/create-worktree-from-issue/SKILL.md
@@ -56,6 +56,8 @@ Self-assignment is idempotent — safe to re-run if the assignee already exists.
 
 If any command fails, warn the user but continue with worktree creation. Status marking is best-effort and must never block the primary workflow.
 
+The "in progress" label is intentionally retained beyond worktree creation and local implementation. It represents active issue lifecycle state until the related pull request is merged or the user explicitly abandons the effort. Do not remove it as part of creating the worktree.
+
 ### 3. Build the Branch Name
 
 Construct a branch name in the format `TYPE/SLUG` where:
@@ -118,6 +120,7 @@ After confirming the worktree exists in `git worktree list`, report:
 - The tmux window name (to help the user switch to it)
 - A note that the issue context was injected into the new session
 - Whether the issue was marked in progress (assigned and labeled), or if status marking was skipped/failed
+- If status marking succeeded, a note that the "in progress" label is retained until PR merge or explicit abandonment
 
 ## Error Handling
 

--- a/dist/codex/plugins/suggest-next-issue/.claude-plugin/plugin.json
+++ b/dist/codex/plugins/suggest-next-issue/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "name": "suggest-next-issue",
   "repository": "https://github.com/cboone/cboone-cc-plugins",
   "skills": "./skills",
-  "version": "1.1.3"
+  "version": "1.1.4"
 }

--- a/dist/codex/plugins/suggest-next-issue/README.md
+++ b/dist/codex/plugins/suggest-next-issue/README.md
@@ -12,7 +12,7 @@ See the [marketplace install instructions](../../../../README.md#install).
 
 ## What It Does
 
-Analyzes open issues in context (current branches, recent work, project goals, and dependencies), then categorizes them as quick wins, high impact, unblocks others, or overdue. Provides specific reasoning for each recommendation so you can make an informed decision.
+Analyzes open issues in context (current branches, issue labels, assignments, recent work, project goals, and dependencies), excludes issues already marked in progress, then categorizes the remaining candidates as quick wins, high impact, unblocks others, or overdue. Provides specific reasoning for each recommendation so you can make an informed decision.
 
 ## Usage
 

--- a/dist/codex/plugins/suggest-next-issue/skills/suggest-next-issue/SKILL.md
+++ b/dist/codex/plugins/suggest-next-issue/skills/suggest-next-issue/SKILL.md
@@ -62,6 +62,8 @@ An issue is considered in progress if **any** of the following are true:
 
 Exclude in-progress issues from recommendations, but note them in the output as "already in progress" along with how each was detected (branch, label, assignment, or a combination).
 
+A label-only match may mean local work is complete but the related PR is still waiting to merge. Keep excluding the issue in that state. Do not recommend it again only because no matching branch or worktree is visible.
+
 ### 3. Analyze Each Issue
 
 Evaluate each open issue (that is not already in progress) on these signals:
@@ -102,7 +104,7 @@ For each recommendation, include:
 
 ### 5. Summarize In-Progress Work
 
-After recommendations, briefly list issues detected as in progress. For each, note how it was detected: branch/worktree, "in progress" label, assignment to current user, or a combination. This gives the user a complete picture of active work.
+After recommendations, briefly list issues detected as in progress. For each, note how it was detected: branch/worktree, "in progress" label, assignment to current user, or a combination. This gives the user a complete picture of active work, including issues that may be waiting on PR merge after local implementation is done.
 
 ### 6. Offer to Start Work
 

--- a/plugins/address-issue/.claude-plugin/plugin.json
+++ b/plugins/address-issue/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "name": "address-issue",
   "repository": "https://github.com/cboone/cboone-cc-plugins",
   "skills": "./skills",
-  "version": "1.0.1"
+  "version": "1.0.2"
 }

--- a/plugins/address-issue/README.md
+++ b/plugins/address-issue/README.md
@@ -11,7 +11,7 @@ See the [marketplace install instructions](../../README.md#install).
 
 ## What It Does
 
-Fetches a GitHub issue by number or search text, classifies it (bug fix, feature, documentation, refactor, or chore), extracts sub-tasks from task list checkboxes, plans the work, executes changes, and commits with conventional commit messages that reference the issue number. Marks the issue "in progress" at the start and removes the label when done.
+Fetches a GitHub issue by number or search text, classifies it (bug fix, feature, documentation, refactor, or chore), extracts sub-tasks from task list checkboxes, plans the work, executes changes, and commits with conventional commit messages that reference the issue number. Marks the issue "in progress" at the start and leaves that label in place until the related PR is merged or the user explicitly abandons the effort.
 
 ## Usage
 

--- a/plugins/address-issue/skills/address-issue/SKILL.md
+++ b/plugins/address-issue/skills/address-issue/SKILL.md
@@ -71,7 +71,7 @@ The `gh label create` command is safe to run even if the label already exists. `
 
 Self-assignment is idempotent, safe to re-run if the assignee already exists.
 
-If any command fails, warn the user but continue. Status marking is best-effort and must never block the primary workflow. Record whether this step succeeded for use in step 9.
+If any command fails, warn the user but continue. Status marking is best-effort and must never block the primary workflow. Record whether this step succeeded for the completion summary.
 
 ### 4. Display Issue Context
 
@@ -171,17 +171,13 @@ docs: update installation instructions (#88)
 
 For multi-commit cases, each commit references the same issue number.
 
-### 9. Mark Issue Done
+### 9. Leave Issue In Progress
 
-**Skip this step if**: step 3 was skipped (closed issue) or step 3 failed (status marking unsuccessful).
+Do not remove the "in progress" label after local implementation or committing.
 
-Remove the "in progress" label:
+The label means the issue has active work associated with it. Keep it in place until the related pull request is merged or the user explicitly abandons the effort.
 
-```bash
-gh issue edit NUMBER --remove-label "in progress"
-```
-
-Best-effort: if the command fails, warn the user but do not treat it as an error.
+If step 3 succeeded, report that issue status cleanup is deferred until PR merge or explicit abandonment. If step 3 was skipped or failed, report that no issue status was retained. Do not add PR merge automation or invent an abandonment workflow.
 
 ### 10. Report Completion
 
@@ -200,6 +196,8 @@ Display a summary of what was done:
 ```
 
 If any changes were skipped, list them with explanations.
+
+If step 3 succeeded, include a note that issue #NUMBER remains labeled "in progress" until the related PR merges or the user explicitly abandons the effort.
 
 ### 11. Offer Next Steps
 

--- a/plugins/create-worktree-from-issue/.claude-plugin/plugin.json
+++ b/plugins/create-worktree-from-issue/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "name": "create-worktree-from-issue",
   "repository": "https://github.com/cboone/cboone-cc-plugins",
   "skills": "./skills",
-  "version": "1.3.1"
+  "version": "1.3.2"
 }

--- a/plugins/create-worktree-from-issue/README.md
+++ b/plugins/create-worktree-from-issue/README.md
@@ -12,7 +12,7 @@ See the [marketplace install instructions](../../README.md#install).
 
 ## What It Does
 
-Finds a GitHub issue by number or fuzzy text search, derives a branch name from the issue title and labels, self-assigns the issue, labels it "in progress", and creates a worktree via `workmux add` with the full issue context injected as a task prompt.
+Finds a GitHub issue by number or fuzzy text search, derives a branch name from the issue title and labels, self-assigns the issue, labels it "in progress", and creates a worktree via `workmux add` with the full issue context injected as a task prompt. The "in progress" label is retained until the related PR is merged or the user explicitly abandons the effort.
 
 ## Usage
 

--- a/plugins/create-worktree-from-issue/skills/create-worktree-from-issue/SKILL.md
+++ b/plugins/create-worktree-from-issue/skills/create-worktree-from-issue/SKILL.md
@@ -60,6 +60,8 @@ Self-assignment is idempotent — safe to re-run if the assignee already exists.
 
 If any command fails, warn the user but continue with worktree creation. Status marking is best-effort and must never block the primary workflow.
 
+The "in progress" label is intentionally retained beyond worktree creation and local implementation. It represents active issue lifecycle state until the related pull request is merged or the user explicitly abandons the effort. Do not remove it as part of creating the worktree.
+
 ### 3. Build the Branch Name
 
 Construct a branch name in the format `TYPE/SLUG` where:
@@ -122,6 +124,7 @@ After confirming the worktree exists in `git worktree list`, report:
 - The tmux window name (to help the user switch to it)
 - A note that the issue context was injected into the new session
 - Whether the issue was marked in progress (assigned and labeled), or if status marking was skipped/failed
+- If status marking succeeded, a note that the "in progress" label is retained until PR merge or explicit abandonment
 
 ## Error Handling
 

--- a/plugins/suggest-next-issue/.claude-plugin/plugin.json
+++ b/plugins/suggest-next-issue/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "name": "suggest-next-issue",
   "repository": "https://github.com/cboone/cboone-cc-plugins",
   "skills": "./skills",
-  "version": "1.1.3"
+  "version": "1.1.4"
 }

--- a/plugins/suggest-next-issue/README.md
+++ b/plugins/suggest-next-issue/README.md
@@ -12,7 +12,7 @@ See the [marketplace install instructions](../../README.md#install).
 
 ## What It Does
 
-Analyzes open issues in context (current branches, recent work, project goals, and dependencies), then categorizes them as quick wins, high impact, unblocks others, or overdue. Provides specific reasoning for each recommendation so you can make an informed decision.
+Analyzes open issues in context (current branches, issue labels, assignments, recent work, project goals, and dependencies), excludes issues already marked in progress, then categorizes the remaining candidates as quick wins, high impact, unblocks others, or overdue. Provides specific reasoning for each recommendation so you can make an informed decision.
 
 ## Usage
 

--- a/plugins/suggest-next-issue/skills/suggest-next-issue/SKILL.md
+++ b/plugins/suggest-next-issue/skills/suggest-next-issue/SKILL.md
@@ -67,6 +67,8 @@ An issue is considered in progress if **any** of the following are true:
 
 Exclude in-progress issues from recommendations, but note them in the output as "already in progress" along with how each was detected (branch, label, assignment, or a combination).
 
+A label-only match may mean local work is complete but the related PR is still waiting to merge. Keep excluding the issue in that state. Do not recommend it again only because no matching branch or worktree is visible.
+
 ### 3. Analyze Each Issue
 
 Evaluate each open issue (that is not already in progress) on these signals:
@@ -107,7 +109,7 @@ For each recommendation, include:
 
 ### 5. Summarize In-Progress Work
 
-After recommendations, briefly list issues detected as in progress. For each, note how it was detected: branch/worktree, "in progress" label, assignment to current user, or a combination. This gives the user a complete picture of active work.
+After recommendations, briefly list issues detected as in progress. For each, note how it was detected: branch/worktree, "in progress" label, assignment to current user, or a combination. This gives the user a complete picture of active work, including issues that may be waiting on PR merge after local implementation is done.
 
 ### 6. Offer to Start Work
 


### PR DESCRIPTION
## Summary

- Keep `address-issue` from removing the `in progress` label after local completion.
- Clarify that `create-worktree-from-issue` retains the label until PR merge or explicit abandonment.
- Treat label-only in-progress issues as active in `suggest-next-issue`.
- Bump affected plugin patch versions and regenerate Codex marketplace outputs.

## Test plan

- [x] `bin/build-codex-marketplace`
- [x] `bin/build-opencode-mirror`
- [x] `yarn lint:fix`
- [x] `yarn validate`
- [x] `yarn lint`
- [x] `check-versions` pass for plugin versions, marketplace metadata, and generated mirrors
- [x] Search active sources and generated outputs for premature `in progress` label removal
