### PR TITLE
Recover tmux context for Codex workmux launchers

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -2,7 +2,7 @@
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "metadata": {
     "description": "Claude Code commands, hooks, and skills from Christopher Boone (cboone.github.io)",
-    "version": "catalog-M61-m108-p154-n53"
+    "version": "catalog-M61-m108-p155-n53"
   },
   "name": "agent-harness-plugins",
   "owner": {
@@ -189,7 +189,7 @@
       "name": "create-worktree",
       "repository": "https://github.com/cboone/agent-harness-plugins",
       "source": "./dist/codex/plugins/create-worktree",
-      "version": "1.1.2"
+      "version": "1.1.3"
     },
     {
       "author": {

--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -203,7 +203,7 @@
       "name": "create-worktree-from-issue",
       "repository": "https://github.com/cboone/agent-harness-plugins",
       "source": "./dist/codex/plugins/create-worktree-from-issue",
-      "version": "1.3.3"
+      "version": "1.3.4"
     },
     {
       "author": {

--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -2,7 +2,7 @@
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "metadata": {
     "description": "Claude Code commands, hooks, and skills from Christopher Boone (cboone.github.io)",
-    "version": "catalog-M61-m108-p155-n53"
+    "version": "catalog-M61-m108-p156-n53"
   },
   "name": "agent-harness-plugins",
   "owner": {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "metadata": {
     "description": "Claude Code commands, hooks, and skills from Christopher Boone (cboone.github.io)",
-    "version": "catalog-M61-m108-p154-n53"
+    "version": "catalog-M61-m108-p155-n53"
   },
   "name": "agent-harness-plugins",
   "owner": {
@@ -189,7 +189,7 @@
       "name": "create-worktree",
       "repository": "https://github.com/cboone/agent-harness-plugins",
       "source": "./plugins/create-worktree",
-      "version": "1.1.2"
+      "version": "1.1.3"
     },
     {
       "author": {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -203,7 +203,7 @@
       "name": "create-worktree-from-issue",
       "repository": "https://github.com/cboone/agent-harness-plugins",
       "source": "./plugins/create-worktree-from-issue",
-      "version": "1.3.3"
+      "version": "1.3.4"
     },
     {
       "author": {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "metadata": {
     "description": "Claude Code commands, hooks, and skills from Christopher Boone (cboone.github.io)",
-    "version": "catalog-M61-m108-p155-n53"
+    "version": "catalog-M61-m108-p156-n53"
   },
   "name": "agent-harness-plugins",
   "owner": {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,11 +28,11 @@ jobs:
       - name: Lint Markdown
         run: yarn lint
       - name: ShellCheck
-        run: shellcheck -S warning bin/* plugins/*/scripts/* tests/fixtures/workmux-stub
+        run: shellcheck -S warning bin/* plugins/*/scripts/* tests/fixtures/*
       - name: Set up shfmt
         uses: cboone/gh-actions/actions/set-up-shfmt@91f9abd25d4f82354c0f950dfc8b6d7525b0f5b5 # v3.0.0
       - name: shfmt
-        run: shfmt -d bin/* plugins/*/scripts/* tests/fixtures/workmux-stub
+        run: shfmt -d bin/* plugins/*/scripts/* tests/fixtures/*
       - uses: cboone/gh-actions/actions/set-up-actionlint@91f9abd25d4f82354c0f950dfc8b6d7525b0f5b5 # v3.0.0
       - name: Actionlint
         run: actionlint
@@ -53,5 +53,7 @@ jobs:
         COMPOSE_ISSUE_PROMPT_BIN=./plugins/create-worktree-from-issue/scripts/compose-issue-prompt
         CREATE_WORKTREE_LAUNCH_WORKMUX_BIN=./plugins/create-worktree/scripts/launch-workmux
         CREATE_WORKTREE_FROM_ISSUE_LAUNCH_WORKMUX_BIN=./plugins/create-worktree-from-issue/scripts/launch-workmux
+        TMUX_STUB_BIN=./tests/fixtures/tmux-stub
+        UNIX_SOCKET_FIXTURE_BIN=./tests/fixtures/create-unix-socket
         WORKMUX_STUB_BIN=./tests/fixtures/workmux-stub
       scrut-test-dir: "tests/scrut/"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
         COMPOSE_ISSUE_PROMPT_BIN=./plugins/create-worktree-from-issue/scripts/compose-issue-prompt
         CREATE_WORKTREE_LAUNCH_WORKMUX_BIN=./plugins/create-worktree/scripts/launch-workmux
         CREATE_WORKTREE_FROM_ISSUE_LAUNCH_WORKMUX_BIN=./plugins/create-worktree-from-issue/scripts/launch-workmux
+        GIT_WORKTREE_STUB_BIN=./tests/fixtures/git-worktree-stub
         TMUX_STUB_BIN=./tests/fixtures/tmux-stub
         UNIX_SOCKET_FIXTURE_BIN=./tests/fixtures/create-unix-socket
         WORKMUX_STUB_BIN=./tests/fixtures/workmux-stub

--- a/.workmux.yaml
+++ b/.workmux.yaml
@@ -1,8 +1,10 @@
 # workmux project configuration
 # For global settings, edit ~/.config/workmux/config.yaml
 
+agent: cx
+
 panes:
-  - command: cx
+  - command: <agent>
     focus: true
   - split: vertical
     percentage: 50

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ test-scrut:
 	COMPOSE_ISSUE_PROMPT_BIN="$(CURDIR)/plugins/create-worktree-from-issue/scripts/compose-issue-prompt" \
 	CREATE_WORKTREE_LAUNCH_WORKMUX_BIN="$(CURDIR)/plugins/create-worktree/scripts/launch-workmux" \
 	CREATE_WORKTREE_FROM_ISSUE_LAUNCH_WORKMUX_BIN="$(CURDIR)/plugins/create-worktree-from-issue/scripts/launch-workmux" \
+	GIT_WORKTREE_STUB_BIN="$(CURDIR)/tests/fixtures/git-worktree-stub" \
 	TMUX_STUB_BIN="$(CURDIR)/tests/fixtures/tmux-stub" \
 	UNIX_SOCKET_FIXTURE_BIN="$(CURDIR)/tests/fixtures/create-unix-socket" \
 	WORKMUX_STUB_BIN="$(CURDIR)/tests/fixtures/workmux-stub" \
@@ -17,6 +18,7 @@ test-scrut-update:
 	COMPOSE_ISSUE_PROMPT_BIN="$(CURDIR)/plugins/create-worktree-from-issue/scripts/compose-issue-prompt" \
 	CREATE_WORKTREE_LAUNCH_WORKMUX_BIN="$(CURDIR)/plugins/create-worktree/scripts/launch-workmux" \
 	CREATE_WORKTREE_FROM_ISSUE_LAUNCH_WORKMUX_BIN="$(CURDIR)/plugins/create-worktree-from-issue/scripts/launch-workmux" \
+	GIT_WORKTREE_STUB_BIN="$(CURDIR)/tests/fixtures/git-worktree-stub" \
 	TMUX_STUB_BIN="$(CURDIR)/tests/fixtures/tmux-stub" \
 	UNIX_SOCKET_FIXTURE_BIN="$(CURDIR)/tests/fixtures/create-unix-socket" \
 	WORKMUX_STUB_BIN="$(CURDIR)/tests/fixtures/workmux-stub" \

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@ test-scrut:
 	COMPOSE_ISSUE_PROMPT_BIN="$(CURDIR)/plugins/create-worktree-from-issue/scripts/compose-issue-prompt" \
 	CREATE_WORKTREE_LAUNCH_WORKMUX_BIN="$(CURDIR)/plugins/create-worktree/scripts/launch-workmux" \
 	CREATE_WORKTREE_FROM_ISSUE_LAUNCH_WORKMUX_BIN="$(CURDIR)/plugins/create-worktree-from-issue/scripts/launch-workmux" \
+	TMUX_STUB_BIN="$(CURDIR)/tests/fixtures/tmux-stub" \
+	UNIX_SOCKET_FIXTURE_BIN="$(CURDIR)/tests/fixtures/create-unix-socket" \
 	WORKMUX_STUB_BIN="$(CURDIR)/tests/fixtures/workmux-stub" \
 	scrut --shell bash test "$(SCRUT_TEST_DIR)"
 
@@ -15,6 +17,8 @@ test-scrut-update:
 	COMPOSE_ISSUE_PROMPT_BIN="$(CURDIR)/plugins/create-worktree-from-issue/scripts/compose-issue-prompt" \
 	CREATE_WORKTREE_LAUNCH_WORKMUX_BIN="$(CURDIR)/plugins/create-worktree/scripts/launch-workmux" \
 	CREATE_WORKTREE_FROM_ISSUE_LAUNCH_WORKMUX_BIN="$(CURDIR)/plugins/create-worktree-from-issue/scripts/launch-workmux" \
+	TMUX_STUB_BIN="$(CURDIR)/tests/fixtures/tmux-stub" \
+	UNIX_SOCKET_FIXTURE_BIN="$(CURDIR)/tests/fixtures/create-unix-socket" \
 	WORKMUX_STUB_BIN="$(CURDIR)/tests/fixtures/workmux-stub" \
 	scrut --shell bash update --replace --assume-yes "$(SCRUT_TEST_DIR)"
 

--- a/dist/codex/plugins/create-worktree-from-issue/.claude-plugin/plugin.json
+++ b/dist/codex/plugins/create-worktree-from-issue/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "name": "create-worktree-from-issue",
   "repository": "https://github.com/cboone/agent-harness-plugins",
   "skills": "./skills",
-  "version": "1.3.3"
+  "version": "1.3.4"
 }

--- a/dist/codex/plugins/create-worktree-from-issue/scripts/launch-workmux
+++ b/dist/codex/plugins/create-worktree-from-issue/scripts/launch-workmux
@@ -87,17 +87,205 @@ function run_workmux_and_cleanup_prompt() {
   return "${status}"
 }
 
+function worktree_path_for_branch() {
+  local branch="${1}"
+  local line path="" branch_ref=""
+
+  while IFS= read -r line || [[ -n "${line}" ]]; do
+    case "${line}" in
+      worktree\ *)
+        path="${line#worktree }"
+        branch_ref=""
+        ;;
+      branch\ refs/heads/*)
+        branch_ref="${line#branch refs/heads/}"
+        ;;
+      "")
+        if [[ "${branch_ref}" == "${branch}" && -n "${path}" ]]; then
+          printf '%s' "${path}"
+          return 0
+        fi
+        path=""
+        branch_ref=""
+        ;;
+    esac
+  done < <(git worktree list --porcelain 2> /dev/null || true)
+
+  if [[ "${branch_ref}" == "${branch}" && -n "${path}" ]]; then
+    printf '%s' "${path}"
+    return 0
+  fi
+
+  return 1
+}
+
+function tmux_socket_candidates() {
+  local uid dir socket socket_dir
+  local -a dirs=()
+
+  uid="$(id -u)"
+  if [[ -n "${TMUX_TMPDIR:-}" ]]; then
+    dirs+=("${TMUX_TMPDIR}/tmux-${uid}")
+  fi
+  dirs+=("/tmp/tmux-${uid}" "/private/tmp/tmux-${uid}")
+
+  for dir in "${dirs[@]}"; do
+    [[ -d "${dir}" ]] || continue
+    for socket in "${dir}"/*; do
+      [[ -S "${socket}" ]] || continue
+      socket_dir="$(cd "$(dirname "${socket}")" && pwd -P)"
+      printf '%s/%s\n' "${socket_dir}" "$(basename "${socket}")"
+    done
+  done | sort -u
+}
+
+function resolved_tmux_env() {
+  if [[ -n "${TMUX:-}" ]]; then
+    printf '%s' "${TMUX}"
+    return
+  fi
+
+  if [[ -n "${WORKMUX_TMUX:-}" ]]; then
+    printf '%s' "${WORKMUX_TMUX}"
+    return
+  fi
+
+  command -v tmux > /dev/null || return
+
+  local cwd socket pane_id pane_command pane_path server_pid candidate
+  local count=0
+  cwd="$(pwd -P)"
+
+  while IFS= read -r socket; do
+    while IFS='|' read -r pane_id pane_command pane_path server_pid; do
+      if [[ -d "${pane_path}" ]]; then
+        pane_path="$(cd "${pane_path}" && pwd -P)"
+      fi
+      [[ "${pane_path}" == "${cwd}" ]] || continue
+
+      case "${pane_command}" in
+        codex* | cx) ;;
+        *) continue ;;
+      esac
+
+      candidate="${socket},${server_pid},${pane_id}"
+      count=$((count + 1))
+    done < <(tmux -S "${socket}" list-panes -a -F '#{pane_id}|#{pane_current_command}|#{pane_current_path}|#{pid}' 2> /dev/null || true)
+  done < <(tmux_socket_candidates)
+
+  if ((count == 1)); then
+    printf '%s' "${candidate}"
+  fi
+}
+
+function codex_pane_for_path() {
+  local tmux_env="${1}" worktree_path="${2}"
+  local pane_id pane_command pane_path candidate
+  local count=0
+
+  [[ -n "${tmux_env}" ]] || return 1
+  worktree_path="$(cd "${worktree_path}" && pwd -P)"
+
+  while IFS='|' read -r pane_id pane_command pane_path; do
+    if [[ -d "${pane_path}" ]]; then
+      pane_path="$(cd "${pane_path}" && pwd -P)"
+    fi
+    [[ "${pane_path}" == "${worktree_path}" ]] || continue
+
+    case "${pane_command}" in
+      codex* | cx) ;;
+      *) continue ;;
+    esac
+
+    candidate="${pane_id}"
+    count=$((count + 1))
+  done < <(env "TMUX=${tmux_env}" tmux list-panes -a -F '#{pane_id}|#{pane_current_command}|#{pane_current_path}' 2> /dev/null || true)
+
+  if ((count == 1)); then
+    printf '%s' "${candidate}"
+  fi
+}
+
+function send_prompt_to_codex_pane() {
+  local tmux_env="${1}" worktree_path="${2}" prompt_file="${3}" safe_name="${4}"
+  local pane_id buffer delay
+
+  [[ -s "${prompt_file}" ]] || return 0
+
+  pane_id="$(codex_pane_for_path "${tmux_env}" "${worktree_path}")"
+  if [[ -z "${pane_id}" ]]; then
+    return 0
+  fi
+
+  buffer="workmux-prompt-${safe_name}"
+  delay="${WORKMUX_CODEX_PROMPT_SUBMIT_DELAY_SECONDS:-0.5}"
+
+  env "TMUX=${tmux_env}" tmux load-buffer -b "${buffer}" "${prompt_file}"
+  env "TMUX=${tmux_env}" tmux paste-buffer -t "${pane_id}" -b "${buffer}"
+  sleep "${delay}"
+  env "TMUX=${tmux_env}" tmux send-keys -t "${pane_id}" Enter
+  sleep "${delay}"
+  env "TMUX=${tmux_env}" tmux send-keys -t "${pane_id}" Enter
+  printf 'Sent prompt to existing Codex pane for %s\n' "${worktree_path}"
+}
+
+function run_workmux_command() {
+  local -a command=(workmux "${@}")
+  local -a env_args=()
+  local tmux_env
+  tmux_env="$(resolved_tmux_env)"
+
+  if [[ -n "${tmux_env}" ]]; then
+    env_args+=("TMUX=${tmux_env}")
+  fi
+
+  if [[ -n "${WORKMUX_TERM:-}" ]]; then
+    env_args+=("TERM=${WORKMUX_TERM}")
+  elif [[ "${TERM:-}" == "dumb" && -n "${tmux_env}" ]]; then
+    env_args+=(TERM=tmux-256color)
+  fi
+
+  if ((${#env_args[@]} > 0)); then
+    env "${env_args[@]}" "${command[@]}"
+  else
+    "${command[@]}"
+  fi
+}
+
+function run_workmux_with_existing_prompt_fallback() {
+  local prompt_file="${1}" existing_worktree_path="${2}" safe_name="${3}"
+  local status tmux_env prompt_to_send
+  shift 3
+
+  set +e
+  run_workmux_command "${@}"
+  status=$?
+  set -e
+
+  if ((status == 0)) && [[ -n "${existing_worktree_path}" ]]; then
+    tmux_env="$(resolved_tmux_env)"
+    prompt_to_send="${existing_worktree_path}/.workmux/PROMPT-${safe_name}.md"
+    if [[ ! -s "${prompt_to_send}" ]]; then
+      prompt_to_send="${prompt_file}"
+    fi
+    send_prompt_to_codex_pane "${tmux_env}" "${existing_worktree_path}" "${prompt_to_send}" "${safe_name}" || true
+  fi
+
+  return "${status}"
+}
+
 function do_launch() {
   local branch="${1}"
   local safe_name="${branch//\//-}"
-  local log prompt_file
+  local existing_worktree_path log prompt_file
   prompt_file="$(mktemp "/tmp/workmux-prompt-${safe_name}.md.XXXXXX")"
 
   write_escaped_prompt "${prompt_file}"
+  existing_worktree_path="$(worktree_path_for_branch "${branch}" || true)"
 
   log="$(mktemp "/tmp/workmux-${safe_name}.log.XXXXXX")"
 
-  run_workmux_and_cleanup_prompt "${prompt_file}" workmux add "${branch}" --open-if-exists -P "${prompt_file}" > "${log}" 2>&1 &
+  run_workmux_and_cleanup_prompt "${prompt_file}" run_workmux_with_existing_prompt_fallback "${prompt_file}" "${existing_worktree_path}" "${safe_name}" add "${branch}" --open-if-exists -P "${prompt_file}" > "${log}" 2>&1 &
   disown
   sleep "${WORKMUX_LAUNCH_WAIT_SECONDS:-8}"
 

--- a/dist/codex/plugins/create-worktree-from-issue/scripts/launch-workmux
+++ b/dist/codex/plugins/create-worktree-from-issue/scripts/launch-workmux
@@ -150,7 +150,7 @@ function resolved_tmux_env() {
     return
   fi
 
-  command -v tmux > /dev/null || return
+  command -v tmux > /dev/null || return 0
 
   local cwd socket pane_id pane_command pane_path server_pid candidate
   local count=0
@@ -176,6 +176,8 @@ function resolved_tmux_env() {
   if ((count == 1)); then
     printf '%s' "${candidate}"
   fi
+
+  return 0
 }
 
 function codex_pane_for_path() {
@@ -183,7 +185,8 @@ function codex_pane_for_path() {
   local pane_id pane_command pane_path candidate
   local count=0
 
-  [[ -n "${tmux_env}" ]] || return 1
+  [[ -n "${tmux_env}" ]] || return 0
+  [[ -d "${worktree_path}" ]] || return 0
   worktree_path="$(cd "${worktree_path}" && pwd -P)"
 
   while IFS='|' read -r pane_id pane_command pane_path; do
@@ -204,6 +207,8 @@ function codex_pane_for_path() {
   if ((count == 1)); then
     printf '%s' "${candidate}"
   fi
+
+  return 0
 }
 
 function send_prompt_to_codex_pane() {
@@ -211,8 +216,9 @@ function send_prompt_to_codex_pane() {
   local pane_id buffer delay
 
   [[ -s "${prompt_file}" ]] || return 0
+  [[ -n "${tmux_env}" ]] || return 0
 
-  pane_id="$(codex_pane_for_path "${tmux_env}" "${worktree_path}")"
+  pane_id="$(codex_pane_for_path "${tmux_env}" "${worktree_path}" || true)"
   if [[ -z "${pane_id}" ]]; then
     return 0
   fi

--- a/dist/codex/plugins/create-worktree-from-issue/scripts/launch-workmux
+++ b/dist/codex/plugins/create-worktree-from-issue/scripts/launch-workmux
@@ -159,7 +159,9 @@ function resolved_tmux_env() {
   while IFS= read -r socket; do
     while IFS='|' read -r pane_id pane_command pane_path server_pid; do
       if [[ -d "${pane_path}" ]]; then
-        pane_path="$(cd "${pane_path}" && pwd -P)"
+        if ! pane_path="$(cd "${pane_path}" 2> /dev/null && pwd -P)"; then
+          continue
+        fi
       fi
       [[ "${pane_path}" == "${cwd}" ]] || continue
 
@@ -187,11 +189,15 @@ function codex_pane_for_path() {
 
   [[ -n "${tmux_env}" ]] || return 0
   [[ -d "${worktree_path}" ]] || return 0
-  worktree_path="$(cd "${worktree_path}" && pwd -P)"
+  if ! worktree_path="$(cd "${worktree_path}" 2> /dev/null && pwd -P)"; then
+    return 0
+  fi
 
   while IFS='|' read -r pane_id pane_command pane_path; do
     if [[ -d "${pane_path}" ]]; then
-      pane_path="$(cd "${pane_path}" && pwd -P)"
+      if ! pane_path="$(cd "${pane_path}" 2> /dev/null && pwd -P)"; then
+        continue
+      fi
     fi
     [[ "${pane_path}" == "${worktree_path}" ]] || continue
 
@@ -213,7 +219,7 @@ function codex_pane_for_path() {
 
 function send_prompt_to_codex_pane() {
   local tmux_env="${1}" worktree_path="${2}" prompt_file="${3}" safe_name="${4}"
-  local pane_id buffer delay
+  local pane_id buffer delay tmux_status
 
   [[ -s "${prompt_file}" ]] || return 0
   [[ -n "${tmux_env}" ]] || return 0
@@ -226,13 +232,32 @@ function send_prompt_to_codex_pane() {
   buffer="workmux-prompt-${safe_name}"
   delay="${WORKMUX_CODEX_PROMPT_SUBMIT_DELAY_SECONDS:-0.5}"
 
+  tmux_status=0
+  set +e
   env "TMUX=${tmux_env}" tmux load-buffer -b "${buffer}" "${prompt_file}"
-  env "TMUX=${tmux_env}" tmux paste-buffer -t "${pane_id}" -b "${buffer}"
-  sleep "${delay}"
-  env "TMUX=${tmux_env}" tmux send-keys -t "${pane_id}" Enter
-  sleep "${delay}"
-  env "TMUX=${tmux_env}" tmux send-keys -t "${pane_id}" Enter
-  printf 'Sent prompt to existing Codex pane for %s\n' "${worktree_path}"
+  tmux_status=$?
+  if ((tmux_status == 0)); then
+    env "TMUX=${tmux_env}" tmux paste-buffer -t "${pane_id}" -b "${buffer}"
+    tmux_status=$?
+  fi
+  if ((tmux_status == 0)); then
+    sleep "${delay}"
+    env "TMUX=${tmux_env}" tmux send-keys -t "${pane_id}" Enter
+    tmux_status=$?
+  fi
+  if ((tmux_status == 0)); then
+    sleep "${delay}"
+    env "TMUX=${tmux_env}" tmux send-keys -t "${pane_id}" Enter
+    tmux_status=$?
+  fi
+  env "TMUX=${tmux_env}" tmux delete-buffer -b "${buffer}" > /dev/null 2>&1
+  set -e
+
+  if ((tmux_status == 0)); then
+    printf 'Sent prompt to existing Codex pane for %s\n' "${worktree_path}"
+  fi
+
+  return 0
 }
 
 function run_workmux_command() {

--- a/dist/codex/plugins/create-worktree/.claude-plugin/plugin.json
+++ b/dist/codex/plugins/create-worktree/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "name": "create-worktree",
   "repository": "https://github.com/cboone/agent-harness-plugins",
   "skills": "./skills",
-  "version": "1.1.2"
+  "version": "1.1.3"
 }

--- a/dist/codex/plugins/create-worktree/scripts/launch-workmux
+++ b/dist/codex/plugins/create-worktree/scripts/launch-workmux
@@ -119,7 +119,7 @@ function resolved_tmux_env() {
     return
   fi
 
-  command -v tmux > /dev/null || return
+  command -v tmux > /dev/null || return 0
 
   local cwd socket pane_id pane_command pane_path server_pid candidate
   local count=0
@@ -145,6 +145,8 @@ function resolved_tmux_env() {
   if ((count == 1)); then
     printf '%s' "${candidate}"
   fi
+
+  return 0
 }
 
 function run_workmux_command() {

--- a/dist/codex/plugins/create-worktree/scripts/launch-workmux
+++ b/dist/codex/plugins/create-worktree/scripts/launch-workmux
@@ -88,6 +88,88 @@ function run_workmux_and_cleanup_prompt() {
   return "${status}"
 }
 
+function tmux_socket_candidates() {
+  local uid dir socket socket_dir
+  local -a dirs=()
+
+  uid="$(id -u)"
+  if [[ -n "${TMUX_TMPDIR:-}" ]]; then
+    dirs+=("${TMUX_TMPDIR}/tmux-${uid}")
+  fi
+  dirs+=("/tmp/tmux-${uid}" "/private/tmp/tmux-${uid}")
+
+  for dir in "${dirs[@]}"; do
+    [[ -d "${dir}" ]] || continue
+    for socket in "${dir}"/*; do
+      [[ -S "${socket}" ]] || continue
+      socket_dir="$(cd "$(dirname "${socket}")" && pwd -P)"
+      printf '%s/%s\n' "${socket_dir}" "$(basename "${socket}")"
+    done
+  done | sort -u
+}
+
+function resolved_tmux_env() {
+  if [[ -n "${TMUX:-}" ]]; then
+    printf '%s' "${TMUX}"
+    return
+  fi
+
+  if [[ -n "${WORKMUX_TMUX:-}" ]]; then
+    printf '%s' "${WORKMUX_TMUX}"
+    return
+  fi
+
+  command -v tmux > /dev/null || return
+
+  local cwd socket pane_id pane_command pane_path server_pid candidate
+  local count=0
+  cwd="$(pwd -P)"
+
+  while IFS= read -r socket; do
+    while IFS='|' read -r pane_id pane_command pane_path server_pid; do
+      if [[ -d "${pane_path}" ]]; then
+        pane_path="$(cd "${pane_path}" && pwd -P)"
+      fi
+      [[ "${pane_path}" == "${cwd}" ]] || continue
+
+      case "${pane_command}" in
+        codex* | cx) ;;
+        *) continue ;;
+      esac
+
+      candidate="${socket},${server_pid},${pane_id}"
+      count=$((count + 1))
+    done < <(tmux -S "${socket}" list-panes -a -F '#{pane_id}|#{pane_current_command}|#{pane_current_path}|#{pid}' 2> /dev/null || true)
+  done < <(tmux_socket_candidates)
+
+  if ((count == 1)); then
+    printf '%s' "${candidate}"
+  fi
+}
+
+function run_workmux_command() {
+  local -a command=(workmux "${@}")
+  local -a env_args=()
+  local tmux_env
+  tmux_env="$(resolved_tmux_env)"
+
+  if [[ -n "${tmux_env}" ]]; then
+    env_args+=("TMUX=${tmux_env}")
+  fi
+
+  if [[ -n "${WORKMUX_TERM:-}" ]]; then
+    env_args+=("TERM=${WORKMUX_TERM}")
+  elif [[ "${TERM:-}" == "dumb" && -n "${tmux_env}" ]]; then
+    env_args+=(TERM=tmux-256color)
+  fi
+
+  if ((${#env_args[@]} > 0)); then
+    env "${env_args[@]}" "${command[@]}"
+  else
+    "${command[@]}"
+  fi
+}
+
 function do_launch() {
   local branch="${1}"
   local base_branch="${2:-}"
@@ -99,7 +181,7 @@ function do_launch() {
 
   log="$(mktemp "/tmp/workmux-${safe_name}.log.XXXXXX")"
 
-  local -a cmd=(workmux add "${branch}" --open-if-exists -P "${prompt_file}")
+  local -a cmd=(run_workmux_command add "${branch}" --open-if-exists -P "${prompt_file}")
   if [[ -n "${base_branch}" ]]; then
     cmd+=(--base "${base_branch}")
   fi

--- a/dist/codex/plugins/create-worktree/scripts/launch-workmux
+++ b/dist/codex/plugins/create-worktree/scripts/launch-workmux
@@ -128,7 +128,9 @@ function resolved_tmux_env() {
   while IFS= read -r socket; do
     while IFS='|' read -r pane_id pane_command pane_path server_pid; do
       if [[ -d "${pane_path}" ]]; then
-        pane_path="$(cd "${pane_path}" && pwd -P)"
+        if ! pane_path="$(cd "${pane_path}" 2> /dev/null && pwd -P)"; then
+          continue
+        fi
       fi
       [[ "${pane_path}" == "${cwd}" ]] || continue
 

--- a/plugins/create-worktree-from-issue/.claude-plugin/plugin.json
+++ b/plugins/create-worktree-from-issue/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "name": "create-worktree-from-issue",
   "repository": "https://github.com/cboone/agent-harness-plugins",
   "skills": "./skills",
-  "version": "1.3.3"
+  "version": "1.3.4"
 }

--- a/plugins/create-worktree-from-issue/scripts/launch-workmux
+++ b/plugins/create-worktree-from-issue/scripts/launch-workmux
@@ -87,17 +87,205 @@ function run_workmux_and_cleanup_prompt() {
   return "${status}"
 }
 
+function worktree_path_for_branch() {
+  local branch="${1}"
+  local line path="" branch_ref=""
+
+  while IFS= read -r line || [[ -n "${line}" ]]; do
+    case "${line}" in
+      worktree\ *)
+        path="${line#worktree }"
+        branch_ref=""
+        ;;
+      branch\ refs/heads/*)
+        branch_ref="${line#branch refs/heads/}"
+        ;;
+      "")
+        if [[ "${branch_ref}" == "${branch}" && -n "${path}" ]]; then
+          printf '%s' "${path}"
+          return 0
+        fi
+        path=""
+        branch_ref=""
+        ;;
+    esac
+  done < <(git worktree list --porcelain 2> /dev/null || true)
+
+  if [[ "${branch_ref}" == "${branch}" && -n "${path}" ]]; then
+    printf '%s' "${path}"
+    return 0
+  fi
+
+  return 1
+}
+
+function tmux_socket_candidates() {
+  local uid dir socket socket_dir
+  local -a dirs=()
+
+  uid="$(id -u)"
+  if [[ -n "${TMUX_TMPDIR:-}" ]]; then
+    dirs+=("${TMUX_TMPDIR}/tmux-${uid}")
+  fi
+  dirs+=("/tmp/tmux-${uid}" "/private/tmp/tmux-${uid}")
+
+  for dir in "${dirs[@]}"; do
+    [[ -d "${dir}" ]] || continue
+    for socket in "${dir}"/*; do
+      [[ -S "${socket}" ]] || continue
+      socket_dir="$(cd "$(dirname "${socket}")" && pwd -P)"
+      printf '%s/%s\n' "${socket_dir}" "$(basename "${socket}")"
+    done
+  done | sort -u
+}
+
+function resolved_tmux_env() {
+  if [[ -n "${TMUX:-}" ]]; then
+    printf '%s' "${TMUX}"
+    return
+  fi
+
+  if [[ -n "${WORKMUX_TMUX:-}" ]]; then
+    printf '%s' "${WORKMUX_TMUX}"
+    return
+  fi
+
+  command -v tmux > /dev/null || return
+
+  local cwd socket pane_id pane_command pane_path server_pid candidate
+  local count=0
+  cwd="$(pwd -P)"
+
+  while IFS= read -r socket; do
+    while IFS='|' read -r pane_id pane_command pane_path server_pid; do
+      if [[ -d "${pane_path}" ]]; then
+        pane_path="$(cd "${pane_path}" && pwd -P)"
+      fi
+      [[ "${pane_path}" == "${cwd}" ]] || continue
+
+      case "${pane_command}" in
+        codex* | cx) ;;
+        *) continue ;;
+      esac
+
+      candidate="${socket},${server_pid},${pane_id}"
+      count=$((count + 1))
+    done < <(tmux -S "${socket}" list-panes -a -F '#{pane_id}|#{pane_current_command}|#{pane_current_path}|#{pid}' 2> /dev/null || true)
+  done < <(tmux_socket_candidates)
+
+  if ((count == 1)); then
+    printf '%s' "${candidate}"
+  fi
+}
+
+function codex_pane_for_path() {
+  local tmux_env="${1}" worktree_path="${2}"
+  local pane_id pane_command pane_path candidate
+  local count=0
+
+  [[ -n "${tmux_env}" ]] || return 1
+  worktree_path="$(cd "${worktree_path}" && pwd -P)"
+
+  while IFS='|' read -r pane_id pane_command pane_path; do
+    if [[ -d "${pane_path}" ]]; then
+      pane_path="$(cd "${pane_path}" && pwd -P)"
+    fi
+    [[ "${pane_path}" == "${worktree_path}" ]] || continue
+
+    case "${pane_command}" in
+      codex* | cx) ;;
+      *) continue ;;
+    esac
+
+    candidate="${pane_id}"
+    count=$((count + 1))
+  done < <(env "TMUX=${tmux_env}" tmux list-panes -a -F '#{pane_id}|#{pane_current_command}|#{pane_current_path}' 2> /dev/null || true)
+
+  if ((count == 1)); then
+    printf '%s' "${candidate}"
+  fi
+}
+
+function send_prompt_to_codex_pane() {
+  local tmux_env="${1}" worktree_path="${2}" prompt_file="${3}" safe_name="${4}"
+  local pane_id buffer delay
+
+  [[ -s "${prompt_file}" ]] || return 0
+
+  pane_id="$(codex_pane_for_path "${tmux_env}" "${worktree_path}")"
+  if [[ -z "${pane_id}" ]]; then
+    return 0
+  fi
+
+  buffer="workmux-prompt-${safe_name}"
+  delay="${WORKMUX_CODEX_PROMPT_SUBMIT_DELAY_SECONDS:-0.5}"
+
+  env "TMUX=${tmux_env}" tmux load-buffer -b "${buffer}" "${prompt_file}"
+  env "TMUX=${tmux_env}" tmux paste-buffer -t "${pane_id}" -b "${buffer}"
+  sleep "${delay}"
+  env "TMUX=${tmux_env}" tmux send-keys -t "${pane_id}" Enter
+  sleep "${delay}"
+  env "TMUX=${tmux_env}" tmux send-keys -t "${pane_id}" Enter
+  printf 'Sent prompt to existing Codex pane for %s\n' "${worktree_path}"
+}
+
+function run_workmux_command() {
+  local -a command=(workmux "${@}")
+  local -a env_args=()
+  local tmux_env
+  tmux_env="$(resolved_tmux_env)"
+
+  if [[ -n "${tmux_env}" ]]; then
+    env_args+=("TMUX=${tmux_env}")
+  fi
+
+  if [[ -n "${WORKMUX_TERM:-}" ]]; then
+    env_args+=("TERM=${WORKMUX_TERM}")
+  elif [[ "${TERM:-}" == "dumb" && -n "${tmux_env}" ]]; then
+    env_args+=(TERM=tmux-256color)
+  fi
+
+  if ((${#env_args[@]} > 0)); then
+    env "${env_args[@]}" "${command[@]}"
+  else
+    "${command[@]}"
+  fi
+}
+
+function run_workmux_with_existing_prompt_fallback() {
+  local prompt_file="${1}" existing_worktree_path="${2}" safe_name="${3}"
+  local status tmux_env prompt_to_send
+  shift 3
+
+  set +e
+  run_workmux_command "${@}"
+  status=$?
+  set -e
+
+  if ((status == 0)) && [[ -n "${existing_worktree_path}" ]]; then
+    tmux_env="$(resolved_tmux_env)"
+    prompt_to_send="${existing_worktree_path}/.workmux/PROMPT-${safe_name}.md"
+    if [[ ! -s "${prompt_to_send}" ]]; then
+      prompt_to_send="${prompt_file}"
+    fi
+    send_prompt_to_codex_pane "${tmux_env}" "${existing_worktree_path}" "${prompt_to_send}" "${safe_name}" || true
+  fi
+
+  return "${status}"
+}
+
 function do_launch() {
   local branch="${1}"
   local safe_name="${branch//\//-}"
-  local log prompt_file
+  local existing_worktree_path log prompt_file
   prompt_file="$(mktemp "/tmp/workmux-prompt-${safe_name}.md.XXXXXX")"
 
   write_escaped_prompt "${prompt_file}"
+  existing_worktree_path="$(worktree_path_for_branch "${branch}" || true)"
 
   log="$(mktemp "/tmp/workmux-${safe_name}.log.XXXXXX")"
 
-  run_workmux_and_cleanup_prompt "${prompt_file}" workmux add "${branch}" --open-if-exists -P "${prompt_file}" > "${log}" 2>&1 &
+  run_workmux_and_cleanup_prompt "${prompt_file}" run_workmux_with_existing_prompt_fallback "${prompt_file}" "${existing_worktree_path}" "${safe_name}" add "${branch}" --open-if-exists -P "${prompt_file}" > "${log}" 2>&1 &
   disown
   sleep "${WORKMUX_LAUNCH_WAIT_SECONDS:-8}"
 

--- a/plugins/create-worktree-from-issue/scripts/launch-workmux
+++ b/plugins/create-worktree-from-issue/scripts/launch-workmux
@@ -150,7 +150,7 @@ function resolved_tmux_env() {
     return
   fi
 
-  command -v tmux > /dev/null || return
+  command -v tmux > /dev/null || return 0
 
   local cwd socket pane_id pane_command pane_path server_pid candidate
   local count=0
@@ -176,6 +176,8 @@ function resolved_tmux_env() {
   if ((count == 1)); then
     printf '%s' "${candidate}"
   fi
+
+  return 0
 }
 
 function codex_pane_for_path() {
@@ -183,7 +185,8 @@ function codex_pane_for_path() {
   local pane_id pane_command pane_path candidate
   local count=0
 
-  [[ -n "${tmux_env}" ]] || return 1
+  [[ -n "${tmux_env}" ]] || return 0
+  [[ -d "${worktree_path}" ]] || return 0
   worktree_path="$(cd "${worktree_path}" && pwd -P)"
 
   while IFS='|' read -r pane_id pane_command pane_path; do
@@ -204,6 +207,8 @@ function codex_pane_for_path() {
   if ((count == 1)); then
     printf '%s' "${candidate}"
   fi
+
+  return 0
 }
 
 function send_prompt_to_codex_pane() {
@@ -211,8 +216,9 @@ function send_prompt_to_codex_pane() {
   local pane_id buffer delay
 
   [[ -s "${prompt_file}" ]] || return 0
+  [[ -n "${tmux_env}" ]] || return 0
 
-  pane_id="$(codex_pane_for_path "${tmux_env}" "${worktree_path}")"
+  pane_id="$(codex_pane_for_path "${tmux_env}" "${worktree_path}" || true)"
   if [[ -z "${pane_id}" ]]; then
     return 0
   fi

--- a/plugins/create-worktree-from-issue/scripts/launch-workmux
+++ b/plugins/create-worktree-from-issue/scripts/launch-workmux
@@ -159,7 +159,9 @@ function resolved_tmux_env() {
   while IFS= read -r socket; do
     while IFS='|' read -r pane_id pane_command pane_path server_pid; do
       if [[ -d "${pane_path}" ]]; then
-        pane_path="$(cd "${pane_path}" && pwd -P)"
+        if ! pane_path="$(cd "${pane_path}" 2> /dev/null && pwd -P)"; then
+          continue
+        fi
       fi
       [[ "${pane_path}" == "${cwd}" ]] || continue
 
@@ -187,11 +189,15 @@ function codex_pane_for_path() {
 
   [[ -n "${tmux_env}" ]] || return 0
   [[ -d "${worktree_path}" ]] || return 0
-  worktree_path="$(cd "${worktree_path}" && pwd -P)"
+  if ! worktree_path="$(cd "${worktree_path}" 2> /dev/null && pwd -P)"; then
+    return 0
+  fi
 
   while IFS='|' read -r pane_id pane_command pane_path; do
     if [[ -d "${pane_path}" ]]; then
-      pane_path="$(cd "${pane_path}" && pwd -P)"
+      if ! pane_path="$(cd "${pane_path}" 2> /dev/null && pwd -P)"; then
+        continue
+      fi
     fi
     [[ "${pane_path}" == "${worktree_path}" ]] || continue
 
@@ -213,7 +219,7 @@ function codex_pane_for_path() {
 
 function send_prompt_to_codex_pane() {
   local tmux_env="${1}" worktree_path="${2}" prompt_file="${3}" safe_name="${4}"
-  local pane_id buffer delay
+  local pane_id buffer delay tmux_status
 
   [[ -s "${prompt_file}" ]] || return 0
   [[ -n "${tmux_env}" ]] || return 0
@@ -226,13 +232,32 @@ function send_prompt_to_codex_pane() {
   buffer="workmux-prompt-${safe_name}"
   delay="${WORKMUX_CODEX_PROMPT_SUBMIT_DELAY_SECONDS:-0.5}"
 
+  tmux_status=0
+  set +e
   env "TMUX=${tmux_env}" tmux load-buffer -b "${buffer}" "${prompt_file}"
-  env "TMUX=${tmux_env}" tmux paste-buffer -t "${pane_id}" -b "${buffer}"
-  sleep "${delay}"
-  env "TMUX=${tmux_env}" tmux send-keys -t "${pane_id}" Enter
-  sleep "${delay}"
-  env "TMUX=${tmux_env}" tmux send-keys -t "${pane_id}" Enter
-  printf 'Sent prompt to existing Codex pane for %s\n' "${worktree_path}"
+  tmux_status=$?
+  if ((tmux_status == 0)); then
+    env "TMUX=${tmux_env}" tmux paste-buffer -t "${pane_id}" -b "${buffer}"
+    tmux_status=$?
+  fi
+  if ((tmux_status == 0)); then
+    sleep "${delay}"
+    env "TMUX=${tmux_env}" tmux send-keys -t "${pane_id}" Enter
+    tmux_status=$?
+  fi
+  if ((tmux_status == 0)); then
+    sleep "${delay}"
+    env "TMUX=${tmux_env}" tmux send-keys -t "${pane_id}" Enter
+    tmux_status=$?
+  fi
+  env "TMUX=${tmux_env}" tmux delete-buffer -b "${buffer}" > /dev/null 2>&1
+  set -e
+
+  if ((tmux_status == 0)); then
+    printf 'Sent prompt to existing Codex pane for %s\n' "${worktree_path}"
+  fi
+
+  return 0
 }
 
 function run_workmux_command() {

--- a/plugins/create-worktree/.claude-plugin/plugin.json
+++ b/plugins/create-worktree/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "name": "create-worktree",
   "repository": "https://github.com/cboone/agent-harness-plugins",
   "skills": "./skills",
-  "version": "1.1.2"
+  "version": "1.1.3"
 }

--- a/plugins/create-worktree/scripts/launch-workmux
+++ b/plugins/create-worktree/scripts/launch-workmux
@@ -119,7 +119,7 @@ function resolved_tmux_env() {
     return
   fi
 
-  command -v tmux > /dev/null || return
+  command -v tmux > /dev/null || return 0
 
   local cwd socket pane_id pane_command pane_path server_pid candidate
   local count=0
@@ -145,6 +145,8 @@ function resolved_tmux_env() {
   if ((count == 1)); then
     printf '%s' "${candidate}"
   fi
+
+  return 0
 }
 
 function run_workmux_command() {

--- a/plugins/create-worktree/scripts/launch-workmux
+++ b/plugins/create-worktree/scripts/launch-workmux
@@ -88,6 +88,88 @@ function run_workmux_and_cleanup_prompt() {
   return "${status}"
 }
 
+function tmux_socket_candidates() {
+  local uid dir socket socket_dir
+  local -a dirs=()
+
+  uid="$(id -u)"
+  if [[ -n "${TMUX_TMPDIR:-}" ]]; then
+    dirs+=("${TMUX_TMPDIR}/tmux-${uid}")
+  fi
+  dirs+=("/tmp/tmux-${uid}" "/private/tmp/tmux-${uid}")
+
+  for dir in "${dirs[@]}"; do
+    [[ -d "${dir}" ]] || continue
+    for socket in "${dir}"/*; do
+      [[ -S "${socket}" ]] || continue
+      socket_dir="$(cd "$(dirname "${socket}")" && pwd -P)"
+      printf '%s/%s\n' "${socket_dir}" "$(basename "${socket}")"
+    done
+  done | sort -u
+}
+
+function resolved_tmux_env() {
+  if [[ -n "${TMUX:-}" ]]; then
+    printf '%s' "${TMUX}"
+    return
+  fi
+
+  if [[ -n "${WORKMUX_TMUX:-}" ]]; then
+    printf '%s' "${WORKMUX_TMUX}"
+    return
+  fi
+
+  command -v tmux > /dev/null || return
+
+  local cwd socket pane_id pane_command pane_path server_pid candidate
+  local count=0
+  cwd="$(pwd -P)"
+
+  while IFS= read -r socket; do
+    while IFS='|' read -r pane_id pane_command pane_path server_pid; do
+      if [[ -d "${pane_path}" ]]; then
+        pane_path="$(cd "${pane_path}" && pwd -P)"
+      fi
+      [[ "${pane_path}" == "${cwd}" ]] || continue
+
+      case "${pane_command}" in
+        codex* | cx) ;;
+        *) continue ;;
+      esac
+
+      candidate="${socket},${server_pid},${pane_id}"
+      count=$((count + 1))
+    done < <(tmux -S "${socket}" list-panes -a -F '#{pane_id}|#{pane_current_command}|#{pane_current_path}|#{pid}' 2> /dev/null || true)
+  done < <(tmux_socket_candidates)
+
+  if ((count == 1)); then
+    printf '%s' "${candidate}"
+  fi
+}
+
+function run_workmux_command() {
+  local -a command=(workmux "${@}")
+  local -a env_args=()
+  local tmux_env
+  tmux_env="$(resolved_tmux_env)"
+
+  if [[ -n "${tmux_env}" ]]; then
+    env_args+=("TMUX=${tmux_env}")
+  fi
+
+  if [[ -n "${WORKMUX_TERM:-}" ]]; then
+    env_args+=("TERM=${WORKMUX_TERM}")
+  elif [[ "${TERM:-}" == "dumb" && -n "${tmux_env}" ]]; then
+    env_args+=(TERM=tmux-256color)
+  fi
+
+  if ((${#env_args[@]} > 0)); then
+    env "${env_args[@]}" "${command[@]}"
+  else
+    "${command[@]}"
+  fi
+}
+
 function do_launch() {
   local branch="${1}"
   local base_branch="${2:-}"
@@ -99,7 +181,7 @@ function do_launch() {
 
   log="$(mktemp "/tmp/workmux-${safe_name}.log.XXXXXX")"
 
-  local -a cmd=(workmux add "${branch}" --open-if-exists -P "${prompt_file}")
+  local -a cmd=(run_workmux_command add "${branch}" --open-if-exists -P "${prompt_file}")
   if [[ -n "${base_branch}" ]]; then
     cmd+=(--base "${base_branch}")
   fi

--- a/plugins/create-worktree/scripts/launch-workmux
+++ b/plugins/create-worktree/scripts/launch-workmux
@@ -128,7 +128,9 @@ function resolved_tmux_env() {
   while IFS= read -r socket; do
     while IFS='|' read -r pane_id pane_command pane_path server_pid; do
       if [[ -d "${pane_path}" ]]; then
-        pane_path="$(cd "${pane_path}" && pwd -P)"
+        if ! pane_path="$(cd "${pane_path}" 2> /dev/null && pwd -P)"; then
+          continue
+        fi
       fi
       [[ "${pane_path}" == "${cwd}" ]] || continue
 

--- a/tests/fixtures/create-unix-socket
+++ b/tests/fixtures/create-unix-socket
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# create-unix-socket -- Create a live Unix socket for launcher tests.
+set -euo pipefail
+
+SCRIPT_NAME="$(basename "$0")"
+readonly SCRIPT_NAME
+
+function die() {
+  echo "${SCRIPT_NAME}: ${1}" >&2
+  exit "${2:-1}"
+}
+
+function start_socket_server() {
+  local socket_path="${1}"
+
+  if command -v ruby > /dev/null; then
+    ruby -rsocket -e 'socket_path = ARGV.fetch(0); server = UNIXServer.new(socket_path); cleanup = proc { server.close rescue nil; File.unlink(socket_path) rescue nil; exit 0 }; trap("TERM", &cleanup); trap("INT", &cleanup); sleep' "${socket_path}" > /dev/null 2>&1 &
+    printf '%s\n' "$!"
+    return 0
+  fi
+
+  if command -v perl > /dev/null; then
+    perl -MIO::Socket::UNIX -MSocket=SOCK_STREAM -e 'use strict; use warnings; my $socket_path = shift @ARGV; my $server = IO::Socket::UNIX->new(Type => SOCK_STREAM, Local => $socket_path, Listen => 1) or die "$!\n"; $SIG{TERM} = sub { close $server; unlink $socket_path; exit 0 }; $SIG{INT} = $SIG{TERM}; sleep 1 while 1;' "${socket_path}" > /dev/null 2>&1 &
+    printf '%s\n' "$!"
+    return 0
+  fi
+
+  die "ruby or perl is required to create a Unix socket"
+}
+
+function main() {
+  if [[ $# -ne 1 ]]; then
+    die "usage: ${SCRIPT_NAME} <socket-path>"
+  fi
+
+  local socket_path="${1}"
+  local socket_dir pid attempts_remaining
+  socket_dir="${socket_path%/*}"
+  if [[ "${socket_dir}" == "${socket_path}" ]]; then
+    socket_dir="."
+  fi
+
+  mkdir -p "${socket_dir}"
+  if [[ -e "${socket_path}" || -L "${socket_path}" ]]; then
+    die "socket path already exists: ${socket_path}"
+  fi
+
+  pid="$(start_socket_server "${socket_path}")"
+  attempts_remaining=50
+  while ((attempts_remaining > 0)); do
+    if [[ -S "${socket_path}" ]]; then
+      printf '%s\n' "${pid}"
+      return 0
+    fi
+    attempts_remaining=$((attempts_remaining - 1))
+    sleep 0.1
+  done
+
+  kill "${pid}" 2> /dev/null || true
+  die "socket was not created: ${socket_path}"
+}
+
+main "$@"

--- a/tests/fixtures/git-worktree-stub
+++ b/tests/fixtures/git-worktree-stub
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# git-worktree-stub -- Test stub for git worktree list.
+set -euo pipefail
+
+SCRIPT_NAME="$(basename "$0")"
+readonly SCRIPT_NAME
+
+function die() {
+  echo "${SCRIPT_NAME}: ${1}" >&2
+  exit "${2:-1}"
+}
+
+function main() {
+  if [[ $# -eq 3 && "${1}" == "worktree" && "${2}" == "list" && "${3}" == "--porcelain" ]]; then
+    printf '%s' "${STUB_GIT_WORKTREE_PORCELAIN:-}"
+    return 0
+  fi
+
+  die "expected git worktree list --porcelain invocation"
+}
+
+main "$@"

--- a/tests/fixtures/tmux-stub
+++ b/tests/fixtures/tmux-stub
@@ -39,6 +39,142 @@ function list_panes() {
   done <<< "${STUB_TMUX_PANES:-}"
 }
 
+function record_tmux_call() {
+  if [[ -n "${STUB_TMUX_LOG:-}" ]]; then
+    printf '%s\n' "${1}" >> "${STUB_TMUX_LOG}"
+  fi
+}
+
+function maybe_fail_command() {
+  local command_name="${1}"
+
+  if [[ "${STUB_TMUX_FAIL_COMMAND:-}" == "${command_name}" ]]; then
+    return 1
+  fi
+
+  return 0
+}
+
+function load_buffer() {
+  local socket="${1}"
+  local buffer="" file=""
+  shift
+
+  while [[ $# -gt 0 ]]; do
+    case "${1}" in
+      -b)
+        if [[ $# -lt 2 ]]; then
+          die "-b requires a buffer name"
+        fi
+        buffer="${2}"
+        shift 2
+        ;;
+      *)
+        if [[ -z "${file}" ]]; then
+          file="${1}"
+          shift
+        else
+          die "unexpected load-buffer argument: ${1}"
+        fi
+        ;;
+    esac
+  done
+
+  [[ -n "${buffer}" ]] || die "missing load-buffer -b"
+  [[ -n "${file}" ]] || die "missing load-buffer file"
+  record_tmux_call "tmux: load-buffer socket=${socket} buffer=${buffer} file=${file}"
+  maybe_fail_command "load-buffer"
+}
+
+function paste_buffer() {
+  local socket="${1}"
+  local target="" buffer=""
+  shift
+
+  while [[ $# -gt 0 ]]; do
+    case "${1}" in
+      -t)
+        if [[ $# -lt 2 ]]; then
+          die "-t requires a target"
+        fi
+        target="${2}"
+        shift 2
+        ;;
+      -b)
+        if [[ $# -lt 2 ]]; then
+          die "-b requires a buffer name"
+        fi
+        buffer="${2}"
+        shift 2
+        ;;
+      *)
+        die "unexpected paste-buffer argument: ${1}"
+        ;;
+    esac
+  done
+
+  [[ -n "${target}" ]] || die "missing paste-buffer -t"
+  [[ -n "${buffer}" ]] || die "missing paste-buffer -b"
+  record_tmux_call "tmux: paste-buffer socket=${socket} target=${target} buffer=${buffer}"
+  maybe_fail_command "paste-buffer"
+}
+
+function send_keys() {
+  local socket="${1}"
+  local target="" keys=""
+  shift
+
+  while [[ $# -gt 0 ]]; do
+    case "${1}" in
+      -t)
+        if [[ $# -lt 2 ]]; then
+          die "-t requires a target"
+        fi
+        target="${2}"
+        shift 2
+        ;;
+      *)
+        if [[ -z "${keys}" ]]; then
+          keys="${1}"
+        else
+          keys="${keys} ${1}"
+        fi
+        shift
+        ;;
+    esac
+  done
+
+  [[ -n "${target}" ]] || die "missing send-keys -t"
+  [[ -n "${keys}" ]] || die "missing send-keys keys"
+  record_tmux_call "tmux: send-keys socket=${socket} target=${target} keys=${keys}"
+  maybe_fail_command "send-keys"
+}
+
+function delete_buffer() {
+  local socket="${1}"
+  local buffer=""
+  shift
+
+  while [[ $# -gt 0 ]]; do
+    case "${1}" in
+      -b)
+        if [[ $# -lt 2 ]]; then
+          die "-b requires a buffer name"
+        fi
+        buffer="${2}"
+        shift 2
+        ;;
+      *)
+        die "unexpected delete-buffer argument: ${1}"
+        ;;
+    esac
+  done
+
+  [[ -n "${buffer}" ]] || die "missing delete-buffer -b"
+  record_tmux_call "tmux: delete-buffer socket=${socket} buffer=${buffer}"
+  maybe_fail_command "delete-buffer"
+}
+
 function main() {
   local socket="" command_name="" format=""
 
@@ -54,9 +190,13 @@ function main() {
 
   while [[ $# -gt 0 ]]; do
     case "${1}" in
-      list-panes)
+      list-panes | load-buffer | paste-buffer | send-keys | delete-buffer)
         command_name="${1}"
         shift
+        if [[ "${command_name}" != "list-panes" ]]; then
+          "${command_name//-/_}" "${socket}" "${@}"
+          return
+        fi
         ;;
       -a)
         shift

--- a/tests/fixtures/tmux-stub
+++ b/tests/fixtures/tmux-stub
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# tmux-stub -- Test stub for tmux pane discovery.
+set -euo pipefail
+
+SCRIPT_NAME="$(basename "$0")"
+readonly SCRIPT_NAME
+
+function die() {
+  echo "${SCRIPT_NAME}: ${1}" >&2
+  exit "${2:-1}"
+}
+
+function socket_from_tmux_env() {
+  local tmux_env="${TMUX:-}"
+
+  if [[ -n "${tmux_env}" ]]; then
+    printf '%s' "${tmux_env%%,*}"
+  fi
+}
+
+function list_panes() {
+  local socket="${1}"
+  local format="${2}"
+  local line pane_socket pane_id pane_command pane_path server_pid
+
+  while IFS= read -r line || [[ -n "${line}" ]]; do
+    [[ -n "${line}" ]] || continue
+    IFS='|' read -r pane_socket pane_id pane_command pane_path server_pid <<< "${line}"
+    [[ -n "${pane_socket}" && -n "${pane_id}" && -n "${pane_command}" && -n "${pane_path}" && -n "${server_pid}" ]] || continue
+    if [[ -n "${socket}" && "${pane_socket}" != "${socket}" ]]; then
+      continue
+    fi
+
+    if [[ "${format}" == *'#{pid}'* ]]; then
+      printf '%s|%s|%s|%s\n' "${pane_id}" "${pane_command}" "${pane_path}" "${server_pid}"
+    else
+      printf '%s|%s|%s\n' "${pane_id}" "${pane_command}" "${pane_path}"
+    fi
+  done <<< "${STUB_TMUX_PANES:-}"
+}
+
+function main() {
+  local socket="" command_name="" format=""
+
+  if [[ "${1:-}" == "-S" ]]; then
+    if [[ $# -lt 2 ]]; then
+      die "-S requires a socket path"
+    fi
+    socket="${2}"
+    shift 2
+  else
+    socket="$(socket_from_tmux_env)"
+  fi
+
+  while [[ $# -gt 0 ]]; do
+    case "${1}" in
+      list-panes)
+        command_name="${1}"
+        shift
+        ;;
+      -a)
+        shift
+        ;;
+      -F)
+        if [[ $# -lt 2 ]]; then
+          die "-F requires a format"
+        fi
+        format="${2}"
+        shift 2
+        ;;
+      *)
+        die "unexpected argument: ${1}"
+        ;;
+    esac
+  done
+
+  if [[ "${command_name}" != "list-panes" ]]; then
+    die "expected tmux list-panes invocation"
+  fi
+  if [[ -z "${format}" ]]; then
+    die "missing -F format"
+  fi
+
+  list_panes "${socket}" "${format}"
+}
+
+main "$@"

--- a/tests/fixtures/workmux-stub
+++ b/tests/fixtures/workmux-stub
@@ -56,6 +56,12 @@ function main() {
   printf 'workmux add\n'
   printf 'branch: %s\n' "${branch}"
   printf 'open-if-exists: %s\n' "${open_if_exists}"
+  if [[ "${STUB_CAPTURE_TERM:-}" == "1" ]]; then
+    printf 'term: %s\n' "${TERM:-}"
+  fi
+  if [[ "${STUB_CAPTURE_TMUX:-}" == "1" ]]; then
+    printf 'tmux: %s\n' "${TMUX:-}"
+  fi
   if [[ -n "${base_branch}" ]]; then
     printf 'base: %s\n' "${base_branch}"
   fi

--- a/tests/fixtures/workmux-stub
+++ b/tests/fixtures/workmux-stub
@@ -57,10 +57,10 @@ function main() {
   printf 'branch: %s\n' "${branch}"
   printf 'open-if-exists: %s\n' "${open_if_exists}"
   if [[ "${STUB_CAPTURE_TERM:-}" == "1" ]]; then
-    printf 'term: %s\n' "${TERM:-}"
+    printf 'term: %s\n' "${TERM:-<unset>}"
   fi
   if [[ "${STUB_CAPTURE_TMUX:-}" == "1" ]]; then
-    printf 'tmux: %s\n' "${TMUX:-}"
+    printf 'tmux: %s\n' "${TMUX:-<unset>}"
   fi
   if [[ -n "${base_branch}" ]]; then
     printf 'base: %s\n' "${base_branch}"

--- a/tests/scrut/launch-workmux.md
+++ b/tests/scrut/launch-workmux.md
@@ -1,11 +1,41 @@
 # Launch workmux
 
-Tests for launcher stdin prompt handling and workmux argument construction.
+Tests for launcher stdin prompt handling, tmux recovery, and workmux argument construction.
+
+## Test helpers
+
+```scrut
+$ function prepare_stubs() {
+>   state="$(mktemp -d)"
+>   stub_dir="$(mktemp -d)"
+>   cp "${WORKMUX_STUB_BIN}" "${stub_dir}/workmux"
+>   cp "${TMUX_STUB_BIN}" "${stub_dir}/tmux"
+>   chmod +x "${stub_dir}/workmux" "${stub_dir}/tmux"
+> }
+> function create_socket_fixture() {
+>   tmux_tmpdir="$(mktemp -d)"
+>   socket_dir="${tmux_tmpdir}/tmux-$(id -u)"
+>   socket_path="${socket_dir}/projects"
+>   socket_pid="$("${UNIX_SOCKET_FIXTURE_BIN}" "${socket_path}")"
+>   socket_real_path="$(cd "${socket_dir}" && pwd -P)/$(basename "${socket_path}")"
+> }
+> function cleanup_socket_fixture() {
+>   if [[ -n "${socket_pid:-}" ]]; then
+>     kill "${socket_pid}" 2> /dev/null || true
+>     socket_pid=""
+>   fi
+> }
+```
 
 ## Create worktree launcher escapes stdin and passes base
 
 ```scrut
-$ state="$(mktemp -d)" && stub_dir="$(mktemp -d)" && cp "${WORKMUX_STUB_BIN}" "${stub_dir}/workmux" && chmod +x "${stub_dir}/workmux" && printf '%s\n' 'Prompt with {{ user }} and {% if ok %} and {# note #}' | env PATH="${stub_dir}:${PATH}" STUB_STATE="${state}" WORKMUX_LAUNCH_WAIT_SECONDS=1 bash "${CREATE_WORKTREE_LAUNCH_WORKMUX_BIN}" "feature/stdin-prompt" --base "main" && sleep 0.1 && prompt_file="$(cat "${state}/prompt_path")" && if [[ -e "${prompt_file}" ]]; then echo "prompt cleanup: no"; else echo "prompt cleanup: yes"; fi
+$ prepare_stubs \
+>   && printf '%s\n' 'Prompt with {{ user }} and {% if ok %} and {# note #}' \
+>     | env PATH="${stub_dir}:${PATH}" STUB_STATE="${state}" WORKMUX_LAUNCH_WAIT_SECONDS=1 bash "${CREATE_WORKTREE_LAUNCH_WORKMUX_BIN}" "feature/stdin-prompt" --base "main" \
+>   && sleep 0.1 \
+>   && prompt_file="$(cat "${state}/prompt_path")" \
+>   && if [[ -e "${prompt_file}" ]]; then echo "prompt cleanup: no"; else echo "prompt cleanup: yes"; fi
 workmux add
 branch: feature/stdin-prompt
 open-if-exists: true
@@ -16,10 +46,28 @@ prompt-file-exists: yes
 prompt cleanup: yes
 ```
 
-## Create worktree from issue launcher reads stdin
+## Create worktree launcher uses `WORKMUX_TMUX`
 
 ```scrut
-$ state="$(mktemp -d)" && stub_dir="$(mktemp -d)" && cp "${WORKMUX_STUB_BIN}" "${stub_dir}/workmux" && chmod +x "${stub_dir}/workmux" && printf '%s\n' 'Issue body with {{ value }}' | env PATH="${stub_dir}:${PATH}" STUB_STATE="${state}" STUB_CAPTURE_TERM=1 STUB_CAPTURE_TMUX=1 WORKMUX_TERM=tmux-256color WORKMUX_TMUX="/tmp/tmux-501/projects,123,%4" WORKMUX_LAUNCH_WAIT_SECONDS=1 bash "${CREATE_WORKTREE_FROM_ISSUE_LAUNCH_WORKMUX_BIN}" "feature/issue-265" && sleep 0.1 && prompt_file="$(cat "${state}/prompt_path")" && if [[ -e "${prompt_file}" ]]; then echo "prompt cleanup: no"; else echo "prompt cleanup: yes"; fi
+$ prepare_stubs \
+>   && printf '%s\n' 'Prompt body' \
+>     | env -u TMUX PATH="${stub_dir}:${PATH}" STUB_STATE="${state}" STUB_CAPTURE_TERM=1 STUB_CAPTURE_TMUX=1 TERM=dumb WORKMUX_TMUX="/tmp/tmux-501/projects,123,%4" WORKMUX_LAUNCH_WAIT_SECONDS=1 bash "${CREATE_WORKTREE_LAUNCH_WORKMUX_BIN}" "feature/workmux-tmux"
+workmux add
+branch: feature/workmux-tmux
+open-if-exists: true
+term: tmux-256color
+tmux: /tmp/tmux-501/projects,123,%4
+prompt:
+Prompt body
+prompt-file-exists: yes
+```
+
+## Create worktree from issue launcher uses `WORKMUX_TMUX`
+
+```scrut
+$ prepare_stubs \
+>   && printf '%s\n' 'Issue body with {{ value }}' \
+>     | env -u TMUX PATH="${stub_dir}:${PATH}" STUB_STATE="${state}" STUB_CAPTURE_TERM=1 STUB_CAPTURE_TMUX=1 TERM=dumb WORKMUX_TMUX="/tmp/tmux-501/projects,123,%4" WORKMUX_LAUNCH_WAIT_SECONDS=1 bash "${CREATE_WORKTREE_FROM_ISSUE_LAUNCH_WORKMUX_BIN}" "feature/issue-265"
 workmux add
 branch: feature/issue-265
 open-if-exists: true
@@ -28,7 +76,126 @@ tmux: /tmp/tmux-501/projects,123,%4
 prompt:
 Issue body with {{ "{{" }} value }}
 prompt-file-exists: yes
-prompt cleanup: yes
+```
+
+## Create worktree launcher keeps existing `TMUX`
+
+```scrut
+$ prepare_stubs \
+>   && printf '%s\n' 'Prompt body' \
+>     | env PATH="${stub_dir}:${PATH}" STUB_STATE="${state}" STUB_CAPTURE_TERM=1 STUB_CAPTURE_TMUX=1 TERM=dumb TMUX="/tmp/tmux-501/existing,111,%1" WORKMUX_TMUX="/tmp/tmux-501/workmux,222,%2" WORKMUX_LAUNCH_WAIT_SECONDS=1 bash "${CREATE_WORKTREE_LAUNCH_WORKMUX_BIN}" "feature/existing-tmux"
+workmux add
+branch: feature/existing-tmux
+open-if-exists: true
+term: tmux-256color
+tmux: /tmp/tmux-501/existing,111,%1
+prompt:
+Prompt body
+prompt-file-exists: yes
+```
+
+## Create worktree from issue launcher keeps existing `TMUX`
+
+```scrut
+$ prepare_stubs \
+>   && printf '%s\n' 'Issue body' \
+>     | env PATH="${stub_dir}:${PATH}" STUB_STATE="${state}" STUB_CAPTURE_TERM=1 STUB_CAPTURE_TMUX=1 TERM=dumb TMUX="/tmp/tmux-501/existing,111,%1" WORKMUX_TMUX="/tmp/tmux-501/workmux,222,%2" WORKMUX_LAUNCH_WAIT_SECONDS=1 bash "${CREATE_WORKTREE_FROM_ISSUE_LAUNCH_WORKMUX_BIN}" "feature/existing-tmux-issue"
+workmux add
+branch: feature/existing-tmux-issue
+open-if-exists: true
+term: tmux-256color
+tmux: /tmp/tmux-501/existing,111,%1
+prompt:
+Issue body
+prompt-file-exists: yes
+```
+
+## Create worktree launcher discovers one matching Codex pane
+
+```scrut
+$ prepare_stubs \
+>   && create_socket_fixture \
+>   && trap cleanup_socket_fixture EXIT \
+>   && cwd="$(pwd -P)" \
+>   && panes="${socket_real_path}|%7|cx|${cwd}|4242" \
+>   && printf '%s\n' 'Prompt body' \
+>     | env -u TMUX PATH="${stub_dir}:${PATH}" TMUX_TMPDIR="${tmux_tmpdir}" STUB_TMUX_PANES="${panes}" STUB_STATE="${state}" STUB_CAPTURE_TERM=1 STUB_CAPTURE_TMUX=1 TERM=dumb WORKMUX_LAUNCH_WAIT_SECONDS=1 bash "${CREATE_WORKTREE_LAUNCH_WORKMUX_BIN}" "feature/discovered-tmux" \
+>   && cleanup_socket_fixture \
+>   && trap - EXIT
+workmux add
+branch: feature/discovered-tmux
+open-if-exists: true
+term: tmux-256color
+tmux: */projects,4242,%7 (glob)
+prompt:
+Prompt body
+prompt-file-exists: yes
+```
+
+## Create worktree from issue launcher discovers one matching Codex pane
+
+```scrut
+$ prepare_stubs \
+>   && create_socket_fixture \
+>   && trap cleanup_socket_fixture EXIT \
+>   && cwd="$(pwd -P)" \
+>   && panes="${socket_real_path}|%7|codex-aarch64-a|${cwd}|4242" \
+>   && printf '%s\n' 'Issue body' \
+>     | env -u TMUX PATH="${stub_dir}:${PATH}" TMUX_TMPDIR="${tmux_tmpdir}" STUB_TMUX_PANES="${panes}" STUB_STATE="${state}" STUB_CAPTURE_TERM=1 STUB_CAPTURE_TMUX=1 TERM=dumb WORKMUX_LAUNCH_WAIT_SECONDS=1 bash "${CREATE_WORKTREE_FROM_ISSUE_LAUNCH_WORKMUX_BIN}" "feature/discovered-tmux-issue" \
+>   && cleanup_socket_fixture \
+>   && trap - EXIT
+workmux add
+branch: feature/discovered-tmux-issue
+open-if-exists: true
+term: tmux-256color
+tmux: */projects,4242,%7 (glob)
+prompt:
+Issue body
+prompt-file-exists: yes
+```
+
+## Create worktree launcher ignores ambiguous Codex panes
+
+```scrut
+$ prepare_stubs \
+>   && create_socket_fixture \
+>   && trap cleanup_socket_fixture EXIT \
+>   && cwd="$(pwd -P)" \
+>   && panes="${socket_real_path}|%7|cx|${cwd}|4242"$'\n'"${socket_real_path}|%8|codex|${cwd}|4242" \
+>   && printf '%s\n' 'Prompt body' \
+>     | env -u TMUX PATH="${stub_dir}:${PATH}" TMUX_TMPDIR="${tmux_tmpdir}" STUB_TMUX_PANES="${panes}" STUB_STATE="${state}" STUB_CAPTURE_TERM=1 STUB_CAPTURE_TMUX=1 TERM=dumb WORKMUX_LAUNCH_WAIT_SECONDS=1 bash "${CREATE_WORKTREE_LAUNCH_WORKMUX_BIN}" "feature/ambiguous-tmux" \
+>   && cleanup_socket_fixture \
+>   && trap - EXIT
+workmux add
+branch: feature/ambiguous-tmux
+open-if-exists: true
+term: dumb
+tmux: <unset>
+prompt:
+Prompt body
+prompt-file-exists: yes
+```
+
+## Create worktree from issue launcher ignores ambiguous Codex panes
+
+```scrut
+$ prepare_stubs \
+>   && create_socket_fixture \
+>   && trap cleanup_socket_fixture EXIT \
+>   && cwd="$(pwd -P)" \
+>   && panes="${socket_real_path}|%7|cx|${cwd}|4242"$'\n'"${socket_real_path}|%8|codex|${cwd}|4242" \
+>   && printf '%s\n' 'Issue body' \
+>     | env -u TMUX PATH="${stub_dir}:${PATH}" TMUX_TMPDIR="${tmux_tmpdir}" STUB_TMUX_PANES="${panes}" STUB_STATE="${state}" STUB_CAPTURE_TERM=1 STUB_CAPTURE_TMUX=1 TERM=dumb WORKMUX_LAUNCH_WAIT_SECONDS=1 bash "${CREATE_WORKTREE_FROM_ISSUE_LAUNCH_WORKMUX_BIN}" "feature/ambiguous-tmux-issue" \
+>   && cleanup_socket_fixture \
+>   && trap - EXIT
+workmux add
+branch: feature/ambiguous-tmux-issue
+open-if-exists: true
+term: dumb
+tmux: <unset>
+prompt:
+Issue body
+prompt-file-exists: yes
 ```
 
 ## Create worktree launcher rejects empty stdin

--- a/tests/scrut/launch-workmux.md
+++ b/tests/scrut/launch-workmux.md
@@ -19,10 +19,12 @@ prompt cleanup: yes
 ## Create worktree from issue launcher reads stdin
 
 ```scrut
-$ state="$(mktemp -d)" && stub_dir="$(mktemp -d)" && cp "${WORKMUX_STUB_BIN}" "${stub_dir}/workmux" && chmod +x "${stub_dir}/workmux" && printf '%s\n' 'Issue body with {{ value }}' | env PATH="${stub_dir}:${PATH}" STUB_STATE="${state}" WORKMUX_LAUNCH_WAIT_SECONDS=1 bash "${CREATE_WORKTREE_FROM_ISSUE_LAUNCH_WORKMUX_BIN}" "feature/issue-265" && sleep 0.1 && prompt_file="$(cat "${state}/prompt_path")" && if [[ -e "${prompt_file}" ]]; then echo "prompt cleanup: no"; else echo "prompt cleanup: yes"; fi
+$ state="$(mktemp -d)" && stub_dir="$(mktemp -d)" && cp "${WORKMUX_STUB_BIN}" "${stub_dir}/workmux" && chmod +x "${stub_dir}/workmux" && printf '%s\n' 'Issue body with {{ value }}' | env PATH="${stub_dir}:${PATH}" STUB_STATE="${state}" STUB_CAPTURE_TERM=1 STUB_CAPTURE_TMUX=1 WORKMUX_TERM=tmux-256color WORKMUX_TMUX="/tmp/tmux-501/projects,123,%4" WORKMUX_LAUNCH_WAIT_SECONDS=1 bash "${CREATE_WORKTREE_FROM_ISSUE_LAUNCH_WORKMUX_BIN}" "feature/issue-265" && sleep 0.1 && prompt_file="$(cat "${state}/prompt_path")" && if [[ -e "${prompt_file}" ]]; then echo "prompt cleanup: no"; else echo "prompt cleanup: yes"; fi
 workmux add
 branch: feature/issue-265
 open-if-exists: true
+term: tmux-256color
+tmux: /tmp/tmux-501/projects,123,%4
 prompt:
 Issue body with {{ "{{" }} value }}
 prompt-file-exists: yes

--- a/tests/scrut/launch-workmux.md
+++ b/tests/scrut/launch-workmux.md
@@ -10,7 +10,8 @@ $ function prepare_stubs() {
 >   stub_dir="$(mktemp -d)"
 >   cp "${WORKMUX_STUB_BIN}" "${stub_dir}/workmux"
 >   cp "${TMUX_STUB_BIN}" "${stub_dir}/tmux"
->   chmod +x "${stub_dir}/workmux" "${stub_dir}/tmux"
+>   cp "${GIT_WORKTREE_STUB_BIN}" "${stub_dir}/git"
+>   chmod +x "${stub_dir}/workmux" "${stub_dir}/tmux" "${stub_dir}/git"
 > }
 > function create_socket_fixture() {
 >   tmux_tmpdir="$(mktemp -d)"
@@ -108,6 +109,57 @@ tmux: /tmp/tmux-501/existing,111,%1
 prompt:
 Issue body
 prompt-file-exists: yes
+```
+
+## Create worktree from issue launcher resends existing worktree prompt
+
+```scrut
+$ prepare_stubs \
+>   && existing_worktree="$(mktemp -d)" \
+>   && mkdir -p "${existing_worktree}/.workmux" \
+>   && printf '%s\n' 'Stored prompt' > "${existing_worktree}/.workmux/PROMPT-feature-existing-worktree.md" \
+>   && tmux_log="${state}/tmux-log" \
+>   && socket="/tmp/tmux-501/projects" \
+>   && panes="${socket}|%9|cx|${existing_worktree}|4242" \
+>   && porcelain="$(printf 'worktree %s\nHEAD abc123\nbranch refs/heads/feature/existing-worktree\n\n' "${existing_worktree}")" \
+>   && printf '%s\n' 'Issue body' \
+>     | env PATH="${stub_dir}:${PATH}" STUB_GIT_WORKTREE_PORCELAIN="${porcelain}" STUB_TMUX_LOG="${tmux_log}" STUB_TMUX_PANES="${panes}" STUB_STATE="${state}" WORKMUX_TMUX="${socket},4242,%1" WORKMUX_CODEX_PROMPT_SUBMIT_DELAY_SECONDS=0 WORKMUX_LAUNCH_WAIT_SECONDS=1 bash "${CREATE_WORKTREE_FROM_ISSUE_LAUNCH_WORKMUX_BIN}" "feature/existing-worktree" \
+>   && sed "s|${existing_worktree}|<worktree>|g" "${tmux_log}"
+workmux add
+branch: feature/existing-worktree
+open-if-exists: true
+prompt:
+Issue body
+prompt-file-exists: yes
+Sent prompt to existing Codex pane for * (glob)
+tmux: load-buffer socket=/tmp/tmux-501/projects buffer=workmux-prompt-feature-existing-worktree file=*/.workmux/PROMPT-feature-existing-worktree.md (glob)
+tmux: paste-buffer socket=/tmp/tmux-501/projects target=%9 buffer=workmux-prompt-feature-existing-worktree
+tmux: send-keys socket=/tmp/tmux-501/projects target=%9 keys=Enter
+tmux: send-keys socket=/tmp/tmux-501/projects target=%9 keys=Enter
+tmux: delete-buffer socket=/tmp/tmux-501/projects buffer=workmux-prompt-feature-existing-worktree
+```
+
+## Create worktree from issue launcher ignores prompt resend failure
+
+```scrut
+$ prepare_stubs \
+>   && existing_worktree="$(mktemp -d)" \
+>   && tmux_log="${state}/tmux-log" \
+>   && socket="/tmp/tmux-501/projects" \
+>   && panes="${socket}|%9|cx|${existing_worktree}|4242" \
+>   && porcelain="$(printf 'worktree %s\nHEAD abc123\nbranch refs/heads/feature/existing-worktree-paste-fail\n\n' "${existing_worktree}")" \
+>   && printf '%s\n' 'Issue body' \
+>     | env PATH="${stub_dir}:${PATH}" STUB_GIT_WORKTREE_PORCELAIN="${porcelain}" STUB_TMUX_FAIL_COMMAND=paste-buffer STUB_TMUX_LOG="${tmux_log}" STUB_TMUX_PANES="${panes}" STUB_STATE="${state}" WORKMUX_TMUX="${socket},4242,%1" WORKMUX_CODEX_PROMPT_SUBMIT_DELAY_SECONDS=0 WORKMUX_LAUNCH_WAIT_SECONDS=1 bash "${CREATE_WORKTREE_FROM_ISSUE_LAUNCH_WORKMUX_BIN}" "feature/existing-worktree-paste-fail" \
+>   && sed "s|${existing_worktree}|<worktree>|g" "${tmux_log}"
+workmux add
+branch: feature/existing-worktree-paste-fail
+open-if-exists: true
+prompt:
+Issue body
+prompt-file-exists: yes
+tmux: load-buffer socket=/tmp/tmux-501/projects buffer=workmux-prompt-feature-existing-worktree-paste-fail file=* (glob)
+tmux: paste-buffer socket=/tmp/tmux-501/projects target=%9 buffer=workmux-prompt-feature-existing-worktree-paste-fail
+tmux: delete-buffer socket=/tmp/tmux-501/projects buffer=workmux-prompt-feature-existing-worktree-paste-fail
 ```
 
 ## Create worktree launcher discovers one matching Codex pane

--- a/tests/scrut/launch-workmux.md
+++ b/tests/scrut/launch-workmux.md
@@ -198,6 +198,44 @@ Issue body
 prompt-file-exists: yes
 ```
 
+## Create worktree launcher continues without `tmux`
+
+```scrut
+$ state="$(mktemp -d)" \
+>   && stub_dir="$(mktemp -d)" \
+>   && cp "${WORKMUX_STUB_BIN}" "${stub_dir}/workmux" \
+>   && chmod +x "${stub_dir}/workmux" \
+>   && printf '%s\n' 'Prompt body' \
+>     | env -u TMUX PATH="${stub_dir}:/usr/bin:/bin:/usr/sbin:/sbin" STUB_STATE="${state}" STUB_CAPTURE_TERM=1 STUB_CAPTURE_TMUX=1 TERM=dumb WORKMUX_LAUNCH_WAIT_SECONDS=1 bash "${CREATE_WORKTREE_LAUNCH_WORKMUX_BIN}" "feature/no-tmux-command"
+workmux add
+branch: feature/no-tmux-command
+open-if-exists: true
+term: dumb
+tmux: <unset>
+prompt:
+Prompt body
+prompt-file-exists: yes
+```
+
+## Create worktree from issue launcher continues without `tmux`
+
+```scrut
+$ state="$(mktemp -d)" \
+>   && stub_dir="$(mktemp -d)" \
+>   && cp "${WORKMUX_STUB_BIN}" "${stub_dir}/workmux" \
+>   && chmod +x "${stub_dir}/workmux" \
+>   && printf '%s\n' 'Issue body' \
+>     | env -u TMUX PATH="${stub_dir}:/usr/bin:/bin:/usr/sbin:/sbin" STUB_STATE="${state}" STUB_CAPTURE_TERM=1 STUB_CAPTURE_TMUX=1 TERM=dumb WORKMUX_LAUNCH_WAIT_SECONDS=1 bash "${CREATE_WORKTREE_FROM_ISSUE_LAUNCH_WORKMUX_BIN}" "feature/no-tmux-command-issue"
+workmux add
+branch: feature/no-tmux-command-issue
+open-if-exists: true
+term: dumb
+tmux: <unset>
+prompt:
+Issue body
+prompt-file-exists: yes
+```
+
 ## Create worktree launcher rejects empty stdin
 
 ```scrut

--- a/tests/scrut/launch-workmux.md
+++ b/tests/scrut/launch-workmux.md
@@ -25,6 +25,13 @@ $ function prepare_stubs() {
 >     kill "${socket_pid}" 2> /dev/null || true
 >     socket_pid=""
 >   fi
+>   if [[ -n "${tmux_tmpdir:-}" ]]; then
+>     rm -r -- "${tmux_tmpdir}"
+>     tmux_tmpdir=""
+>     socket_dir=""
+>     socket_path=""
+>     socket_real_path=""
+>   fi
 > }
 ```
 


### PR DESCRIPTION
## Summary

- Recover Codex-launched workmux tmux context in both worktree launchers when `TMUX` is missing.
- Preserve explicit `TMUX` precedence, support `WORKMUX_TMUX`, and reconstruct a single matching Codex pane from tmux sockets.
- Add Scrut socket and tmux fixtures for recovery, ambiguity, and cleanup coverage.
- Refresh plugin versions and generated Codex marketplace state after the rebase.

## Test plan

- [x] `yarn lint`
- [x] `make test-scrut`
- [x] `shellcheck -S warning bin/* plugins/*/scripts/* tests/fixtures/*`
- [x] `shfmt -d bin/* plugins/*/scripts/* tests/fixtures/*`
- [x] `bin/validate-json`
- [x] `bin/validate-plugins`
- [x] `actionlint`
- [x] `bin/build-codex-marketplace && git diff --exit-code .agents dist/codex`
- [x] `bin/build-opencode-mirror && git diff --exit-code dist/opencode`
- [x] Live `env -u TMUX TERM=dumb` validation for both launchers, with temporary worktrees and tmux windows cleaned up.

## Closes

Fixes #302
