### PR TITLE
Continue parent workflows after lint fixes

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -2,7 +2,7 @@
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "metadata": {
     "description": "Claude Code commands, hooks, and skills from Christopher Boone (cboone.github.io)",
-    "version": "catalog-M63-m79-p143-n51"
+    "version": "catalog-M63-m79-p145-n51"
   },
   "name": "agent-harness-plugins",
   "owner": {
@@ -231,7 +231,7 @@
       "name": "lint-and-fix",
       "repository": "https://github.com/cboone/agent-harness-plugins",
       "source": "./dist/codex/plugins/lint-and-fix",
-      "version": "1.3.7"
+      "version": "1.3.8"
     },
     {
       "author": {
@@ -315,7 +315,7 @@
       "name": "pr",
       "repository": "https://github.com/cboone/agent-harness-plugins",
       "source": "./dist/codex/plugins/pr",
-      "version": "1.5.4"
+      "version": "1.5.5"
     },
     {
       "author": {

--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -2,7 +2,7 @@
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "metadata": {
     "description": "Claude Code commands, hooks, and skills from Christopher Boone (cboone.github.io)",
-    "version": "catalog-M63-m79-p145-n51"
+    "version": "catalog-M63-m79-p146-n51"
   },
   "name": "agent-harness-plugins",
   "owner": {
@@ -371,7 +371,7 @@
       "name": "resolve-copilot-pr-feedback",
       "repository": "https://github.com/cboone/agent-harness-plugins",
       "source": "./dist/codex/plugins/resolve-copilot-pr-feedback",
-      "version": "1.4.2"
+      "version": "1.4.3"
     },
     {
       "author": {

--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -2,7 +2,7 @@
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "metadata": {
     "description": "Claude Code commands, hooks, and skills from Christopher Boone (cboone.github.io)",
-    "version": "catalog-M63-m79-p146-n51"
+    "version": "catalog-M63-m79-p147-n51"
   },
   "name": "agent-harness-plugins",
   "owner": {
@@ -371,7 +371,7 @@
       "name": "resolve-copilot-pr-feedback",
       "repository": "https://github.com/cboone/agent-harness-plugins",
       "source": "./dist/codex/plugins/resolve-copilot-pr-feedback",
-      "version": "1.4.3"
+      "version": "1.4.4"
     },
     {
       "author": {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "metadata": {
     "description": "Claude Code commands, hooks, and skills from Christopher Boone (cboone.github.io)",
-    "version": "catalog-M63-m79-p145-n51"
+    "version": "catalog-M63-m79-p146-n51"
   },
   "name": "agent-harness-plugins",
   "owner": {
@@ -371,7 +371,7 @@
       "name": "resolve-copilot-pr-feedback",
       "repository": "https://github.com/cboone/agent-harness-plugins",
       "source": "./plugins/resolve-copilot-pr-feedback",
-      "version": "1.4.2"
+      "version": "1.4.3"
     },
     {
       "author": {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "metadata": {
     "description": "Claude Code commands, hooks, and skills from Christopher Boone (cboone.github.io)",
-    "version": "catalog-M63-m79-p146-n51"
+    "version": "catalog-M63-m79-p147-n51"
   },
   "name": "agent-harness-plugins",
   "owner": {
@@ -371,7 +371,7 @@
       "name": "resolve-copilot-pr-feedback",
       "repository": "https://github.com/cboone/agent-harness-plugins",
       "source": "./plugins/resolve-copilot-pr-feedback",
-      "version": "1.4.3"
+      "version": "1.4.4"
     },
     {
       "author": {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "metadata": {
     "description": "Claude Code commands, hooks, and skills from Christopher Boone (cboone.github.io)",
-    "version": "catalog-M63-m79-p143-n51"
+    "version": "catalog-M63-m79-p145-n51"
   },
   "name": "agent-harness-plugins",
   "owner": {
@@ -231,7 +231,7 @@
       "name": "lint-and-fix",
       "repository": "https://github.com/cboone/agent-harness-plugins",
       "source": "./plugins/lint-and-fix",
-      "version": "1.3.7"
+      "version": "1.3.8"
     },
     {
       "author": {
@@ -315,7 +315,7 @@
       "name": "pr",
       "repository": "https://github.com/cboone/agent-harness-plugins",
       "source": "./plugins/pr",
-      "version": "1.5.4"
+      "version": "1.5.5"
     },
     {
       "author": {

--- a/dist/codex/plugins/lint-and-fix/.claude-plugin/plugin.json
+++ b/dist/codex/plugins/lint-and-fix/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "name": "lint-and-fix",
   "repository": "https://github.com/cboone/agent-harness-plugins",
   "skills": "./skills",
-  "version": "1.3.7"
+  "version": "1.3.8"
 }

--- a/dist/codex/plugins/lint-and-fix/README.md
+++ b/dist/codex/plugins/lint-and-fix/README.md
@@ -28,7 +28,7 @@ Checks for configuration files to detect ESLint, Prettier, markdownlint, ShellCh
 | `--check`       | Report issues without fixing (dry run)            |
 | `--tool <name>` | Run only a specific tool                          |
 | `--no-commit`   | Skip committing and pushing                       |
-| `--no-push`     | Commit but do not push (default: commit and push) |
+| `--no-push`     | Commit but leave push to the caller or user       |
 
 ## Recommended Permissions
 

--- a/dist/codex/plugins/lint-and-fix/skills/lint-and-fix/SKILL.md
+++ b/dist/codex/plugins/lint-and-fix/skills/lint-and-fix/SKILL.md
@@ -14,9 +14,38 @@ Detect project linters and formatters, run them with auto-fix, and resolve remai
 The user may provide these options inline:
 
 - **--no-commit**: Skip committing and pushing (default: commit and push after fixing)
-- **--no-push**: Commit but do not push (default: push after committing)
+- **--no-push**: Commit but leave push to the caller or user (default: push after committing)
 - **--tool <name>**: Run only a specific tool (e.g., `--tool eslint`, `--tool prettier`)
 - **--check**: Run in check-only mode (report issues without fixing)
+
+## Parent Continuation Contract
+
+When another skill invokes `lint-and-fix`, that parent skill may provide an explicit continuation block immediately after the command:
+
+```text
+Parent continuation:
+- Caller: <parent skill name>
+- Resume target: <parent workflow step to resume>
+- On lint success: <what the parent must do next>
+- On lint failure or skipped required lint work: <what the parent must do next>
+```
+
+Honor this block as part of the `lint-and-fix` invocation.
+
+- `--no-push` means "commit fixes, but leave push to the caller or user." It is not a terminal stop when a parent continuation block is supplied.
+- Do not ask the user whether to proceed when the continuation block says the parent should continue.
+- Do not end with a vague handoff as the terminal outcome. Report the structured result and the caller resume target instead.
+- On lint success, no tools detected, or no file changes needed, report the result and allow the parent to continue immediately according to `On lint success`.
+- On unresolved lint issues, skipped required lint work, missing required tools, or tool execution failures, report a workflow failure result and list the unresolved items so the parent can follow `On lint failure or skipped required lint work`.
+
+Final output for a parent invocation must include:
+
+```text
+Lint status: <success|no-tools|failure>
+Commit: <none|commit SHA>
+Unresolved or skipped: <none|summary>
+Caller resume target: <target from continuation block>
+```
 
 ## Workflow
 
@@ -80,7 +109,7 @@ Would produce two additional detected tools:
 
 If **--tool <name>** was specified, filter the detected list to only that tool. If the specified tool was not detected, report that and stop.
 
-If **no tools are detected**, report that no linters or formatters were found and stop.
+If **no tools are detected**, report that no linters or formatters were found. If a parent continuation block was supplied, report `Lint status: no-tools`, include the caller resume target, and allow the parent workflow to continue according to its continuation block. Otherwise stop.
 
 ### 2. Present Detected Tools
 
@@ -194,7 +223,7 @@ Skip this step only if:
 Check for file changes and commit:
 
 1. Run `git status --porcelain` and check whether its output is empty.
-1. **If no files were modified** (i.e., `git status --porcelain` produced no output): Report "No changes needed, all files were already clean." and stop.
+1. **If no files were modified** (i.e., `git status --porcelain` produced no output): Report "No changes needed, all files were already clean." If a parent continuation block was supplied, include the final output required by [Parent Continuation Contract](#parent-continuation-contract) and allow the parent workflow to continue according to its continuation block. Otherwise stop.
 1. **If files were modified** (i.e., `git status --porcelain` produced any output): Stage all modified files and commit them.
 1. Generate a conventional commit message:
    - Use `style:` for pure formatting and linting fixes.
@@ -203,7 +232,8 @@ Check for file changes and commit:
 
 After committing, push to the remote:
 
-1. **If --no-push was specified**: Stop after committing.
+1. **If --no-push was specified without a parent continuation block**: Report the final lint status and commit SHA, then stop.
+1. **If --no-push was specified with a parent continuation block**: Report the final output required by [Parent Continuation Contract](#parent-continuation-contract), including the caller resume target. The parent workflow should then continue according to its continuation block without asking the user for confirmation.
 1. Push to the current branch's upstream remote.
 1. If no upstream is set, push with `-u` to set it.
 

--- a/dist/codex/plugins/pr/.claude-plugin/plugin.json
+++ b/dist/codex/plugins/pr/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "name": "pr",
   "repository": "https://github.com/cboone/agent-harness-plugins",
   "skills": "./skills",
-  "version": "1.5.4"
+  "version": "1.5.5"
 }

--- a/dist/codex/plugins/pr/skills/pr/SKILL.md
+++ b/dist/codex/plugins/pr/skills/pr/SKILL.md
@@ -190,13 +190,19 @@ Run the `lint-and-fix` skill to catch lint and formatting errors before pushing.
 
    ```text
    lint-and-fix --no-push
+
+   Parent continuation:
+   - Caller: pr
+   - Resume target: Step 6, push branch, then Step 7, create the pull request.
+   - On lint success: Continue immediately to Step 6 without asking the user for confirmation.
+   - On lint failure or skipped required lint work: Stop before push and PR creation, then report the unresolved lint state.
    ```
 
    This runs all detected project linters and formatters, auto-fixes what it can, manually resolves remaining issues, and commits the fixes without pushing.
 
 1. **If no linters are detected**: Proceed to step 6. The absence of linters is not an error.
 1. **If all linters pass** (with or without auto-fixes) **and no issues remain unresolved or skipped**: Proceed to step 6. Any fix commits created by `lint-and-fix` will be included in the push.
-1. **If any linting issues remain unresolved, any items are skipped, or a required linter cannot run**: Stop and report the unresolved lint errors. Do not push or create the PR. The user must resolve the remaining issues before retrying.
+1. **If any linting issues remain unresolved, any required lint work is skipped, or a required linter cannot run**: Stop and report the unresolved lint state. Do not push or create the PR. The user must resolve the remaining issues before retrying.
 
 ### 6. Push to Remote
 

--- a/dist/codex/plugins/resolve-copilot-pr-feedback/.claude-plugin/plugin.json
+++ b/dist/codex/plugins/resolve-copilot-pr-feedback/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "name": "resolve-copilot-pr-feedback",
   "repository": "https://github.com/cboone/agent-harness-plugins",
   "skills": "./skills",
-  "version": "1.4.2"
+  "version": "1.4.3"
 }

--- a/dist/codex/plugins/resolve-copilot-pr-feedback/.claude-plugin/plugin.json
+++ b/dist/codex/plugins/resolve-copilot-pr-feedback/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "name": "resolve-copilot-pr-feedback",
   "repository": "https://github.com/cboone/agent-harness-plugins",
   "skills": "./skills",
-  "version": "1.4.3"
+  "version": "1.4.4"
 }

--- a/dist/codex/plugins/resolve-copilot-pr-feedback/skills/resolve-copilot-pr-feedback/SKILL.md
+++ b/dist/codex/plugins/resolve-copilot-pr-feedback/skills/resolve-copilot-pr-feedback/SKILL.md
@@ -258,11 +258,18 @@ This step prevents CI failures from lint issues introduced while resolving feedb
 
    ```text
    lint-and-fix --no-push
+
+   Parent continuation:
+   - Caller: resolve-copilot-pr-feedback
+   - Resume target: Step 6, push changes, re-fetch Copilot threads, then Step 7 summary comment.
+   - On lint success: Continue immediately to Step 6 without asking the user for confirmation.
+   - On lint failure or skipped required lint work: Record a workflow failure, then continue to the required terminal summary path in Step 7 because PR context exists.
    ```
 
    This runs all detected project linters and formatters, fixes issues, and commits the fixes without pushing.
 
-1. If lint-and-fix finds and fixes issues, the fixes are committed automatically. Proceed to step 6.
+1. If `lint-and-fix` reports `Lint status: success` or `Lint status: no-tools`, proceed to step 6. Any fix commits created by `lint-and-fix` will be included in the push.
+1. If `lint-and-fix` reports unresolved lint issues, skipped required lint work, missing required tools, or tool execution failures, record a workflow-level failure. Do not claim lint success. Continue through step 6 only for required verification that is still possible, then post the required partial or failed summary in step 7 because PR context exists.
 
 ### 6. Verify Completion
 

--- a/dist/codex/plugins/resolve-copilot-pr-feedback/skills/resolve-copilot-pr-feedback/SKILL.md
+++ b/dist/codex/plugins/resolve-copilot-pr-feedback/skills/resolve-copilot-pr-feedback/SKILL.md
@@ -263,15 +263,17 @@ This step prevents CI failures from lint issues introduced while resolving feedb
    - Caller: resolve-copilot-pr-feedback
    - Resume target: Step 6, push changes, re-fetch Copilot threads, then Step 7 summary comment.
    - On lint success: Continue immediately to Step 6 without asking the user for confirmation.
-   - On lint failure or skipped required lint work: Record a workflow failure, then continue to the required terminal summary path in Step 7 because PR context exists.
+   - On lint failure or skipped required lint work: Record a workflow failure, skip Step 6 push and verification, then continue directly to the required terminal summary path in Step 7 because PR context exists.
    ```
 
    This runs all detected project linters and formatters, fixes issues, and commits the fixes without pushing.
 
 1. If `lint-and-fix` reports `Lint status: success` or `Lint status: no-tools`, proceed to step 6. Any fix commits created by `lint-and-fix` will be included in the push.
-1. If `lint-and-fix` reports unresolved lint issues, skipped required lint work, missing required tools, or tool execution failures, record a workflow-level failure. Do not claim lint success. Continue through step 6 only for required verification that is still possible, then post the required partial or failed summary in step 7 because PR context exists.
+1. If `lint-and-fix` reports unresolved lint issues, skipped required lint work, missing required tools, or tool execution failures, record a workflow-level failure. Do not claim lint success, do not push potentially non-compliant changes, skip step 6, and post the required partial or failed summary in step 7 because PR context exists.
 
 ### 6. Verify Completion
+
+Do not run this step if step 5 recorded a lint failure or skipped required lint work. In that case, go directly to step 7 and report the lint failure in the final summary.
 
 1. **Push any changes:** `git push`
 1. Re-fetch to confirm all Copilot threads resolved:

--- a/plugins/lint-and-fix/.claude-plugin/plugin.json
+++ b/plugins/lint-and-fix/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "name": "lint-and-fix",
   "repository": "https://github.com/cboone/agent-harness-plugins",
   "skills": "./skills",
-  "version": "1.3.7"
+  "version": "1.3.8"
 }

--- a/plugins/lint-and-fix/README.md
+++ b/plugins/lint-and-fix/README.md
@@ -28,7 +28,7 @@ Checks for configuration files to detect ESLint, Prettier, markdownlint, ShellCh
 | `--check`       | Report issues without fixing (dry run)            |
 | `--tool <name>` | Run only a specific tool                          |
 | `--no-commit`   | Skip committing and pushing                       |
-| `--no-push`     | Commit but do not push (default: commit and push) |
+| `--no-push`     | Commit but leave push to the caller or user       |
 
 ## Recommended Permissions
 

--- a/plugins/lint-and-fix/skills/lint-and-fix/SKILL.md
+++ b/plugins/lint-and-fix/skills/lint-and-fix/SKILL.md
@@ -18,9 +18,38 @@ Detect project linters and formatters, run them with auto-fix, and resolve remai
 The user may provide these options inline:
 
 - **--no-commit**: Skip committing and pushing (default: commit and push after fixing)
-- **--no-push**: Commit but do not push (default: push after committing)
+- **--no-push**: Commit but leave push to the caller or user (default: push after committing)
 - **--tool <name>**: Run only a specific tool (e.g., `--tool eslint`, `--tool prettier`)
 - **--check**: Run in check-only mode (report issues without fixing)
+
+## Parent Continuation Contract
+
+When another skill invokes `lint-and-fix`, that parent skill may provide an explicit continuation block immediately after the command:
+
+```text
+Parent continuation:
+- Caller: <parent skill name>
+- Resume target: <parent workflow step to resume>
+- On lint success: <what the parent must do next>
+- On lint failure or skipped required lint work: <what the parent must do next>
+```
+
+Honor this block as part of the `lint-and-fix` invocation.
+
+- `--no-push` means "commit fixes, but leave push to the caller or user." It is not a terminal stop when a parent continuation block is supplied.
+- Do not ask the user whether to proceed when the continuation block says the parent should continue.
+- Do not end with a vague handoff as the terminal outcome. Report the structured result and the caller resume target instead.
+- On lint success, no tools detected, or no file changes needed, report the result and allow the parent to continue immediately according to `On lint success`.
+- On unresolved lint issues, skipped required lint work, missing required tools, or tool execution failures, report a workflow failure result and list the unresolved items so the parent can follow `On lint failure or skipped required lint work`.
+
+Final output for a parent invocation must include:
+
+```text
+Lint status: <success|no-tools|failure>
+Commit: <none|commit SHA>
+Unresolved or skipped: <none|summary>
+Caller resume target: <target from continuation block>
+```
 
 ## Workflow
 
@@ -84,7 +113,7 @@ Would produce two additional detected tools:
 
 If **--tool <name>** was specified, filter the detected list to only that tool. If the specified tool was not detected, report that and stop.
 
-If **no tools are detected**, report that no linters or formatters were found and stop.
+If **no tools are detected**, report that no linters or formatters were found. If a parent continuation block was supplied, report `Lint status: no-tools`, include the caller resume target, and allow the parent workflow to continue according to its continuation block. Otherwise stop.
 
 ### 2. Present Detected Tools
 
@@ -198,7 +227,7 @@ Skip this step only if:
 Check for file changes and commit:
 
 1. Run `git status --porcelain` and check whether its output is empty.
-1. **If no files were modified** (i.e., `git status --porcelain` produced no output): Report "No changes needed, all files were already clean." and stop.
+1. **If no files were modified** (i.e., `git status --porcelain` produced no output): Report "No changes needed, all files were already clean." If a parent continuation block was supplied, include the final output required by [Parent Continuation Contract](#parent-continuation-contract) and allow the parent workflow to continue according to its continuation block. Otherwise stop.
 1. **If files were modified** (i.e., `git status --porcelain` produced any output): Stage all modified files and commit them.
 1. Generate a conventional commit message:
    - Use `style:` for pure formatting and linting fixes.
@@ -207,7 +236,8 @@ Check for file changes and commit:
 
 After committing, push to the remote:
 
-1. **If --no-push was specified**: Stop after committing.
+1. **If --no-push was specified without a parent continuation block**: Report the final lint status and commit SHA, then stop.
+1. **If --no-push was specified with a parent continuation block**: Report the final output required by [Parent Continuation Contract](#parent-continuation-contract), including the caller resume target. The parent workflow should then continue according to its continuation block without asking the user for confirmation.
 1. Push to the current branch's upstream remote.
 1. If no upstream is set, push with `-u` to set it.
 

--- a/plugins/pr/.claude-plugin/plugin.json
+++ b/plugins/pr/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "name": "pr",
   "repository": "https://github.com/cboone/agent-harness-plugins",
   "skills": "./skills",
-  "version": "1.5.4"
+  "version": "1.5.5"
 }

--- a/plugins/pr/skills/pr/SKILL.md
+++ b/plugins/pr/skills/pr/SKILL.md
@@ -195,13 +195,19 @@ Run the `lint-and-fix` skill to catch lint and formatting errors before pushing.
 
    ```text
    lint-and-fix --no-push
+
+   Parent continuation:
+   - Caller: pr
+   - Resume target: Step 6, push branch, then Step 7, create the pull request.
+   - On lint success: Continue immediately to Step 6 without asking the user for confirmation.
+   - On lint failure or skipped required lint work: Stop before push and PR creation, then report the unresolved lint state.
    ```
 
    This runs all detected project linters and formatters, auto-fixes what it can, manually resolves remaining issues, and commits the fixes without pushing.
 
 1. **If no linters are detected**: Proceed to step 6. The absence of linters is not an error.
 1. **If all linters pass** (with or without auto-fixes) **and no issues remain unresolved or skipped**: Proceed to step 6. Any fix commits created by `lint-and-fix` will be included in the push.
-1. **If any linting issues remain unresolved, any items are skipped, or a required linter cannot run**: Stop and report the unresolved lint errors. Do not push or create the PR. The user must resolve the remaining issues before retrying.
+1. **If any linting issues remain unresolved, any required lint work is skipped, or a required linter cannot run**: Stop and report the unresolved lint state. Do not push or create the PR. The user must resolve the remaining issues before retrying.
 
 ### 6. Push to Remote
 

--- a/plugins/resolve-copilot-pr-feedback/.claude-plugin/plugin.json
+++ b/plugins/resolve-copilot-pr-feedback/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "name": "resolve-copilot-pr-feedback",
   "repository": "https://github.com/cboone/agent-harness-plugins",
   "skills": "./skills",
-  "version": "1.4.2"
+  "version": "1.4.3"
 }

--- a/plugins/resolve-copilot-pr-feedback/.claude-plugin/plugin.json
+++ b/plugins/resolve-copilot-pr-feedback/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "name": "resolve-copilot-pr-feedback",
   "repository": "https://github.com/cboone/agent-harness-plugins",
   "skills": "./skills",
-  "version": "1.4.3"
+  "version": "1.4.4"
 }

--- a/plugins/resolve-copilot-pr-feedback/skills/resolve-copilot-pr-feedback/SKILL.md
+++ b/plugins/resolve-copilot-pr-feedback/skills/resolve-copilot-pr-feedback/SKILL.md
@@ -261,11 +261,18 @@ This step prevents CI failures from lint issues introduced while resolving feedb
 
    ```text
    lint-and-fix --no-push
+
+   Parent continuation:
+   - Caller: resolve-copilot-pr-feedback
+   - Resume target: Step 6, push changes, re-fetch Copilot threads, then Step 7 summary comment.
+   - On lint success: Continue immediately to Step 6 without asking the user for confirmation.
+   - On lint failure or skipped required lint work: Record a workflow failure, then continue to the required terminal summary path in Step 7 because PR context exists.
    ```
 
    This runs all detected project linters and formatters, fixes issues, and commits the fixes without pushing.
 
-1. If lint-and-fix finds and fixes issues, the fixes are committed automatically. Proceed to step 6.
+1. If `lint-and-fix` reports `Lint status: success` or `Lint status: no-tools`, proceed to step 6. Any fix commits created by `lint-and-fix` will be included in the push.
+1. If `lint-and-fix` reports unresolved lint issues, skipped required lint work, missing required tools, or tool execution failures, record a workflow-level failure. Do not claim lint success. Continue through step 6 only for required verification that is still possible, then post the required partial or failed summary in step 7 because PR context exists.
 
 ### 6. Verify Completion
 

--- a/plugins/resolve-copilot-pr-feedback/skills/resolve-copilot-pr-feedback/SKILL.md
+++ b/plugins/resolve-copilot-pr-feedback/skills/resolve-copilot-pr-feedback/SKILL.md
@@ -266,15 +266,17 @@ This step prevents CI failures from lint issues introduced while resolving feedb
    - Caller: resolve-copilot-pr-feedback
    - Resume target: Step 6, push changes, re-fetch Copilot threads, then Step 7 summary comment.
    - On lint success: Continue immediately to Step 6 without asking the user for confirmation.
-   - On lint failure or skipped required lint work: Record a workflow failure, then continue to the required terminal summary path in Step 7 because PR context exists.
+   - On lint failure or skipped required lint work: Record a workflow failure, skip Step 6 push and verification, then continue directly to the required terminal summary path in Step 7 because PR context exists.
    ```
 
    This runs all detected project linters and formatters, fixes issues, and commits the fixes without pushing.
 
 1. If `lint-and-fix` reports `Lint status: success` or `Lint status: no-tools`, proceed to step 6. Any fix commits created by `lint-and-fix` will be included in the push.
-1. If `lint-and-fix` reports unresolved lint issues, skipped required lint work, missing required tools, or tool execution failures, record a workflow-level failure. Do not claim lint success. Continue through step 6 only for required verification that is still possible, then post the required partial or failed summary in step 7 because PR context exists.
+1. If `lint-and-fix` reports unresolved lint issues, skipped required lint work, missing required tools, or tool execution failures, record a workflow-level failure. Do not claim lint success, do not push potentially non-compliant changes, skip step 6, and post the required partial or failed summary in step 7 because PR context exists.
 
 ### 6. Verify Completion
+
+Do not run this step if step 5 recorded a lint failure or skipped required lint work. In that case, go directly to step 7 and report the lint failure in the final summary.
 
 1. **Push any changes:** `git push`
 1. Re-fetch to confirm all Copilot threads resolved:


### PR DESCRIPTION
## Summary

- Add an explicit parent continuation contract for nested `lint-and-fix --no-push` calls.
- Update `pr` and `resolve-copilot-pr-feedback` to pass continuation blocks and handle lint outcomes without pausing after successful lint.
- Bump affected plugin versions, recompute the catalog state, and regenerate the Codex mirror.

## Test plan

- [x] `yarn lint:fix`
- [x] `yarn lint`
- [x] `bin/validate-json`
- [x] `bin/validate-plugins`
- [x] `bin/compute-catalog-state`
- [x] `git diff --check`
